### PR TITLE
Fix du clavier : EOI timer avant changement de contexte

### DIFF
--- a/boot/isr_stubs.s
+++ b/boot/isr_stubs.s
@@ -21,15 +21,16 @@ irq0:
     mov es, ax
     mov fs, ax
     mov gs, ax
+
+    ; EOI avant le handler C : schedule() fait iret et ne revient jamais.
+    ; Sans ceci, IRQ0 reste in-service et le PIC bloque IRQ1 (clavier).
+    mov al, 0x20
+    out 0x20, al
     
     ; Passe un pointeur vers la structure de registres au handler C
     push esp
     call timer_handler
     add esp, 4
-    
-    ; Envoie EOI au PIC pour IRQ 0
-    mov al, 0x20
-    out 0x20, al
     
     ; Restaure l'état complet du processeur
     popad

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -60,14 +60,15 @@ void timer_handler(cpu_state_t* cpu) {
     extern task_t* current_task;
     extern task_t* task_queue;
     
+    // EOI déjà envoyé par irq0 avant cet appel. Ne pas le renvoyer ici :
+    // schedule() saute par iret et n'atteint jamais un EOI placé après.
+    // Un EOI ici casserait aussi INT 0x30 (yield), qui n'est pas une IRQ PIC.
+
     // CORRECTION: Activer le scheduler dès que possible pour lancer le shell utilisateur
     if (g_reschedule_needed || (current_task && task_queue && timer_ticks > 2)) {
         g_reschedule_needed = 0;
         schedule(cpu);
     }
-
-    // Envoyer le signal End-of-Interrupt (EOI) au PIC
-    pic_send_eoi(0);
 }
 
 // Fonction unifiée pour obtenir les ticks (marche avec les deux modes)

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -56,16 +56,10 @@ void timer_handler(cpu_state_t* cpu) {
         print_string_serial("\n");
     }
     
-    // Vérifier que le système de tâches est initialisé avant de faire du scheduling
-    extern task_t* current_task;
-    extern task_t* task_queue;
-    
-    // EOI déjà envoyé par irq0 avant cet appel. Ne pas le renvoyer ici :
-    // schedule() saute par iret et n'atteint jamais un EOI placé après.
-    // Un EOI ici casserait aussi INT 0x30 (yield), qui n'est pas une IRQ PIC.
-
-    // CORRECTION: Activer le scheduler dès que possible pour lancer le shell utilisateur
-    if (g_reschedule_needed || (current_task && task_queue && timer_ticks > 2)) {
+    // Un seul changement de contexte quand il est demandé (lancement du shell,
+    // exec/spawn). Planifier à chaque tick après EOI provoque un page fault :
+    // jump_to_task() ne revient pas, et l'état IRQ du kernel devient invalide.
+    if (g_reschedule_needed) {
         g_reschedule_needed = 0;
         schedule(cpu);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Le shell AI-OS démarrait, mais le clavier PS/2 ne répondait plus une fois le prompt affiché.

**Cause :** `schedule()` saute vers la tâche suivante par `iret` et ne revient jamais dans le stub IRQ0. L’EOI PIC était envoyé *après* cet appel, donc IRQ0 restait « in-service ». Sur le 8259, cela bloque IRQ1 (clavier).

Le `schedule()` à chaque tick n’était « sûr » que parce que le PIC restait bloqué. Après l’EOI, ce chemin provoquait un page fault.

**Correction kernel :**
1. Envoyer l’EOI dès le début du stub IRQ0, avant `timer_handler` / `schedule()`.
2. Ne planifier que lorsque `g_reschedule_needed` est positionné (lancement du shell, exec/spawn).
3. Retirer l’EOI de `timer_handler`, aussi appelé par INT 0x30 (yield).

**Correction tests (`test_shell`) :**
- Borner le parseur de commandes (évite un stack smash).
- Corriger les assertions `strstr` (littéraux distincts) et max-args.
- Renvoyer la sortie Unity sur stdout.

**Documentation (aucun rapport historique supprimé) :**
- Nouveau [docs/ETAT_REEL.md](https://github.com/kamgueblondin/ai-os/blob/cursor/fix-keyboard-eoi-6f7a/docs/ETAT_REEL.md) : source de vérité (ce qui marche, stubs du shell, IA simulée, MOHHOS non codé).
- Nouveau [docs/README.md](https://github.com/kamgueblondin/ai-os/blob/cursor/fix-keyboard-eoi-6f7a/docs/README.md) : index actuel vs historique.
- Bannières d’état sur TODO, diagnostics, analyses, user stories US — le contenu technique d’origine est conservé.

**Vérifié :**
- `make test-all` : 4/4 binaires OK (pmm, syscall, task, shell)
- QEMU GTK + `sendkey` : `help`, `ls`, `sysinfo`, `ai bonjour`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

