### PR TITLE
Correction du crash au démarrage des programmes en mode utilisateur

### DIFF
--- a/kernel/elf.c
+++ b/kernel/elf.c
@@ -21,74 +21,70 @@ int elf_validate(uint8_t* elf_data) {
 
 uint32_t elf_load(uint8_t* file_data, vmm_directory_t* vmm_dir) {
     if (!elf_validate(file_data)) {
-        print_string_serial("ERREUR: ELF invalide\n");
+        print_string_serial("ERROR: Invalid ELF file.\n");
         return 0;
     }
 
     elf32_ehdr_t* header = (elf32_ehdr_t*)file_data;
-    uint32_t entry_point = header->e_entry;
-    uint32_t highest_addr = 0;
-
-    // Charger les segments PT_LOAD
     elf32_phdr_t* pheaders = (elf32_phdr_t*)(file_data + header->e_phoff);
+
+    print_string_serial("ELF Loader: Starting...\n");
+
+    // It is safer to modify a non-active page directory by temporarily mapping
+    // pages into the kernel's address space. However, the current design
+    // switches to the new directory first. The code below assumes this design
+    // but is now corrected for BSS handling and permissions.
+
     for (int i = 0; i < header->e_phnum; i++) {
         if (pheaders[i].p_type == PT_LOAD) {
-            uint32_t virt_addr = pheaders[i].p_vaddr;
-            uint32_t mem_size = pheaders[i].p_memsz;
-            uint32_t file_size = pheaders[i].p_filesz;
+            uint32_t vaddr = pheaders[i].p_vaddr;
+            uint32_t filesz = pheaders[i].p_filesz;
+            uint32_t memsz = pheaders[i].p_memsz;
+            uint32_t flags = pheaders[i].p_flags;
+            uint8_t* segment_data = file_data + pheaders[i].p_offset;
 
-            for (uint32_t addr = virt_addr; addr < virt_addr + mem_size; addr += PAGE_SIZE) {
-                void* page = pmm_alloc_page();
-                if (page) {
-                    vmm_map_page_in_directory(vmm_dir, page, (void*)addr, PAGE_PRESENT | PAGE_WRITE | PAGE_USER);
-                } else {
-                    print_string_serial("ERREUR: Impossible d'allouer une page pour le segment PT_LOAD\n");
+            // Determine page flags
+            uint32_t page_flags = PAGE_PRESENT | PAGE_USER;
+            if (flags & PF_W) {
+                page_flags |= PAGE_WRITE;
+            }
+
+            print_string_serial("  - Segment: vaddr=0x");
+            print_hex_serial(vaddr);
+            print_string_serial(", memsz=0x");
+            print_hex_serial(memsz);
+            print_string_serial(", perms=");
+            print_string_serial((flags & PF_W) ? "RW" : "R-");
+            print_string_serial("\n");
+
+            // Map all pages for this segment
+            uint32_t start_addr = vaddr & ~0xFFF; // Page-align start address
+            uint32_t end_addr = (vaddr + memsz + 0xFFF) & ~0xFFF;
+            for (uint32_t page_addr = start_addr; page_addr < end_addr; page_addr += PAGE_SIZE) {
+                void* phys_page = pmm_alloc_page();
+                if (!phys_page) {
+                    print_string_serial("ERROR: pmm_alloc_page failed for ELF segment.\n");
+                    // TODO: Here we should unmap all previously mapped pages
                     return 0;
                 }
+                vmm_map_page_in_directory(vmm_dir, phys_page, (void*)page_addr, page_flags);
             }
 
-            // Copier les données
-            memcpy((void*)virt_addr, file_data + pheaders[i].p_offset, file_size);
-
-            // Mettre à jour l'adresse la plus haute
-            if (virt_addr + mem_size > highest_addr) {
-                highest_addr = virt_addr + mem_size;
+            // Copy data from file (filesz)
+            if (filesz > 0) {
+                memcpy((void*)vaddr, segment_data, filesz);
             }
-        }
-    }
 
-    // --- GESTION DE LA SECTION .BSS ---
-    elf32_shdr_t* sections = (elf32_shdr_t*)(file_data + header->e_shoff);
-    char* string_table = (char*)(file_data + sections[header->e_shstrndx].sh_offset);
-
-    for (int i = 0; i < header->e_shnum; i++) {
-        if (sections[i].sh_type == SHT_NOBITS && sections[i].sh_size > 0) {
-            if (strcmp(string_table + sections[i].sh_name, ".bss") == 0) {
-
-                uint32_t bss_addr = sections[i].sh_addr;
-                uint32_t bss_size = sections[i].sh_size;
-
-                print_string_serial("Allocation de la section .bss...\n");
-                uint32_t start_addr = bss_addr & ~0xFFF;
-                uint32_t end_addr = bss_addr + bss_size;
-
-                for (uint32_t addr = start_addr; addr < end_addr; addr += PAGE_SIZE) {
-                    void* page = pmm_alloc_page();
-                    if (page) {
-                        vmm_map_page_in_directory(vmm_dir, page, (void*)addr, PAGE_PRESENT | PAGE_WRITE | PAGE_USER);
-                        // It is crucial to zero the page
-                        memset((void*)addr, 0, PAGE_SIZE);
-                    } else {
-                        print_string_serial("ERREUR: Impossible d'allouer une page pour .bss\n");
-                        return 0;
-                    }
-                }
-                print_string_serial(".bss alloue de "); print_hex_serial(bss_addr);
-                print_string_serial(" a "); print_hex_serial(end_addr); print_string_serial("\n");
-                break; // Found and handled .bss, exit loop
+            // Zero-fill the .bss section part of the segment (memsz - filesz)
+            if (memsz > filesz) {
+                memset((void*)(vaddr + filesz), 0, memsz - filesz);
             }
         }
     }
 
-    return entry_point;
+    print_string_serial("ELF loading complete. Entry point: 0x");
+    print_hex_serial(header->e_entry);
+    print_string_serial("\n");
+
+    return header->e_entry;
 }


### PR DESCRIPTION
Ce commit résout un problème critique où le système se figeait ou redémarrait lors de la tentative de lancement d'un programme en mode utilisateur. Le crash était dû à une série de problèmes dans la configuration de la mémoire pour le nouveau processus.

Les changements principaux sont :
- La taille de la pile utilisateur est augmentée de 4 Ko à 16 Ko pour prévenir les débordements de pile, qui étaient la cause la plus probable d'un page fault immédiat.
- Le chargeur ELF (`kernel/elf.c`) a été refactorisé. Il utilise maintenant correctement les en-têtes de programme (`PT_LOAD`) pour mapper les segments, y compris une gestion correcte de la section BSS (zero-fill) en se basant sur la différence entre `p_memsz` et `p_filesz`.
- Les permissions des segments (lecture seule vs lecture/écriture) sont maintenant définies correctement en fonction des flags de l'en-tête de programme (`p_flags`), améliorant la sécurité et la robustesse.
- Des logs de débogage ont été ajoutés ou améliorés dans les fonctions de chargement de processus pour faciliter les diagnostics futurs.