### PR TITLE
Aligner la documentation et les tests shell sur l’état réel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # AI-OS - Système d'Exploitation pour Intelligence Artificielle
 
 [![Version](https://img.shields.io/badge/version-6.1-blue.svg)](https://github.com/kamgueblondin/ai-os)
-[![Status](https://img.shields.io/badge/status-stable-green.svg)](https://github.com/kamgueblondin/ai-os)
+[![Status](https://img.shields.io/badge/status-prototype-yellow.svg)](https://github.com/kamgueblondin/ai-os)
 [![Keyboard](https://img.shields.io/badge/keyboard-FIXED-brightgreen.svg)](https://github.com/kamgueblondin/ai-os)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## 🎯 Description
 
-AI-OS est un système d'exploitation spécialement conçu pour héberger et exécuter des applications d'intelligence artificielle. Il offre une architecture modulaire optimisée pour les charges de travail IA avec un environnement sécurisé et performant.
+AI-OS est un **prototype de noyau pédagogique i386 32-bit** (hobby OS) qui boote sous QEMU, isole Ring 0/3 et lance un shell utilisateur ELF. L’orientation « OS pour l’IA » est réelle au niveau architecture (userspace, syscalls, initrd), mais l’IA embarquée est un **simulateur par mots-clés** (`userspace/fake_ai.c`), pas un moteur d’inférence.
+
+**État réel du code (août 2026) :** [docs/ETAT_REEL.md](docs/ETAT_REEL.md) — ce qui marche, les stubs du shell, ce qui n’est pas encore codé (FS persistant, réseau, vision MOHHOS). Index de toute la doc : [docs/README.md](docs/README.md).
 
 ## 🔥 MISE À JOUR v6.1 - Clavier Définitivement Corrigé (27 août 2025)
 
 **🎉 PROBLÈME RÉSOLU !** Le clavier est maintenant **entièrement fonctionnel** après corrections expertes !
+
+*Complément août 2026 :* l’init PS/2 et le buffer clavier de v6.1 ne suffisaient pas. IRQ0 restait in-service si `schedule()` ne revenait pas dans le stub PIC, ce qui bloquait IRQ1. Correctif : EOI timer *avant* le changement de contexte, et `schedule()` uniquement sur `g_reschedule_needed`. Détail : [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
 
 ### Corrections Appliquées :
 - ✅ **Handler d'interruption optimisé** - Suppression du logging excessif
@@ -32,19 +36,19 @@ make run-gui
 
 ## ⭐ Fonctionnalités Principales
 
-- **🖥️ Shell Interactif Complet** - Interface utilisateur entièrement fonctionnelle
-- **🤖 Simulateur d'IA Intégré** - Intelligence artificielle simulée avec base de connaissances
-- **🛡️ Espace Utilisateur Sécurisé** - Isolation complète Ring 0/3 avec protection mémoire
-- **⚡ Multitâche Préemptif** - Ordonnanceur Round-Robin avec changement de contexte optimisé
-- **💾 Système de Fichiers** - Support Initrd avec parser TAR POSIX
-- **🧠 Gestion Mémoire Avancée** - VMM/PMM avec paging complet (support ~128MB RAM)
-- **🔌 Gestion Interruptions** - PIC, clavier, timer avec handlers optimisés
+- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3 ; un sous-ensemble de commandes est réellement branché (`help`, `ls`, `sysinfo`, `ai`, …). `help` en liste davantage (stubs / non implémentées).
+- **🤖 Simulateur d'IA Intégré** - Réponses préprogrammées par mots-clés (`fake_ai.c`), pas un modèle ML
+- **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
+- **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
+- **💾 Système de Fichiers** - Initrd TAR en RAM uniquement (pas de disque persistant). `ls` du shell est encore une liste figée.
+- **🧠 Gestion Mémoire** - VMM/PMM avec paging (cible ~128 MB RAM sous QEMU)
+- **🔌 Gestion Interruptions** - PIC, clavier PS/2, timer PIT
 
 ## 🚀 Démarrage Rapide
 
 ### Prérequis
 ```bash
-sudo apt-get install build-essential nasm qemu-system-i386
+sudo apt-get install build-essential gcc-multilib nasm qemu-system-i386
 ```
 
 ### Compilation et Exécution
@@ -76,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS v6.1 inclut maintenant une suite complète de tests automatisés pour garantir la qualité du code.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **93 tests** répartis dans `test_pmm` (17), `test_syscall` (30), `test_task` (21), `test_shell` (25). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash
@@ -220,8 +224,8 @@ make clean && make all && make run
 - **Interactivité** : ✅ Clavier entièrement fonctionnel
 
 ### Métriques de Test (NOUVEAU)
-- **Tests implémentés** : 156 tests automatisés
-- **Couverture de code** : 85% kernel, 72% userspace
+- **Tests implémentés** : 93 tests unitaires automatisés (chiffre 156 : ancien objectif / simulation du script de couverture, non un décompte des `RUN_TEST`)
+- **Couverture de code** : 85% kernel, 72% userspace (valeurs affichées par `run_all_tests.sh`, non mesurées par gcov)
 - **Temps d'exécution** : <5 minutes suite complète
 - **Performance** : Aucune régression détectée
 - **Qualité** : 0 test flaky, 100% déterministe
@@ -229,16 +233,21 @@ make clean && make all && make run
 ## 📚 Documentation
 
 ### Guides Techniques
-- [`docs/README.md`](docs/README.md) - Documentation complète du projet
-- [`docs/etape_7_shell_ia.md`](docs/etape_7_shell_ia.md) - Documentation Shell & IA
-- [`CORRECTION_CLAVIER_FINALE.md`](CORRECTION_CLAVIER_FINALE.md) - Détail des corrections v6.0
+- [`docs/ETAT_REEL.md`](docs/ETAT_REEL.md) - **État actuel du code** (à lire en premier)
+- [`docs/README.md`](docs/README.md) - Index de toute la documentation (actuel vs historique)
+- [`docs/GUIDE_EXECUTION.md`](docs/GUIDE_EXECUTION.md) - Lancement QEMU
+- [`docs/etape_7_shell_ia.md`](docs/etape_7_shell_ia.md) - Documentation Shell & IA simulée
+- [`docs/CORRECTION_CLAVIER_FINALE.md`](docs/CORRECTION_CLAVIER_FINALE.md) - Détail des corrections clavier v6.0 (historique)
 
 ### Rapports de Développement
-- [`RAPPORT_CORRECTION_FINALE.md`](RAPPORT_CORRECTION_FINALE.md) - Rapport final des corrections
-- [`ANALYSE_ARCHITECTURE.md`](ANALYSE_ARCHITECTURE.md) - Analyse architecture système
-- [`DIAGNOSTIC_COMPLET.md`](DIAGNOSTIC_COMPLET.md) - Diagnostic technique complet
+- [`docs/RAPPORT_CORRECTION_FINALE.md`](docs/RAPPORT_CORRECTION_FINALE.md) - Rapport final des corrections
+- [`docs/ANALYSE_ARCHITECTURE.md`](docs/ANALYSE_ARCHITECTURE.md) - Analyse architecture (dont diagnostic historique)
+- [`docs/DIAGNOSTIC_COMPLET.md`](docs/DIAGNOSTIC_COMPLET.md) - Diagnostic technique complet
+- [`US/README.md`](US/README.md) - Vision MOHHOS (spécifications, non implémenté)
 
 ## 🛣️ Roadmap
+
+Cibles **non implémentées** à ce jour (le code actuel s’arrête au prototype QEMU + shell + simulateur). Le dossier [`US/`](US/README.md) détaille une vision plus large (MOHHOS, 8 phases) : spécifications uniquement.
 
 ### Version 7.0 - IA Véritable (Prochaine)
 - [ ] Moteur d'inférence intégré
@@ -270,6 +279,12 @@ Le projet suit une architecture modulaire facilitant l'ajout de nouvelles foncti
 
 ## 🛠️ Mises à Jour Récentes
 
+### v6.1.1 - EOI timer / clavier shell (Août 2026) ✅
+- **Problème résolu** : prompt visible mais aucune touche reçue (`SYS_GETS` timeout)
+- **Cause** : EOI PIC IRQ0 après `schedule()` qui ne revient jamais (`jump_to_task` / iret)
+- **Solution** : EOI dans le stub IRQ0 avant le handler C ; `schedule()` seulement si `g_reschedule_needed`
+- **Résultat** : IRQ1 livrée, commandes `help` / `ls` / `sysinfo` / `ai` saisissables
+
 ### v6.0.1 - Correction Clavier (Août 2025) ✅
 - **Problème résolu** : Affichage clavier non fonctionnel dans le shell
 - **Cause** : Incohérence entre systèmes de buffer clavier (ASCII vs scancodes)
@@ -290,9 +305,9 @@ Le projet suit une architecture modulaire facilitant l'ajout de nouvelles foncti
 
 ---
 
-**AI-OS v6.0** - *Système d'exploitation multitâche avec shell interactif fonctionnel*  
-*Prêt pour l'hébergement d'intelligence artificielle* 🤖
+**AI-OS v6.1** - *Prototype de noyau i386 avec shell userspace sous QEMU*  
+*Simulateur d’IA par mots-clés — pas un moteur d’inférence*
 
 **Développé avec ❤️ pour l'avenir de l'IA**
 
-*Dernière mise à jour : 2025-01-27 - CLAVIER ENTIÈREMENT FONCTIONNEL* 🎉
+*Dernière mise à jour : 2026-08-13 — documentation alignée sur l’état réel du code*

--- a/US/README.md
+++ b/US/README.md
@@ -1,5 +1,7 @@
 # MOHHOS - Dossier User Stories (US)
 
+> **État réel (août 2026).** Ce dossier est un **plan / spécification**. Aucune des 8 phases MOHHOS n’est livrée dans le noyau actuel (toujours un kernel monolithique pédagogique + simulateur `fake_ai`). Les fichiers US restent la référence de conception. Implémenté aujourd’hui : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+
 ## Vue d'Ensemble
 
 Ce dossier contient l'ensemble des User Stories (US) et spécifications techniques pour transformer AI-OS v5.0 en **MOHHOS** (Manus Operating Hybrid Hosted OS), un système d'exploitation révolutionnaire basé sur l'intelligence artificielle.

--- a/US/individual_us/INDEX.md
+++ b/US/individual_us/INDEX.md
@@ -1,5 +1,10 @@
 # Index des User Stories MOHHOS - Fichiers Détaillés
 
+> **Légende (août 2026)**  
+> - ✅ dans cet index = **spécification rédigée** (fichier présent), **pas** « implémenté dans le noyau ».  
+> - Dans le code AI-OS actuel : **aucune US MOHHOS n’est livrée** en tant que telle. Recouvrement partiel non revendiqué : PMM/VMM (voisinage US-002), tests unitaires Unity (voisinage US-008), isolation Ring 0/3.  
+> - État du dépôt : [../../docs/ETAT_REEL.md](../../docs/ETAT_REEL.md).
+
 ## Vue d'Ensemble
 
 Ce dossier contient les spécifications détaillées de chaque User Story du projet MOHHOS. Chaque fichier fournit une analyse technique approfondie, des spécifications complètes, et des critères d'acceptation précis pour guider l'implémentation.

--- a/US/mohhos_us_phase1_foundation.md
+++ b/US/mohhos_us_phase1_foundation.md
@@ -1,5 +1,7 @@
 # MOHHOS - Phase 1 Foundation - User Stories Détaillées
 
+> **État réel (août 2026).** Phase **non commencée dans le code** : le noyau reste monolithique (`kernel/kernel.c`). Spécifications conservées. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+
 ## Vue d'Ensemble de la Phase 1
 
 La Phase Foundation constitue la base technique fondamentale pour transformer AI-OS v5.0 en MOHHOS. Cette phase se concentre sur la modernisation de l'architecture existante, l'implémentation d'un microkernel modulaire, et la mise en place des infrastructures nécessaires pour supporter les fonctionnalités avancées des phases suivantes.

--- a/US/mohhos_us_phase2_ai_core.md
+++ b/US/mohhos_us_phase2_ai_core.md
@@ -1,5 +1,7 @@
 # MOHHOS - Phase 2 AI Core - User Stories Détaillées
 
+> **État réel (août 2026).** Phase **non implémentée**. L’IA actuelle est `userspace/fake_ai.c` (mots-clés), pas TensorFlow Lite. Spécifications conservées. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+
 ## Vue d'Ensemble de la Phase 2
 
 La Phase AI Core constitue le cœur révolutionnaire de MOHHOS, transformant un système d'exploitation traditionnel en une plateforme intelligente où l'intelligence artificielle est intégrée nativement à tous les niveaux du système. Cette phase implémente la vision fondamentale de MOHHOS : un OS où l'IA n'est pas une application, mais le système nerveux central qui comprend, apprend et s'adapte.

--- a/US/mohhos_us_phase3_web_runtime.md
+++ b/US/mohhos_us_phase3_web_runtime.md
@@ -1,5 +1,7 @@
 # MOHHOS - Phase 3 Web Runtime - User Stories Détaillées
 
+> **État réel (août 2026).** Phase **non implémentée** (pas de navigateur-OS). Spécifications conservées. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+
 ## Vue d'Ensemble de la Phase 3
 
 La Phase Web Runtime transforme MOHHOS en un système d'exploitation basé sur un navigateur amélioré, réalisant la vision d'un OS où toutes les applications sont des applications web et où le navigateur devient le système de fichiers et l'explorateur principal. Cette phase implémente l'idée révolutionnaire que "le web c'est l'avenir" et que MOHHOS doit exploiter l'écosystème existant d'applications web.

--- a/US/mohhos_us_phases_4_8_synthese.md
+++ b/US/mohhos_us_phases_4_8_synthese.md
@@ -1,5 +1,7 @@
 # MOHHOS - Phases 4-8 - Synthèse des User Stories
 
+> **État réel (août 2026).** Phases 4 à 8 **non implémentées** (PromptMessage, P2P, multi-plateforme, économie, production). Synthèse de conception conservée. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+
 ## Vue d'Ensemble des Phases Avancées
 
 Les phases 4 à 8 de MOHHOS complètent la transformation révolutionnaire du système d'exploitation en implémentant les fonctionnalités les plus innovantes : le langage PromptMessage, le réseau P2P distribué, l'adaptation multi-plateforme, l'économie collaborative, et l'optimisation pour la production.

--- a/US/mohhos_user_stories_master.md
+++ b/US/mohhos_user_stories_master.md
@@ -1,5 +1,7 @@
 # MOHHOS - Plan de Développement par User Stories
 
+> **État réel (août 2026).** Document de **planification**. AI-OS n’a pas encore migré vers MOHHOS (pas de microkernel, pas de TensorFlow Lite, pas de P2P). Les US ci-dessous restent valides comme backlog. Code actuel : [docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+
 ## Vue d'Ensemble du Projet
 
 **MOHHOS** (Manus Operating Hybrid Hosted OS) représente l'évolution révolutionnaire d'AI-OS vers un système d'exploitation intelligent, distribué et basé sur l'IA. Ce document présente un plan de développement structuré en User Stories (US) pour transformer le système d'exploitation actuel AI-OS v5.0 en MOHHOS, un OS révolutionnaire qui supprime toutes les barrières des systèmes d'exploitation actuels.

--- a/US/recherche_technologies_mohhos.md
+++ b/US/recherche_technologies_mohhos.md
@@ -1,5 +1,7 @@
 # Recherche Approfondie - Technologies pour MOHHOS
 
+> **État réel (août 2026).** Veille / spécification. Ces technologies (TFLite, P2P, navigateur-OS, …) **ne sont pas** dans le dépôt AI-OS actuel. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+
 ## Vue d'Ensemble du Projet MOHHOS
 
 D'après l'analyse de l'objectif fourni, MOHHOS est un projet révolutionnaire visant à créer un système d'exploitation basé sur l'IA avec les caractéristiques suivantes :

--- a/docs/ANALYSE_ARCHITECTURE.md
+++ b/docs/ANALYSE_ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Analyse de l'Architecture AI-OS
 
+> **État réel (août 2026).** Le passage au shell Ring 3 fonctionne (`create_task_from_initrd_file` + `jump_to_task`). Les sections « Problèmes identifiés » et « Flux actuel (problématique) » ci-dessous sont un **diagnostic historique** conservé. Voir [ETAT_REEL.md](ETAT_REEL.md).
+
 ## Vue d'ensemble du système
 
 AI-OS est un système d'exploitation expérimental en 32-bit avec les composants suivants :
@@ -24,7 +26,7 @@ AI-OS est un système d'exploitation expérimental en 32-bit avec les composants
 
 4. **Appels système (kernel/syscall/)**
    - `syscall.c/h` : Interface kernel/userspace
-   - 7 appels système définis (exit, putc, getc, puts, yield, gets, exec)
+   - 8 appels système : exit, putc, getc, puts, yield, gets, exec, spawn
 
 5. **Chargeur ELF (kernel/)**
    - `elf.c/h` : Chargement d'exécutables ELF
@@ -39,11 +41,22 @@ AI-OS est un système d'exploitation expérimental en 32-bit avec les composants
    - `paging.s` : Support pagination mémoire
 
 8. **Programmes utilisateur (userspace/)**
-   - `shell.c` : Shell interactif avancé avec IA intégrée
-   - `fake_ai.c` : Simulateur d'intelligence artificielle
+   - `shell.c` : Shell interactif (sous-ensemble de commandes réellement branché ; `ls`/`ps` encore simulés)
+   - `fake_ai.c` : Simulateur d'intelligence artificielle (mots-clés)
+   - `ai_assistant.c` : Assistant empaqueté dans l’initrd
    - `test_program.c` : Programme de test
 
-## Problèmes identifiés
+## État actuel du passage au mode utilisateur (août 2026)
+
+1. `kmain()` initialise IDT/PIC/clavier/mémoire/initrd/tâches/syscalls
+2. Charge `bin/shell` depuis l’initrd (`create_task_from_initrd_file`)
+3. `timer_init(100)` puis `g_reschedule_needed = 1`
+4. IRQ0 : EOI immédiat, puis `schedule()` → `jump_to_task()` (iret Ring 3)
+5. Le shell ELF s’exécute ; le clavier IRQ1 n’est plus masqué par un EOI manquant
+
+Le changement de contexte n’utilise plus le `switch_task` commenté cité plus bas : `schedule()` appelle `jump_to_task()`. Un répertoire de pages utilisateur est créé (`create_user_vmm_directory`).
+
+## Problèmes identifiés (diagnostic historique)
 
 ### 1. Problème principal : Changement de contexte désactivé
 

--- a/docs/ANALYSE_PROBLEMES.md
+++ b/docs/ANALYSE_PROBLEMES.md
@@ -1,5 +1,7 @@
 # Analyse des Problèmes - AI-OS Mode Utilisateur
 
+> **État réel (août 2026).** Le kernel n’est plus coincé dans une boucle shell simulée : le programme `userspace/shell.c` s’exécute en Ring 3. Ce fichier reste une analyse utile de l’ancien flux. Voir [ETAT_REEL.md](ETAT_REEL.md).
+
 ## Problèmes Identifiés
 
 ### 1. Problème Principal: Pas de Vrai Passage au Mode Utilisateur

--- a/docs/ANALYSE_PROBLEMES_SHELL.md
+++ b/docs/ANALYSE_PROBLEMES_SHELL.md
@@ -1,5 +1,7 @@
 # Analyse des Problèmes - Shell Utilisateur AI-OS
 
+> **État réel (août 2026).** L’interface n’est plus figée au passage userspace ; le shell ELF démarre. Contenu historique conservé. Voir [ETAT_REEL.md](ETAT_REEL.md).
+
 ## Problème Principal Identifié
 
 **Symptôme**: L'interface reste figée lors du passage au mode utilisateur et le système redémarre en boucle.

--- a/docs/CHANGELOG_v6.1.md
+++ b/docs/CHANGELOG_v6.1.md
@@ -18,4 +18,14 @@
 
 ## Statut
 
-✅ FONCTIONNEL - Clavier pleinement opérationnel
+✅ FONCTIONNEL - Clavier pleinement opérationnel *(init PS/2 + buffer v6.1)*
+
+## Complément août 2026 (EOI PIC)
+
+La v6.1 laissait encore IRQ1 bloquée une fois le shell lancé : `schedule()` ne revient pas dans le stub IRQ0, l’EOI placé après n’était pas envoyé, le 8259 gardait IRQ0 in-service.
+
+- `boot/isr_stubs.s` : EOI IRQ0 **avant** `timer_handler`
+- `kernel/timer.c` : `schedule()` seulement si `g_reschedule_needed`
+
+Sans ce complément, le boot affichait le prompt mais `SYS_GETS` restait en timeout. Voir [ETAT_REEL.md](ETAT_REEL.md).
+

--- a/docs/CORRECTION_CLAVIER_DEFINITIVE_v7.md
+++ b/docs/CORRECTION_CLAVIER_DEFINITIVE_v7.md
@@ -1,5 +1,7 @@
 # Correction Définitive du Clavier AI-OS - Rapport Final
 
+> **Complément août 2026.** Un second blocage (EOI IRQ0 / PIC) subsistait après ce rapport. Voir [ETAT_REEL.md](ETAT_REEL.md).
+
 ## 🎯 Problème Résolu
 
 **Symptôme initial :** Une fois le shell utilisateur affiché, aucune touche du clavier ne fonctionnait, rendant le système inutilisable.

--- a/docs/CORRECTION_STABILITE.md
+++ b/docs/CORRECTION_STABILITE.md
@@ -1,6 +1,8 @@
 # Rapport de Correction de Stabilité - AI-OS v5.0
 ## Résolution des Redémarrages en Boucle et Stabilisation du Système
 
+> **État réel (août 2026).** Les redémarrages en boucle décrits ici ne sont plus le comportement observé après le correctif de planification/EOI. Rapport conservé. Voir [ETAT_REEL.md](ETAT_REEL.md).
+
 ### 📋 Résumé Exécutif
 
 **Projet :** AI-OS v5.0 - Correction de Stabilité  

--- a/docs/DIAGNOSTIC_COMPLET.md
+++ b/docs/DIAGNOSTIC_COMPLET.md
@@ -1,5 +1,7 @@
 # Diagnostic Complet - Projet AI-OS
 
+> **État réel (août 2026).** Le projet boote jusqu’au shell userspace. Ce rapport de campagne reste valable comme chronologie. Synthèse à jour : [ETAT_REEL.md](ETAT_REEL.md).
+
 ## 📋 Résumé Exécutif
 
 **Statut Global : ✅ FONCTIONNEL AVEC CORRECTIONS APPLIQUÉES**

--- a/docs/DIAGNOSTIC_FINAL_CLAVIER_RESOLU.md
+++ b/docs/DIAGNOSTIC_FINAL_CLAVIER_RESOLU.md
@@ -1,5 +1,7 @@
 # 🎯 DIAGNOSTIC FINAL - PROBLÈME CLAVIER AI-OS RÉSOLU
 
+> **Complément août 2026.** Les correctifs PS/2 de ce diagnostic restent dans le code. Un blocage PIC (EOI IRQ0 après `schedule()`) a encore dû être traité ensuite. Voir [ETAT_REEL.md](ETAT_REEL.md) et [CHANGELOG_v6.1.md](CHANGELOG_v6.1.md).
+
 **Date:** 27 août 2025  
 **Status:** ✅ **PROBLÈME IDENTIFIÉ ET RÉSOLU**  
 **Auteur:** MiniMax Agent

--- a/docs/DIAGNOSTIC_SHELL_IA_PROBLEMES.md
+++ b/docs/DIAGNOSTIC_SHELL_IA_PROBLEMES.md
@@ -1,5 +1,7 @@
 # Diagnostic Complet - Problèmes Shell Utilisateur et IA
 
+> **État réel (août 2026).** Le système **utilise** le shell utilisateur (`userspace/shell.c` en Ring 3). L’affirmation « faux shell kernel » ci-dessous décrit un état antérieur. Voir [ETAT_REEL.md](ETAT_REEL.md).
+
 ## 🚨 **PROBLÈME PRINCIPAL IDENTIFIÉ**
 
 **Le système AI-OS n'utilise PAS le shell utilisateur réel !**

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,0 +1,131 @@
+# État réel d’AI-OS
+
+**Date de constat :** 13 août 2026  
+**Code de référence :** branche `cursor/fix-keyboard-eoi-6f7a` (correctif EOI IRQ0 + tests)  
+**Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
+
+Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
+
+## Synthèse
+
+AI-OS est un **prototype de noyau pédagogique i386 32-bit**. Il boote sous QEMU, charge un initrd TAR, passe en espace utilisateur (Ring 3) et exécute un shell ELF interactif. L’« IA » est un **simulateur par mots-clés** (`userspace/fake_ai.c`), pas un moteur d’inférence.
+
+| Périmètre | Avancement réel |
+|---|---|
+| Hobby OS minimal (boot → shell sous QEMU) | ~60–70 % |
+| Produit « OS pour l’IA » décrit dans d’anciens README | ~15–25 % |
+| Vision MOHHOS (120 US, 8 phases) | ~1–2 % (spécifications + simulateur) |
+
+Ce n’est **pas** un système d’exploitation utilisable au quotidien (pas de FS persistant, pas de réseau, pas d’interface graphique native, pas de vrais pilotes hors QEMU/i8042).
+
+## Ce qui fonctionne (vérifié)
+
+Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavier via `sendkey`, et `make test-all`.
+
+### Noyau
+
+- Boot Multiboot, affichage VGA + logs série
+- GDT, IDT, PIC 8259, PIT (timer), clavier PS/2 (IRQ1)
+- PMM / VMM / heap, paging
+- Initrd format TAR POSIX (`fs/initrd.c`)
+- Chargeur ELF 32-bit
+- Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
+- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`
+
+### Espace utilisateur
+
+- `userspace/shell.c` s’exécute vraiment en Ring 3 (plus de boucle shell simulée dans le kernel)
+- Programmes empaquetés dans l’initrd : `shell`, `fake_ai`, `ai_assistant`, `user_program`
+- Commande `ai <texte>` lance `fake_ai` via `SYS_EXEC`
+
+### Clavier (août 2026)
+
+Les nombreuses notes « clavier corrigé » des versions 6.0/6.1 étaient **partiellement** vraies (init PS/2, scancodes, buffer). Un bug restait : `schedule()` fait `iret` et ne revient jamais dans le stub IRQ0, donc l’EOI PIC placé *après* `schedule()` n’était pas envoyé. IRQ0 restait in-service et **bloquait IRQ1**.
+
+Correctif actuel :
+
+1. EOI IRQ0 **avant** `timer_handler` / `schedule()` (`boot/isr_stubs.s`)
+2. Planification seulement si `g_reschedule_needed` (lancement du shell, exec/spawn) — plus à chaque tick, ce qui provoquait un page fault une fois l’EOI rétabli (`kernel/timer.c`)
+
+Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` reçus par `SYS_GETS`.
+
+### Tests
+
+`make test-all` (binaires 32-bit) :
+
+| Binaire | Tests unitaires |
+|---|---|
+| `test_pmm` | 17/17 |
+| `test_syscall` | 30/30 |
+| `test_task` | 21/21 |
+| `test_shell` | 25/25 |
+
+Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le compteur « Total Tests » du script `run_all_tests.sh` reste à 0 (incrément placé après `return`) : bug d’affichage, pas d’échec des binaires.
+
+Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en plus de `nasm` et `qemu-system-i386`).
+
+## Shell : commandes réelles vs affichées
+
+`help` liste beaucoup plus de commandes que `execute_builtin_command()` n’en implémente.
+
+**Branchées dans le code :**
+
+| Commande | Comportement réel |
+|---|---|
+| `help` | Aide (liste plus large que le code) |
+| `ls` / `dir` | Liste **codée en dur**, pas un listing initrd |
+| `ps` | Table de processus **simulée** |
+| `sysinfo` / `info` | Texte fixe (128 MB, etc.) |
+| `mem` / `memory` | Affichage simulé |
+| `history`, `env`, `echo`, `clear`/`cls` | Fonctionnels en mémoire processus |
+| `pwd`, `cd` | Chemin en RAM seulement (pas de FS) |
+| `cat` | Stub : « pas d’API FS » |
+| `which` | Builtin ou `bin/<cmd> (non vérifié)` |
+| `exit` / `quit` | Sortie du programme |
+| `ai`, `ai-mode`, `ai-help`, `ai-test` | Pont vers le simulateur |
+
+**Annoncées dans `help` mais absentes du gestionnaire :**  
+`mkdir`, `rmdir`, `cp`, `mv`, `rm`, `kill`, `jobs`, `top`, `uptime`, `date`, `whoami`, `alias`, `unalias`, `export`, `grep`, `wc`, `sort`, `head`, `ai-stats`, etc.
+
+## « Intelligence artificielle »
+
+`userspace/fake_ai.c` compare la question (minuscules) à des mots-clés et imprime une réponse préprogrammée (`bonjour` → `AI: bonjour`, `healthcheck` → `AI HEALTH: OK`, …). Il n’y a pas de TensorFlow Lite, pas de NLP, pas de modèle, pas d’apprentissage.
+
+`initrd_content/ai_knowledge.txt` et `ai_data.txt` sont des fichiers texte d’accompagnement, pas une base vectorielle.
+
+## Ce qui n’existe pas dans le code
+
+Malgré la roadmap README v7/v8 et le dossier `US/` :
+
+- Moteur d’IA réel, apprentissage fédéré, cloud-edge
+- Système de fichiers persistant (disque)
+- Pile TCP/IP, services réseau
+- Interface graphique du OS (seul QEMU affiche du VGA texte)
+- Architecture microkernel, IPC, plugins
+- Réseau P2P, multi-plateforme, économie collaborative
+- Les 120 User Stories MOHHOS : **spécifications**, pas d’implémentation (sauf recouvrement accidentel avec le noyau actuel : mémoire, tests unitaires partiels)
+
+Le préemptif « à chaque tick » est volontairement **limité** : après le premier passage au shell, le timer n’appelle plus `schedule()` sauf `g_reschedule_needed`. Le round-robin continu n’est pas le mode de production actuel (stabilité).
+
+## Documents historiques à ne pas prendre pour l’état courant
+
+Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusion « le shell ne se lance pas » / « crash timer » / « clavier mort à jamais » est **obsolète** :
+
+- `docs/todo.md` (phases 3–4 : blocage userspace) — mis à jour, le diagnostic d’origine est conservé
+- `docs/ANALYSE_ARCHITECTURE.md`, `ANALYSE_PROBLEMES.md`, `ANALYSE_PROBLEMES_SHELL.md`
+- `docs/diagnostic_problemes.md`, `DIAGNOSTIC_SHELL_IA_PROBLEMES.md`
+- Série `CORRECTION_CLAVIER_*.md`, `DIAGNOSTIC_CLAVIER_*.md`, `KEYBOARD_*.md` (correctifs PS/2 toujours pertinents ; le blocage PIC/EOI n’y est en général pas identifié)
+
+## Comment vérifier
+
+```bash
+sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
+make clean && make all
+make test-all
+make run          # console curses (recommandé en local)
+make run-gui      # fenêtre GTK
+```
+
+En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
+
+Prompt actuel du shell : `/ (-.-) :`

--- a/docs/GUIDE_EXECUTION.md
+++ b/docs/GUIDE_EXECUTION.md
@@ -1,5 +1,9 @@
 # Guide d'Exécution AI-OS - Modes Console et GUI
 
+Prérequis : `build-essential`, `gcc-multilib`, `nasm`, `qemu-system-i386` (ajouter `qemu-system-gui` pour GTK). État du système : [ETAT_REEL.md](ETAT_REEL.md).
+
+Le shell lit le **clavier emulé PS/2**, pas le port série. En nographic, la saisie du terminal hôte n’atteint souvent pas le guest ; préférer `make run` (curses) ou `make run-gui`.
+
 ## 🚀 Options de Lancement
 
 ### 1. Mode Console Optimal (Recommandé)

--- a/docs/RAPPORT_IMPLEMENTATION.md
+++ b/docs/RAPPORT_IMPLEMENTATION.md
@@ -1,5 +1,7 @@
 # Rapport d'Implémentation - Gestion des Interruptions et Clavier
 
+> **Complément août 2026.** L’IRQ clavier n’était pleinement livrée au shell qu’après l’EOI timer avant `schedule()`. Voir [ETAT_REEL.md](ETAT_REEL.md).
+
 ## Résumé
 
 L'implémentation de la gestion des interruptions et de l'interaction avec le clavier a été réalisée avec succès selon les spécifications fournies. Le système AI-OS peut maintenant détecter et réagir aux entrées clavier de l'utilisateur.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,72 @@
+# Documentation AI-OS
+
+## Lire en premier
+
+1. [ETAT_REEL.md](ETAT_REEL.md) — **état actuel du code** (août 2026)
+2. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) — lancement QEMU (console / GUI / nographic)
+3. [../README.md](../README.md) — compilation, tests, architecture des sources
+
+Les autres fichiers de ce dossier sont conservés : rapports de debug, chronologie des correctifs clavier, spécifications d’étapes. Beaucoup décrivent un état **intermédiaire** (shell simulé dans le kernel, crash timer, clavier mort). Ils ne sont pas effacés.
+
+## Documents à jour (comportement courant)
+
+| Fichier | Contenu |
+|---|---|
+| [ETAT_REEL.md](ETAT_REEL.md) | Ce qui marche / stubs / vision non codée |
+| [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) | Modes QEMU et dépannage clavier |
+| [CHANGELOG_v6.1.md](CHANGELOG_v6.1.md) | Notes de version 6.1 + correctif EOI |
+| [todo.md](todo.md) | Suivi des tâches (historique + reste à faire) |
+| [etape_7_shell_ia.md](etape_7_shell_ia.md) | Étape shell + IA simulée (liste de commandes actualisée) |
+| [analyse_logique_docs.md](analyse_logique_docs.md) | Logique des étapes 1–7 |
+| [etapes_3_4_specifications.md](etapes_3_4_specifications.md) | Specs mémoire / initrd |
+| [etapes_5_6_implementation.md](etapes_5_6_implementation.md) | Multitâche / userspace |
+| [AI_OS_v5_NOUVELLES_FONCTIONNALITES.md](AI_OS_v5_NOUVELLES_FONCTIONNALITES.md) | Fonctionnalités v5 |
+
+## Diagnostics et correctifs (historiques, contenu technique conservé)
+
+Utile pour comprendre *pourquoi* un correctif a été tenté. La conclusion « toujours cassé » peut être fausse aujourd’hui.
+
+### Architecture et userspace
+
+- [ANALYSE_ARCHITECTURE.md](ANALYSE_ARCHITECTURE.md)
+- [ANALYSE_PROBLEMES.md](ANALYSE_PROBLEMES.md)
+- [ANALYSE_PROBLEMES_SHELL.md](ANALYSE_PROBLEMES_SHELL.md)
+- [diagnostic_problemes.md](diagnostic_problemes.md)
+- [DIAGNOSTIC_SHELL_IA_PROBLEMES.md](DIAGNOSTIC_SHELL_IA_PROBLEMES.md)
+- [DIAGNOSTIC_COMPLET.md](DIAGNOSTIC_COMPLET.md)
+- [CORRECTION_SHELL_V5.md](CORRECTION_SHELL_V5.md)
+- [CORRECTION_STABILITE.md](CORRECTION_STABILITE.md)
+
+### Clavier PS/2 (plusieurs itérations)
+
+- [CORRECTION_CLAVIER_FINALE.md](CORRECTION_CLAVIER_FINALE.md)
+- [CORRECTION_CLAVIER_FINALE_V2.md](CORRECTION_CLAVIER_FINALE_V2.md)
+- [CORRECTION_CLAVIER_ULTIME.md](CORRECTION_CLAVIER_ULTIME.md)
+- [CORRECTION_CLAVIER_DEFINITIVE_v7.md](CORRECTION_CLAVIER_DEFINITIVE_v7.md)
+- [CORRECTION_DEFINITIVE_CLAVIER_FINALE.md](CORRECTION_DEFINITIVE_CLAVIER_FINALE.md)
+- [CORRECTION_AFFICHAGE_CLAVIER_V6.md](CORRECTION_AFFICHAGE_CLAVIER_V6.md)
+- [CORRECTIONS_CLAVIER.md](CORRECTIONS_CLAVIER.md)
+- [KEYBOARD_STABLE_FIX.md](KEYBOARD_STABLE_FIX.md)
+- [KEYBOARD_ULTIMATE_FIX.md](KEYBOARD_ULTIMATE_FIX.md)
+- [DIAGNOSTIC_CLAVIER_V3.md](DIAGNOSTIC_CLAVIER_V3.md)
+- [DIAGNOSTIC_FINAL_CLAVIER_RESOLU.md](DIAGNOSTIC_FINAL_CLAVIER_RESOLU.md)
+- [RAPPORT_CORRECTION_CLAVIER_FINALE.md](RAPPORT_CORRECTION_CLAVIER_FINALE.md)
+
+Le blocage restant (EOI IRQ0 après `schedule()` / PIC qui masque IRQ1) est documenté dans [ETAT_REEL.md](ETAT_REEL.md), pas dans ces itérations.
+
+### Rapports de campagne de tests / implémentation
+
+- [RAPPORT_IMPLEMENTATION.md](RAPPORT_IMPLEMENTATION.md)
+- [RAPPORT_CORRECTION_FINALE.md](RAPPORT_CORRECTION_FINALE.md)
+- [RAPPORT_DIAGNOSTIC_APPROFONDI.md](RAPPORT_DIAGNOSTIC_APPROFONDI.md)
+- [RAPPORT_TEST_FINAL_v7.md](RAPPORT_TEST_FINAL_v7.md)
+- [RAPPORT_FINAL_V2.md](RAPPORT_FINAL_V2.md)
+- [RAPPORT_FINAL_V4.md](RAPPORT_FINAL_V4.md)
+- [rapport_tests_shell_ia.md](rapport_tests_shell_ia.md)
+- [rapport_stabilite_modules.md](rapport_stabilite_modules.md)
+
+Les fichiers `.log` / `.txt` du même dossier sont des captures QEMU ou de build : traces brutes, pas de spécification.
+
+## Vision MOHHOS (hors code actuel)
+
+Dossier [../US/](../US/README.md) : 120 user stories et phases Foundation → Production. Ce sont des **spécifications cibles**, pas l’état du dépôt. Légende dans [../US/individual_us/INDEX.md](../US/individual_us/INDEX.md).

--- a/docs/analyse_logique_docs.md
+++ b/docs/analyse_logique_docs.md
@@ -1,5 +1,7 @@
 # Analyse de la Logique du Projet AI-OS
 
+> **État réel (août 2026).** Les étapes 1 à 7 existent dans le code (noyau + shell + simulateur IA). Les syscalls sont au nombre de **8** (dont exec/spawn). Voir [ETAT_REEL.md](ETAT_REEL.md).
+
 ## Vue d'Ensemble du Projet
 
 AI-OS est un système d'exploitation spécialement conçu pour héberger et exécuter des applications d'intelligence artificielle de manière sécurisée et efficace. Le projet suit une approche progressive par étapes, chaque version ajoutant des fonctionnalités essentielles.
@@ -24,7 +26,7 @@ AI-OS est un système d'exploitation spécialement conçu pour héberger et exé
 - **Système de tâches** : Multitâche préemptif avec ordonnanceur Round-Robin
 - **Changement de contexte** : Optimisé en assembleur
 - **Séparation Ring 0/3** : Isolation kernel/utilisateur
-- **Appels système** : Interface sécurisée (5 syscalls)
+- **Appels système** : Interface sécurisée (**8** syscalls : exit, putc, getc, puts, yield, gets, exec, spawn ; le chiffre 5 ci-dessous est l’état à l’étape 5–6 d’origine)
 - **Chargeur ELF** : Exécution de programmes externes
 
 ## Logique Technique Détaillée

--- a/docs/diagnostic_problemes.md
+++ b/docs/diagnostic_problemes.md
@@ -1,5 +1,7 @@
 # Diagnostic des Problèmes AI-OS
 
+> **État réel (août 2026).** Le crash/redémarrage après activation du timer n’est plus le comportement observé : le système atteint le prompt shell. Analyse d’origine conservée ci-dessous. Voir [ETAT_REEL.md](ETAT_REEL.md).
+
 ## Problème Principal Identifié
 
 **Symptôme**: Redémarrage en boucle du système

--- a/docs/etape_7_shell_ia.md
+++ b/docs/etape_7_shell_ia.md
@@ -1,6 +1,8 @@
 # AI-OS Étape 7 : Shell Interactif et Simulateur d'IA
 ## Implémentation Complète de l'Interface Conversationnelle
 
+> **État réel (août 2026).** L’étape 7 est en place (shell ELF + `fake_ai`). Ce n’est pas une « plateforme conversationnelle » au sens ML : simulateur par mots-clés. Liste des commandes réellement branchées : [ETAT_REEL.md](ETAT_REEL.md).
+
 ### 📋 Vue d'Ensemble
 
 L'étape 7 représente l'aboutissement du projet AI-OS avec l'implémentation d'un shell interactif complet intégrant un simulateur d'intelligence artificielle. Cette version transforme AI-OS d'un système d'exploitation expérimental en une plateforme conversationnelle fonctionnelle.
@@ -20,7 +22,14 @@ L'étape 7 représente l'aboutissement du projet AI-OS avec l'implémentation d'
 - Boucle interactive avec prompt personnalisé
 - Gestion des erreurs et mode de secours
 
-**Commandes internes supportées :**
+**Commandes internes réellement gérées par `execute_builtin_command()` (août 2026) :**
+- `help`, `ls`/`dir`, `ps`, `sysinfo`/`info`, `mem`/`memory`
+- `history`, `env`, `echo`, `clear`/`cls`, `pwd`, `cd`, `cat` (stub FS), `which`
+- `exit`/`quit`, `ai`, `ai-mode`, `ai-help`, `ai-test`
+
+`help` affiche aussi mkdir/rm/kill/top/… : **non implémentées** dans le gestionnaire. `ls` et `ps` affichent des données simulées.
+
+**Commandes internes supportées (liste d’origine du document, v5) :**
 - `exit/quit` : Quitter le shell
 - `clear/cls` : Effacer l'écran
 - `about/version` : Informations sur AI-OS

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,7 @@
 # TODO - Correction AI-OS Shell Utilisateur
 
+> **État réel (août 2026).** Le shell utilisateur Ring 3 **se lance** et le clavier **répond** (correctif EOI IRQ0). Les cases des phases 5–6 ci-dessous sont mises à jour. Le diagnostic d’origine (phases 1–4) est **conservé** : il décrit correctement un état antérieur. Référence : [ETAT_REEL.md](ETAT_REEL.md).
+
 ## Phase 1: Récupération et configuration du projet ✅
 - [x] Cloner le projet depuis GitHub
 - [x] Examiner la structure du projet
@@ -35,21 +37,32 @@
 - ✅ **Compilation réussie** après installation de nasm, gcc-multilib et qemu
 - ✅ **Système stable** - Plus de redémarrage en boucle
 - ✅ **Timer fonctionnel** - Ticks réguliers à 100Hz
-- ❌ **Mode simulation seulement** - Le système reste en mode kernel au lieu de passer au shell utilisateur
+- ❌ **Mode simulation seulement** - Le système reste en mode kernel au lieu de passer au shell utilisateur *(constat d’alors)*
 - 📝 **Point de blocage identifié**: Le code reste dans la boucle de simulation au lieu d'exécuter le shell utilisateur
 
-## Phase 5: Correction et refactorisation
-- [ ] Corriger les problèmes identifiés
-- [ ] Refactoriser le code si nécessaire
-- [ ] Améliorer la stabilité du système
-- [ ] Optimiser la communication kernel/userspace
+*Mise à jour août 2026 :* le shell ELF userspace est lancé ; le « mode simulation seulement » ne s’applique plus. Voir phase 5.
 
-## Phase 6: Tests finaux et soumission sur GitHub
-- [ ] Tests complets du système corrigé
-- [ ] Validation du fonctionnement en mode utilisateur
-- [ ] Commit et push des corrections sur GitHub
-- [ ] Documentation des corrections apportées
+## Phase 5: Correction et refactorisation ✅ (août 2026)
+- [x] Corriger les problèmes identifiés (transition userspace via `jump_to_task`, EOI PIC avant `schedule()`)
+- [x] Refactoriser le code si nécessaire (planification uniquement sur `g_reschedule_needed`)
+- [x] Améliorer la stabilité du système (plus de reboot systématique après le timer)
+- [x] Optimiser la communication kernel/userspace (syscalls GETS/EXEC fonctionnels)
 
-## Problème identifié
+### Reste ouvert (hors périmètre « shell qui démarre »)
+- [ ] `ls` / `ps` / `sysinfo` : remplacer les affichages simulés par de vrais syscalls
+- [ ] API FS userspace (`cat` est un stub)
+- [ ] Commandes listées dans `help` mais absentes du gestionnaire (`mkdir`, `kill`, `top`, …)
+- [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
+- [ ] FS persistant, réseau, vrai moteur IA — voir roadmap README / dossier `US/`
+
+## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)
+- [x] Tests complets du système corrigé (`make test-all` : 93 tests unitaires)
+- [x] Validation du fonctionnement en mode utilisateur (QEMU GTK + `sendkey`)
+- [x] Commit et push des corrections sur GitHub
+- [x] Documentation des corrections apportées ([ETAT_REEL.md](ETAT_REEL.md))
+
+## Problème identifié (historique — phases 1 à 4)
 Le mode simulation fonctionnait parfaitement mais le passage au mode utilisateur échoue - l'interface reste figée. Besoin d'analyser les appels système et la gestion des processus.
+
+**Statut 2026 :** ce blocage est levé. Le kernel pose `g_reschedule_needed` puis le timer appelle `schedule()` une fois vers le shell ELF.
 

--- a/tests/unit/userspace/test_shell.c
+++ b/tests/unit/userspace/test_shell.c
@@ -3,6 +3,8 @@
 #include "../../framework/unity.h"
 #include "../../framework/test_kernel.h"
 
+extern int putchar(int c);
+
 // Mock des syscalls pour les tests userspace
 static char mock_output_buffer[2048];
 static int mock_output_pos = 0;
@@ -16,6 +18,7 @@ void unity_putc_redirect(char c) {
         mock_output_buffer[mock_output_pos++] = c;
         mock_output_buffer[mock_output_pos] = '\0';
     }
+    putchar(c);
 }
 
 void gets(char* buffer, int size) {
@@ -253,8 +256,9 @@ void test_strcpy_basic(void) {
 }
 
 void test_strstr_basic(void) {
-    TEST_ASSERT_EQUAL_PTR("hello world", strstr("hello world", ""));
-    TEST_ASSERT_EQUAL_PTR("world", strstr("hello world", "world"));
+    const char* haystack = "hello world";
+    TEST_ASSERT_EQUAL_PTR(haystack, strstr(haystack, ""));
+    TEST_ASSERT_EQUAL_PTR(haystack + 6, strstr(haystack, "world"));
     TEST_ASSERT_NULL(strstr("hello", "xyz"));
 }
 
@@ -319,7 +323,8 @@ void test_parse_command_max_args(void) {
     parse_command(long_cmd, command, args, &argc);
     
     TEST_ASSERT_EQUAL_STRING("cmd", command);
-    TEST_ASSERT_LESS_THAN(MAX_ARGS, argc + 1); // +1 pour la commande
+    TEST_ASSERT_LESS_THAN(MAX_ARGS, argc);
+    TEST_ASSERT_EQUAL(15, argc);
 }
 
 // === TESTS DES COMMANDES SHELL ===

--- a/tests/unit/userspace/test_shell.c
+++ b/tests/unit/userspace/test_shell.c
@@ -160,10 +160,11 @@ int parse_command(const char* input, char* command, char args[][64], int* argc) 
     // Skip leading spaces
     while (input[input_pos] == ' ') input_pos++;
     
-    // Extract command
-    while (input[input_pos] != '\0' && input[input_pos] != ' ') {
+    // Extract command (leave room for NUL)
+    while (input[input_pos] != '\0' && input[input_pos] != ' ' && cmd_pos < 63) {
         command[cmd_pos++] = input[input_pos++];
     }
+    while (input[input_pos] != '\0' && input[input_pos] != ' ') input_pos++;
     command[cmd_pos] = '\0';
     
     // Extract arguments
@@ -175,9 +176,10 @@ int parse_command(const char* input, char* command, char args[][64], int* argc) 
         
         // Extract argument
         int arg_pos = 0;
-        while (input[input_pos] != '\0' && input[input_pos] != ' ') {
+        while (input[input_pos] != '\0' && input[input_pos] != ' ' && arg_pos < 63) {
             args[*argc][arg_pos++] = input[input_pos++];
         }
+        while (input[input_pos] != '\0' && input[input_pos] != ' ') input_pos++;
         args[*argc][arg_pos] = '\0';
         (*argc)++;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
La PR #50 a été fusionnée avant les commits de documentation et de tests. Ce PR les amène sur `master`.

**Documentation (aucun rapport historique supprimé)**
- Nouveau `docs/ETAT_REEL.md` : source de vérité (ce qui marche, stubs du shell, IA simulée, MOHHOS non codé)
- Nouveau `docs/README.md` : index actuel vs historique
- README, TODO, diagnostics, analyses et user stories US : bannières d’état réel, contenu technique conservé

**Tests `test_shell`**
- Parseur borné (évite un stack smash)
- Assertions `strstr` et max-args corrigées
- Sortie Unity visible sur stdout

Branche distante vérifiée : `cursor/docs-etat-reel-6f7a` @ `ce367fb`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

