### PR TITLE
Brancher les commandes help manquantes (mkdir, rm, grep, kill, top, …)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make run-gui
 
 ## ⭐ Fonctionnalités Principales
 
-- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3 ; un sous-ensemble de commandes est réellement branché (`help`, `ls`, `sysinfo`, `ai`, …). `help` en liste davantage (stubs / non implémentées).
+- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. Les commandes de `help` sont branchées (`mkdir`, `rm`, `grep`, `kill`, `top`, …) sur un **VFS RAM** et une table de processus simulée, pas un disque ni le scheduler.
 - **🤖 Simulateur d'IA Intégré** - Réponses préprogrammées par mots-clés (`fake_ai.c`), pas un modèle ML
 - **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
 - **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
@@ -178,7 +178,7 @@ ai-os/
 - ✅ **Interruptions clavier (IRQ1) générées par QEMU**
 - ✅ **Fin des boucles infinies** sur appels système
 - ✅ **IA accessible** via interface clavier
-- ✅ **Toutes les commandes fonctionnelles** (`help`, `ls`, `ai`, etc.)
+- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `grep`, `kill`, `top`, `ai`, etc. — VFS RAM / table simulée, voir `docs/ETAT_REEL.md`)
 
 ### ✅ Corrections Antérieures
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** branche `cursor/fix-keyboard-eoi-6f7a` (correctif EOI IRQ0 + tests)  
+**Code de référence :** branche `cursor/shell-missing-builtins-6f7a` (builtins shell + VFS RAM)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -59,6 +59,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | `test_syscall` | 30/30 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
+| `test_ramfs` | 10/10 |
 
 Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le compteur « Total Tests » du script `run_all_tests.sh` reste à 0 (incrément placé après `return`) : bug d’affichage, pas d’échec des binaires.
 
@@ -66,26 +67,27 @@ Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en
 
 ## Shell : commandes réelles vs affichées
 
-`help` liste beaucoup plus de commandes que `execute_builtin_command()` n’en implémente.
-
-**Branchées dans le code :**
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. Ce n’est **pas** un vrai disque ni le scheduler du noyau : fichiers et processus vivent dans le processus shell (`userspace/ramfs.c`, `userspace/procsim.c`).
 
 | Commande | Comportement réel |
 |---|---|
-| `help` | Aide (liste plus large que le code) |
-| `ls` / `dir` | Liste **codée en dur**, pas un listing initrd |
-| `ps` | Table de processus **simulée** |
-| `sysinfo` / `info` | Texte fixe (128 MB, etc.) |
-| `mem` / `memory` | Affichage simulé |
-| `history`, `env`, `echo`, `clear`/`cls` | Fonctionnels en mémoire processus |
-| `pwd`, `cd` | Chemin en RAM seulement (pas de FS) |
-| `cat` | Stub : « pas d’API FS » |
-| `which` | Builtin ou `bin/<cmd> (non vérifié)` |
-| `exit` / `quit` | Sortie du programme |
-| `ai`, `ai-mode`, `ai-help`, `ai-test` | Pont vers le simulateur |
-
-**Annoncées dans `help` mais absentes du gestionnaire :**  
-`mkdir`, `rmdir`, `cp`, `mv`, `rm`, `kill`, `jobs`, `top`, `uptime`, `date`, `whoami`, `alias`, `unalias`, `export`, `grep`, `wc`, `sort`, `head`, `ai-stats`, etc.
+| `help` | Aide |
+| `ls` / `dir` | Listing du **VFS RAM** (répertoire courant ou argument) |
+| `mkdir` / `rmdir` / `rm` / `cp` / `mv` | Mutation du VFS RAM |
+| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture du VFS RAM |
+| `echo` | Affichage ; `echo texte > fichier` écrit dans le VFS RAM |
+| `cd` / `pwd` | Chemin en RAM, `cd` refuse un dossier absent du VFS |
+| `ps` / `jobs` / `top` / `kill` | Table de processus **simulée** (`kill` ne touche pas le noyau ; pid 0/1 protégés) |
+| `sysinfo` / `info` / `mem` / `memory` | Texte fixe (128 MB, etc.) |
+| `uptime` / `date` | Horloge pédagogique (compteur de commandes, pas de RTC) |
+| `whoami` / `env` / `export` | Variables d’environnement du shell (`USER=root` par défaut) |
+| `alias` / `unalias` | Table d’alias, expansion avant exécution |
+| `history` | Historique en mémoire |
+| `which` | `builtin` ou `bin/<cmd> (non verifie)` |
+| `clear`/`cls` | Séquence ANSI + bannière |
+| `ai`, `ai-mode`, `ai-help`, `ai-test`, `ai-stats` | Pont vers le simulateur + compteur de requêtes |
+| `exit` / `quit` / `logout` | Sortie du programme |
+| `reboot` / `shutdown` | Message simulé (QEMU n’est pas arrêté) |
 
 ## « Intelligence artificielle »
 

--- a/docs/etape_7_shell_ia.md
+++ b/docs/etape_7_shell_ia.md
@@ -23,11 +23,15 @@ L'étape 7 représente l'aboutissement du projet AI-OS avec l'implémentation d'
 - Gestion des erreurs et mode de secours
 
 **Commandes internes réellement gérées par `execute_builtin_command()` (août 2026) :**
-- `help`, `ls`/`dir`, `ps`, `sysinfo`/`info`, `mem`/`memory`
-- `history`, `env`, `echo`, `clear`/`cls`, `pwd`, `cd`, `cat` (stub FS), `which`
-- `exit`/`quit`, `ai`, `ai-mode`, `ai-help`, `ai-test`
+- Fichiers (VFS RAM) : `ls`/`dir`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `cat`, `cd`, `pwd`
+- Texte : `echo` (`>` vers le VFS), `grep`, `wc`, `sort`, `head`, `tail`
+- Processus simulés : `ps`, `kill`, `jobs`, `top`
+- Système pédagogique : `sysinfo`/`info`, `mem`/`memory`, `uptime`, `date`, `whoami`
+- Shell : `help`, `history`, `env`, `export`, `alias`, `unalias`, `which`, `clear`/`cls`
+- IA : `ai`, `ai-mode`, `ai-help`, `ai-test`, `ai-stats`
+- Contrôle : `exit`/`quit`/`logout` ; `reboot`/`shutdown` (messages simulés)
 
-`help` affiche aussi mkdir/rm/kill/top/… : **non implémentées** dans le gestionnaire. `ls` et `ps` affichent des données simulées.
+`ls`/`cat`/`mkdir` opèrent sur un VFS en mémoire, pas sur l’initrd ni un disque. `ps`/`kill` ne parlent pas au scheduler. Détail : [ETAT_REEL.md](ETAT_REEL.md).
 
 **Commandes internes supportées (liste d’origine du document, v5) :**
 - `exit/quit` : Quitter le shell

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -49,14 +49,14 @@
 - [x] Optimiser la communication kernel/userspace (syscalls GETS/EXEC fonctionnels)
 
 ### Reste ouvert (hors périmètre « shell qui démarre »)
-- [ ] `ls` / `ps` / `sysinfo` : remplacer les affichages simulés par de vrais syscalls
-- [ ] API FS userspace (`cat` est un stub)
-- [ ] Commandes listées dans `help` mais absentes du gestionnaire (`mkdir`, `kill`, `top`, …)
+- [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
+- [ ] `ls` / `ps` / `sysinfo` : remplacer VFS RAM / table simulée par de vrais syscalls noyau
+- [ ] API FS userspace vers l’initrd / un disque (le VFS RAM n’est pas persistant)
 - [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
 - [ ] FS persistant, réseau, vrai moteur IA — voir roadmap README / dossier `US/`
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)
-- [x] Tests complets du système corrigé (`make test-all` : 93 tests unitaires)
+- [x] Tests complets du système corrigé (`make test-all` : tests unitaires kernel + shell + ramfs)
 - [x] Validation du fonctionnement en mode utilisateur (QEMU GTK + `sendkey`)
 - [x] Commit et push des corrections sur GitHub
 - [x] Documentation des corrections apportées ([ETAT_REEL.md](ETAT_REEL.md))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -88,6 +88,11 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_%: $(UNIT_DIR)/kernel/test_%.c $(FRAMEWORK_
 	@echo "Compiled kernel test: $(notdir $@)"
 
 # Compilation des tests userspace
+$(BUILD_DIR)/$(UNIT_DIR)/userspace/test_ramfs: $(UNIT_DIR)/userspace/test_ramfs.c ../userspace/ramfs.c ../userspace/procsim.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_USER) -I../userspace -o $@ $< ../userspace/ramfs.c ../userspace/procsim.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled userspace test: $(notdir $@)"
+
 $(BUILD_DIR)/$(UNIT_DIR)/userspace/test_%: $(UNIT_DIR)/userspace/test_%.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_USER) -o $@ $< $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -66,16 +66,22 @@ run_test() {
     
     # Flags de compilation spécialisés selon le type de test
     local cflags="-I$TEST_DIR -I$BASE_DIR -I$BASE_DIR/kernel -I$BASE_DIR/include -Wall -Wextra -std=c99 -DKERNEL_TEST=1"
+    local extra_src=""
     
     if [ "$test_type" == "kernel" ]; then
         cflags="$cflags -m32 -ffreestanding -nostdlib -fno-pie"
     else
         cflags="$cflags -m32"
     fi
+
+    if [ "$(basename "$test_file")" = "test_ramfs.c" ]; then
+        extra_src="$BASE_DIR/userspace/ramfs.c $BASE_DIR/userspace/procsim.c"
+        cflags="$cflags -I$BASE_DIR/userspace"
+    fi
     
     # Compiler
-    echo "gcc $cflags -o \"$test_binary\" \"$test_file\" \"$TEST_DIR/framework/unity.c\" \"$TEST_DIR/framework/test_kernel.c\" \"$TEST_DIR/framework/kernel_mocks.c\"" >> "$RESULTS_FILE"
-    if gcc $cflags -o "$test_binary" "$test_file" "$TEST_DIR/framework/unity.c" "$TEST_DIR/framework/test_kernel.c" "$TEST_DIR/framework/kernel_mocks.c" 2>> "$RESULTS_FILE"; then
+    echo "gcc $cflags -o \"$test_binary\" \"$test_file\" $extra_src \"$TEST_DIR/framework/unity.c\" \"$TEST_DIR/framework/test_kernel.c\" \"$TEST_DIR/framework/kernel_mocks.c\"" >> "$RESULTS_FILE"
+    if gcc $cflags -o "$test_binary" "$test_file" $extra_src "$TEST_DIR/framework/unity.c" "$TEST_DIR/framework/test_kernel.c" "$TEST_DIR/framework/kernel_mocks.c" 2>> "$RESULTS_FILE"; then
         # Exécuter le test
         local test_output
         if test_output=$("$test_binary" 2>&1); then

--- a/tests/unit/userspace/test_ramfs.c
+++ b/tests/unit/userspace/test_ramfs.c
@@ -1,0 +1,147 @@
+/* test_ramfs.c - Tests du VFS RAM et de la table de processus simulée */
+
+#include "../../framework/unity.h"
+#include "../../framework/test_kernel.h"
+#include "ramfs.h"
+#include "procsim.h"
+#include <string.h>
+
+static void test_ramfs_seed_files(void) {
+    ramfs_init();
+    TEST_ASSERT(ramfs_is_dir("/"));
+    TEST_ASSERT(ramfs_is_dir("/bin"));
+    TEST_ASSERT(ramfs_is_dir("/home/user"));
+    TEST_ASSERT(ramfs_is_file("/test.txt"));
+    TEST_ASSERT(ramfs_is_file("/hello.txt"));
+    TEST_ASSERT(ramfs_is_file("/config.cfg"));
+    TEST_ASSERT(ramfs_node_count() > 8);
+}
+
+static void test_ramfs_resolve_relative(void) {
+    char out[RAMFS_PATH_MAX];
+    ramfs_resolve("/home/user", "docs", out, RAMFS_PATH_MAX);
+    TEST_ASSERT_EQUAL_STRING("/home/user/docs", out);
+    ramfs_resolve("/home/user", "..", out, RAMFS_PATH_MAX);
+    TEST_ASSERT_EQUAL_STRING("/home", out);
+    ramfs_resolve("/home/user", "../..", out, RAMFS_PATH_MAX);
+    TEST_ASSERT_EQUAL_STRING("/", out);
+    ramfs_resolve("/home", "/abs", out, RAMFS_PATH_MAX);
+    TEST_ASSERT_EQUAL_STRING("/abs", out);
+}
+
+static void test_ramfs_mkdir_and_list(void) {
+    ramfs_dirent_t ents[RAMFS_MAX_LIST];
+    int n;
+    int found = 0;
+    ramfs_init();
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_mkdir("/testdir"));
+    TEST_ASSERT(ramfs_is_dir("/testdir"));
+    TEST_ASSERT_EQUAL(RAMFS_ERR_EXISTS, ramfs_mkdir("/testdir"));
+    n = ramfs_list("/", ents, RAMFS_MAX_LIST);
+    TEST_ASSERT(n > 0);
+    for (int i = 0; i < n; i++) {
+        if (strcmp(ents[i].name, "testdir") == 0 && ents[i].is_dir) found = 1;
+    }
+    TEST_ASSERT(found);
+}
+
+static void test_ramfs_write_read_cat(void) {
+    int size = 0;
+    const char *data;
+    ramfs_init();
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_write("/notes.txt", "alpha\nbeta\ngamma\n", 17));
+    TEST_ASSERT(ramfs_is_file("/notes.txt"));
+    data = ramfs_read("/notes.txt", &size);
+    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_EQUAL(17, size);
+    TEST_ASSERT_EQUAL_STRING("alpha\nbeta\ngamma\n", data);
+}
+
+static void test_ramfs_rm_and_rmdir(void) {
+    ramfs_init();
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_mkdir("/empty"));
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_rmdir("/empty"));
+    TEST_ASSERT(!ramfs_exists("/empty"));
+
+    TEST_ASSERT_EQUAL(RAMFS_ERR_ISDIR, ramfs_rm("/home"));
+    TEST_ASSERT_EQUAL(RAMFS_ERR_NOTEMPTY, ramfs_rmdir("/home"));
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_write("/tmpdel.txt", "x", 1));
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_rm("/tmpdel.txt"));
+    TEST_ASSERT(!ramfs_exists("/tmpdel.txt"));
+    TEST_ASSERT_EQUAL(RAMFS_ERR_NOTFOUND, ramfs_rm("/nope.txt"));
+}
+
+static void test_ramfs_cp_mv(void) {
+    int size = 0;
+    const char *data;
+    ramfs_init();
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_cp("/hello.txt", "/hello2.txt"));
+    data = ramfs_read("/hello2.txt", &size);
+    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT(size > 0);
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_mv("/hello2.txt", "/hello3.txt"));
+    TEST_ASSERT(!ramfs_exists("/hello2.txt"));
+    TEST_ASSERT(ramfs_is_file("/hello3.txt"));
+}
+
+static void test_ramfs_grep_content(void) {
+    int size = 0;
+    const char *data;
+    ramfs_init();
+    data = ramfs_read("/ai_knowledge.txt", &size);
+    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_NOT_NULL(strstr(data, "bonjour"));
+    TEST_ASSERT_NULL(strstr(data, "zzzz-not-found"));
+}
+
+static void test_ramfs_parent_must_exist(void) {
+    ramfs_init();
+    TEST_ASSERT_EQUAL(RAMFS_ERR_NOTDIR, ramfs_mkdir("/no/such/dir"));
+    TEST_ASSERT_EQUAL(RAMFS_ERR_NOTDIR, ramfs_write("/no/file.txt", "a", 1));
+}
+
+static void test_procsim_table_and_kill(void) {
+    procsim_init();
+    TEST_ASSERT_EQUAL(5, procsim_count());
+    TEST_ASSERT_EQUAL(5, procsim_alive_count());
+    TEST_ASSERT_EQUAL(-2, procsim_kill(0));
+    TEST_ASSERT_EQUAL(-2, procsim_kill(1));
+    TEST_ASSERT_EQUAL(0, procsim_kill(3));
+    TEST_ASSERT_EQUAL(4, procsim_alive_count());
+    {
+        const procsim_entry_t *p = procsim_get_by_pid(3);
+        TEST_ASSERT_NOT_NULL(p);
+        TEST_ASSERT_EQUAL(0, p->alive);
+        TEST_ASSERT_EQUAL('Z', p->state);
+    }
+    TEST_ASSERT_EQUAL(-1, procsim_kill(99));
+}
+
+static void test_ramfs_mv_directory(void) {
+    ramfs_init();
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_mkdir("/proj"));
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_write("/proj/a.txt", "hi", 2));
+    TEST_ASSERT_EQUAL(RAMFS_OK, ramfs_mv("/proj", "/proj2"));
+    TEST_ASSERT(!ramfs_exists("/proj"));
+    TEST_ASSERT(ramfs_is_dir("/proj2"));
+    TEST_ASSERT(ramfs_is_file("/proj2/a.txt"));
+}
+
+int main(void) {
+    unity_init();
+
+    RUN_TEST(test_ramfs_seed_files);
+    RUN_TEST(test_ramfs_resolve_relative);
+    RUN_TEST(test_ramfs_mkdir_and_list);
+    RUN_TEST(test_ramfs_write_read_cat);
+    RUN_TEST(test_ramfs_rm_and_rmdir);
+    RUN_TEST(test_ramfs_cp_mv);
+    RUN_TEST(test_ramfs_grep_content);
+    RUN_TEST(test_ramfs_parent_must_exist);
+    RUN_TEST(test_ramfs_mv_directory);
+    RUN_TEST(test_procsim_table_and_kill);
+
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}

--- a/userspace/Makefile
+++ b/userspace/Makefile
@@ -12,7 +12,7 @@ PROGRAMS = shell fake_ai test_program ai_assistant
 
 all: $(PROGRAMS)
 
-shell: shell.o start.o
+shell: shell.o ramfs.o procsim.o start.o
 	@echo "Linking shell..."
 	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
 

--- a/userspace/procsim.c
+++ b/userspace/procsim.c
@@ -1,0 +1,77 @@
+/* procsim.c - Table de processus simulée (pas le vrai scheduler). */
+
+#include "procsim.h"
+
+static procsim_entry_t g_procs[PROCSIM_MAX];
+static int g_n;
+
+static void set_proc(int i, int pid, int ppid, const char *name, char state, int cpu, int mem) {
+    int k = 0;
+    g_procs[i].pid = pid;
+    g_procs[i].ppid = ppid;
+    while (name[k] && k < 31) {
+        g_procs[i].name[k] = name[k];
+        k++;
+    }
+    g_procs[i].name[k] = 0;
+    g_procs[i].state = state;
+    g_procs[i].alive = 1;
+    g_procs[i].cpu = cpu;
+    g_procs[i].mem = mem;
+}
+
+void procsim_init(void) {
+    int i;
+    for (i = 0; i < PROCSIM_MAX; i++) {
+        g_procs[i].pid = -1;
+        g_procs[i].alive = 0;
+        g_procs[i].name[0] = 0;
+    }
+    g_n = 5;
+    set_proc(0, 0, 0, "[kernel]", 'R', 1, 21);
+    set_proc(1, 1, 0, "init", 'S', 0, 15);
+    set_proc(2, 2, 1, "ai-shell", 'R', 2, 32);
+    set_proc(3, 3, 2, "ai-assistant", 'S', 0, 8);
+    set_proc(4, 4, 1, "memory-manager", 'S', 0, 5);
+}
+
+int procsim_count(void) {
+    return g_n;
+}
+
+int procsim_alive_count(void) {
+    int c = 0;
+    for (int i = 0; i < g_n; i++) {
+        if (g_procs[i].alive) c++;
+    }
+    return c;
+}
+
+const procsim_entry_t *procsim_get_by_index(int i) {
+    if (i < 0 || i >= g_n) return 0;
+    return &g_procs[i];
+}
+
+const procsim_entry_t *procsim_get_by_pid(int pid) {
+    for (int i = 0; i < g_n; i++) {
+        if (g_procs[i].pid == pid) return &g_procs[i];
+    }
+    return 0;
+}
+
+int procsim_kill(int pid) {
+    procsim_entry_t *p = 0;
+    for (int i = 0; i < g_n; i++) {
+        if (g_procs[i].pid == pid) {
+            p = &g_procs[i];
+            break;
+        }
+    }
+    if (!p) return -1;
+    if (pid == 0 || pid == 1) return -2;
+    if (!p->alive) return -1;
+    p->alive = 0;
+    p->state = 'Z';
+    p->cpu = 0;
+    return 0;
+}

--- a/userspace/procsim.h
+++ b/userspace/procsim.h
@@ -1,0 +1,26 @@
+/* procsim.h - Table de processus simulée pour ps/kill/jobs/top */
+
+#ifndef AIOS_PROCSIM_H
+#define AIOS_PROCSIM_H
+
+#define PROCSIM_MAX 16
+
+typedef struct {
+    int pid;
+    int ppid;
+    char name[32];
+    char state; /* R, S, Z */
+    int alive;
+    int cpu; /* dixièmes de % */
+    int mem; /* dixièmes de % */
+} procsim_entry_t;
+
+void procsim_init(void);
+int procsim_count(void);
+int procsim_alive_count(void);
+const procsim_entry_t *procsim_get_by_index(int i);
+const procsim_entry_t *procsim_get_by_pid(int pid);
+/* 0 ok, -1 introuvable, -2 protégé (kernel/init) */
+int procsim_kill(int pid);
+
+#endif

--- a/userspace/ramfs.c
+++ b/userspace/ramfs.c
@@ -1,0 +1,468 @@
+/* ramfs.c - VFS RAM (table de nœuds en mémoire). Sans libc. */
+
+#include "ramfs.h"
+
+typedef struct {
+    int used;
+    int is_dir;
+    char path[RAMFS_PATH_MAX];
+    char content[RAMFS_CONTENT_MAX];
+    int size;
+} ramfs_node_t;
+
+static ramfs_node_t g_nodes[RAMFS_MAX_NODES];
+static int g_count;
+
+static int rf_strlen(const char *s) {
+    int n = 0;
+    if (!s) return 0;
+    while (s[n]) n++;
+    return n;
+}
+
+static int rf_strcmp(const char *a, const char *b) {
+    int i = 0;
+    if (!a) a = "";
+    if (!b) b = "";
+    while (a[i] && b[i]) {
+        if (a[i] != b[i]) return a[i] - b[i];
+        i++;
+    }
+    return a[i] - b[i];
+}
+
+static int rf_strncmp(const char *a, const char *b, int n) {
+    for (int i = 0; i < n; i++) {
+        if (a[i] != b[i]) return a[i] - b[i];
+        if (a[i] == 0) return 0;
+    }
+    return 0;
+}
+
+static void rf_strcpy(char *d, const char *s) {
+    int i = 0;
+    if (!s) s = "";
+    while (s[i]) {
+        d[i] = s[i];
+        i++;
+    }
+    d[i] = 0;
+}
+
+static void rf_memcpy(char *d, const char *s, int n) {
+    for (int i = 0; i < n; i++) d[i] = s[i];
+}
+
+static int rf_push_part(char parts[][64], int *n, const char *start, int len) {
+    if (len <= 0) return 0;
+    if (len == 1 && start[0] == '.') return 0;
+    if (len == 2 && start[0] == '.' && start[1] == '.') {
+        if (*n > 0) (*n)--;
+        return 0;
+    }
+    if (*n >= 32) return -1;
+    if (len > 63) len = 63;
+    for (int i = 0; i < len; i++) parts[*n][i] = start[i];
+    parts[*n][len] = 0;
+    (*n)++;
+    return 0;
+}
+
+static void rf_split_push(char parts[][64], int *n, const char *s) {
+    int i = 0;
+    if (!s) return;
+    while (s[i]) {
+        while (s[i] == '/') i++;
+        if (!s[i]) break;
+        int start = i;
+        while (s[i] && s[i] != '/') i++;
+        rf_push_part(parts, n, s + start, i - start);
+    }
+}
+
+void ramfs_resolve(const char *cwd, const char *path, char *out, int outsz) {
+    char parts[32][64];
+    int n = 0;
+    if (!out || outsz < 2) return;
+    if (!path || path[0] == 0) {
+        const char *src = (cwd && cwd[0]) ? cwd : "/";
+        int i = 0;
+        while (src[i] && i < outsz - 1) {
+            out[i] = src[i];
+            i++;
+        }
+        out[i] = 0;
+        return;
+    }
+    if (path[0] != '/') {
+        rf_split_push(parts, &n, (cwd && cwd[0]) ? cwd : "/");
+    }
+    rf_split_push(parts, &n, path);
+    if (n == 0) {
+        out[0] = '/';
+        out[1] = 0;
+        return;
+    }
+    int pos = 0;
+    for (int i = 0; i < n; i++) {
+        if (pos >= outsz - 1) break;
+        out[pos++] = '/';
+        int j = 0;
+        while (parts[i][j] && pos < outsz - 1) {
+            out[pos++] = parts[i][j++];
+        }
+    }
+    out[pos] = 0;
+}
+
+static void rf_parent(const char *path, char *out) {
+    int len = rf_strlen(path);
+    int i;
+    if (len <= 1) {
+        out[0] = '/';
+        out[1] = 0;
+        return;
+    }
+    i = len - 1;
+    if (path[i] == '/') i--;
+    while (i > 0 && path[i] != '/') i--;
+    if (i == 0) {
+        out[0] = '/';
+        out[1] = 0;
+        return;
+    }
+    for (int k = 0; k < i; k++) out[k] = path[k];
+    out[i] = 0;
+}
+
+static const char *rf_basename(const char *path) {
+    int i;
+    int last = 0;
+    if (!path || (path[0] == '/' && path[1] == 0)) return path ? path : "/";
+    for (i = 0; path[i]; i++) {
+        if (path[i] == '/' && path[i + 1] != 0) last = i + 1;
+    }
+    return path + last;
+}
+
+static ramfs_node_t *find_node(const char *path) {
+    for (int i = 0; i < RAMFS_MAX_NODES; i++) {
+        if (g_nodes[i].used && rf_strcmp(g_nodes[i].path, path) == 0) {
+            return &g_nodes[i];
+        }
+    }
+    return 0;
+}
+
+static ramfs_node_t *alloc_node(void) {
+    for (int i = 0; i < RAMFS_MAX_NODES; i++) {
+        if (!g_nodes[i].used) {
+            g_nodes[i].used = 1;
+            g_nodes[i].is_dir = 0;
+            g_nodes[i].path[0] = 0;
+            g_nodes[i].content[0] = 0;
+            g_nodes[i].size = 0;
+            g_count++;
+            return &g_nodes[i];
+        }
+    }
+    return 0;
+}
+
+static int add_dir(const char *path) {
+    ramfs_node_t *n;
+    if (find_node(path)) return RAMFS_ERR_EXISTS;
+    n = alloc_node();
+    if (!n) return RAMFS_ERR_NOSPACE;
+    rf_strcpy(n->path, path);
+    n->is_dir = 1;
+    return RAMFS_OK;
+}
+
+static int add_file(const char *path, const char *text) {
+    ramfs_node_t *n;
+    int len;
+    if (find_node(path)) return RAMFS_ERR_EXISTS;
+    n = alloc_node();
+    if (!n) return RAMFS_ERR_NOSPACE;
+    rf_strcpy(n->path, path);
+    n->is_dir = 0;
+    len = rf_strlen(text);
+    if (len >= RAMFS_CONTENT_MAX) len = RAMFS_CONTENT_MAX - 1;
+    rf_memcpy(n->content, text, len);
+    n->content[len] = 0;
+    n->size = len;
+    return RAMFS_OK;
+}
+
+static int is_direct_child(const char *dir, const char *path) {
+    int dlen = rf_strlen(dir);
+    if (dlen == 1 && dir[0] == '/') {
+        int i;
+        if (path[0] != '/' || path[1] == 0) return 0;
+        for (i = 1; path[i]; i++) {
+            if (path[i] == '/') return 0;
+        }
+        return 1;
+    }
+    if (rf_strncmp(path, dir, dlen) != 0) return 0;
+    if (path[dlen] != '/') return 0;
+    {
+        const char *rest = path + dlen + 1;
+        if (*rest == 0) return 0;
+        for (; *rest; rest++) {
+            if (*rest == '/') return 0;
+        }
+    }
+    return 1;
+}
+
+static int has_children(const char *dir) {
+    for (int i = 0; i < RAMFS_MAX_NODES; i++) {
+        if (g_nodes[i].used && is_direct_child(dir, g_nodes[i].path)) return 1;
+    }
+    return 0;
+}
+
+static int parent_is_dir(const char *path) {
+    char p[RAMFS_PATH_MAX];
+    ramfs_node_t *n;
+    rf_parent(path, p);
+    n = find_node(p);
+    if (!n || !n->is_dir) return 0;
+    return 1;
+}
+
+void ramfs_init(void) {
+    int i;
+    for (i = 0; i < RAMFS_MAX_NODES; i++) {
+        g_nodes[i].used = 0;
+        g_nodes[i].path[0] = 0;
+        g_nodes[i].content[0] = 0;
+        g_nodes[i].size = 0;
+        g_nodes[i].is_dir = 0;
+    }
+    g_count = 0;
+
+    add_dir("/");
+    add_dir("/bin");
+    add_dir("/docs");
+    add_dir("/home");
+    add_dir("/home/user");
+    add_file("/test.txt", "Ceci est un fichier de test depuis l'initrd !\n");
+    add_file("/hello.txt", "Un autre fichier de demonstration.\n");
+    add_file("/config.cfg", "Configuration du systeme AI-OS v5.0\n");
+    add_file("/startup.sh", "#!/bin/sh\necho 'Script de demarrage AI-OS v5.0'\n");
+    add_file("/ai_data.txt", "Donnees pour l'intelligence artificielle simulee\n");
+    add_file("/ai_knowledge.txt", "Base de connaissances IA - Version simulation\nbonjour\nmemoire\nprocessus\n");
+    add_file("/docs/readme.txt", "Documentation AI-OS (VFS RAM pedagogique).\n");
+}
+
+int ramfs_exists(const char *path) {
+    return find_node(path) != 0;
+}
+
+int ramfs_is_dir(const char *path) {
+    ramfs_node_t *n = find_node(path);
+    return n && n->is_dir;
+}
+
+int ramfs_is_file(const char *path) {
+    ramfs_node_t *n = find_node(path);
+    return n && !n->is_dir;
+}
+
+int ramfs_mkdir(const char *path) {
+    if (!path || path[0] == 0 || rf_strcmp(path, "/") == 0) return RAMFS_ERR_INVAL;
+    if (find_node(path)) return RAMFS_ERR_EXISTS;
+    if (!parent_is_dir(path)) return RAMFS_ERR_NOTDIR;
+    return add_dir(path);
+}
+
+int ramfs_rmdir(const char *path) {
+    ramfs_node_t *n;
+    if (!path || rf_strcmp(path, "/") == 0) return RAMFS_ERR_INVAL;
+    n = find_node(path);
+    if (!n) return RAMFS_ERR_NOTFOUND;
+    if (!n->is_dir) return RAMFS_ERR_NOTDIR;
+    if (has_children(path)) return RAMFS_ERR_NOTEMPTY;
+    n->used = 0;
+    g_count--;
+    return RAMFS_OK;
+}
+
+int ramfs_rm(const char *path) {
+    ramfs_node_t *n;
+    if (!path || rf_strcmp(path, "/") == 0) return RAMFS_ERR_INVAL;
+    n = find_node(path);
+    if (!n) return RAMFS_ERR_NOTFOUND;
+    if (n->is_dir) return RAMFS_ERR_ISDIR;
+    n->used = 0;
+    g_count--;
+    return RAMFS_OK;
+}
+
+int ramfs_write(const char *path, const char *data, int len) {
+    ramfs_node_t *n;
+    if (!path || path[0] == 0 || rf_strcmp(path, "/") == 0) return RAMFS_ERR_INVAL;
+    if (len < 0) len = 0;
+    if (len >= RAMFS_CONTENT_MAX) len = RAMFS_CONTENT_MAX - 1;
+    n = find_node(path);
+    if (n) {
+        if (n->is_dir) return RAMFS_ERR_ISDIR;
+        if (data) rf_memcpy(n->content, data, len);
+        n->content[len] = 0;
+        n->size = len;
+        return RAMFS_OK;
+    }
+    if (!parent_is_dir(path)) return RAMFS_ERR_NOTDIR;
+    n = alloc_node();
+    if (!n) return RAMFS_ERR_NOSPACE;
+    rf_strcpy(n->path, path);
+    n->is_dir = 0;
+    if (data) rf_memcpy(n->content, data, len);
+    n->content[len] = 0;
+    n->size = len;
+    return RAMFS_OK;
+}
+
+const char *ramfs_read(const char *path, int *size) {
+    ramfs_node_t *n = find_node(path);
+    if (!n) {
+        if (size) *size = 0;
+        return 0;
+    }
+    if (n->is_dir) {
+        if (size) *size = 0;
+        return 0;
+    }
+    if (size) *size = n->size;
+    return n->content;
+}
+
+int ramfs_cp(const char *src, const char *dst) {
+    ramfs_node_t *s;
+    char dest[RAMFS_PATH_MAX];
+    ramfs_node_t *dnode;
+    if (!src || !dst) return RAMFS_ERR_INVAL;
+    s = find_node(src);
+    if (!s) return RAMFS_ERR_NOTFOUND;
+    if (s->is_dir) return RAMFS_ERR_ISDIR;
+    rf_strcpy(dest, dst);
+    dnode = find_node(dst);
+    if (dnode && dnode->is_dir) {
+        int pos = rf_strlen(dest);
+        if (pos > 0 && dest[pos - 1] != '/') {
+            dest[pos++] = '/';
+            dest[pos] = 0;
+        }
+        /* dest + basename(src) */
+        {
+            const char *bn = rf_basename(src);
+            int i = 0;
+            while (bn[i] && pos < RAMFS_PATH_MAX - 1) dest[pos++] = bn[i++];
+            dest[pos] = 0;
+        }
+        dnode = find_node(dest);
+    }
+    if (dnode && dnode->is_dir) return RAMFS_ERR_ISDIR;
+    return ramfs_write(dest, s->content, s->size);
+}
+
+int ramfs_mv(const char *src, const char *dst) {
+    ramfs_node_t *s;
+    ramfs_node_t *d;
+    char dest[RAMFS_PATH_MAX];
+    int slen;
+    if (!src || !dst) return RAMFS_ERR_INVAL;
+    if (rf_strcmp(src, "/") == 0) return RAMFS_ERR_INVAL;
+    s = find_node(src);
+    if (!s) return RAMFS_ERR_NOTFOUND;
+    rf_strcpy(dest, dst);
+    d = find_node(dst);
+    if (d && d->is_dir) {
+        int pos = rf_strlen(dest);
+        if (pos > 0 && dest[pos - 1] != '/') {
+            dest[pos++] = '/';
+            dest[pos] = 0;
+        }
+        {
+            const char *bn = rf_basename(src);
+            int i = 0;
+            while (bn[i] && pos < RAMFS_PATH_MAX - 1) dest[pos++] = bn[i++];
+            dest[pos] = 0;
+        }
+        d = find_node(dest);
+    }
+    if (d) return RAMFS_ERR_EXISTS;
+    if (!parent_is_dir(dest)) return RAMFS_ERR_NOTDIR;
+    slen = rf_strlen(src);
+    if (s->is_dir) {
+        for (int i = 0; i < RAMFS_MAX_NODES; i++) {
+            if (!g_nodes[i].used) continue;
+            if (rf_strcmp(g_nodes[i].path, src) == 0) {
+                rf_strcpy(g_nodes[i].path, dest);
+            } else if (rf_strncmp(g_nodes[i].path, src, slen) == 0 &&
+                       g_nodes[i].path[slen] == '/') {
+                char np[RAMFS_PATH_MAX];
+                int dlen = rf_strlen(dest);
+                int k;
+                rf_strcpy(np, dest);
+                k = 0;
+                while (g_nodes[i].path[slen + k] && dlen + k < RAMFS_PATH_MAX - 1) {
+                    np[dlen + k] = g_nodes[i].path[slen + k];
+                    k++;
+                }
+                np[dlen + k] = 0;
+                rf_strcpy(g_nodes[i].path, np);
+            }
+        }
+        return RAMFS_OK;
+    }
+    rf_strcpy(s->path, dest);
+    return RAMFS_OK;
+}
+
+int ramfs_list(const char *path, ramfs_dirent_t *out, int max_n) {
+    ramfs_node_t *n;
+    int count = 0;
+    if (!path || !out || max_n <= 0) return RAMFS_ERR_INVAL;
+    n = find_node(path);
+    if (!n) return RAMFS_ERR_NOTFOUND;
+    if (!n->is_dir) return RAMFS_ERR_NOTDIR;
+    for (int i = 0; i < RAMFS_MAX_NODES && count < max_n; i++) {
+        if (!g_nodes[i].used) continue;
+        if (!is_direct_child(path, g_nodes[i].path)) continue;
+        {
+            const char *bn = rf_basename(g_nodes[i].path);
+            int j = 0;
+            while (bn[j] && j < RAMFS_NAME_MAX - 1) {
+                out[count].name[j] = bn[j];
+                j++;
+            }
+            out[count].name[j] = 0;
+            out[count].is_dir = g_nodes[i].is_dir;
+            out[count].size = g_nodes[i].size;
+            count++;
+        }
+    }
+    return count;
+}
+
+int ramfs_node_count(void) {
+    return g_count;
+}
+
+const char *ramfs_strerror(int err) {
+    switch (err) {
+        case RAMFS_OK: return "ok";
+        case RAMFS_ERR_NOTFOUND: return "fichier introuvable";
+        case RAMFS_ERR_EXISTS: return "existe deja";
+        case RAMFS_ERR_NOTDIR: return "n'est pas un repertoire";
+        case RAMFS_ERR_ISDIR: return "est un repertoire";
+        case RAMFS_ERR_NOTEMPTY: return "repertoire non vide";
+        case RAMFS_ERR_NOSPACE: return "plus de place";
+        case RAMFS_ERR_INVAL: return "argument invalide";
+        default: return "erreur";
+    }
+}

--- a/userspace/ramfs.h
+++ b/userspace/ramfs.h
@@ -1,0 +1,50 @@
+/* ramfs.h - VFS RAM pédagogique pour le shell AI-OS
+ * Pas un vrai système de fichiers : table en mémoire processus.
+ */
+
+#ifndef AIOS_RAMFS_H
+#define AIOS_RAMFS_H
+
+#define RAMFS_MAX_NODES     64
+#define RAMFS_PATH_MAX      128
+#define RAMFS_NAME_MAX      64
+#define RAMFS_CONTENT_MAX   1024
+#define RAMFS_MAX_LIST      32
+
+#define RAMFS_OK            0
+#define RAMFS_ERR_NOTFOUND  -1
+#define RAMFS_ERR_EXISTS    -2
+#define RAMFS_ERR_NOTDIR    -3
+#define RAMFS_ERR_ISDIR     -4
+#define RAMFS_ERR_NOTEMPTY  -5
+#define RAMFS_ERR_NOSPACE   -6
+#define RAMFS_ERR_INVAL     -7
+
+typedef struct {
+    char name[RAMFS_NAME_MAX];
+    int is_dir;
+    int size;
+} ramfs_dirent_t;
+
+void ramfs_init(void);
+void ramfs_resolve(const char *cwd, const char *path, char *out, int outsz);
+
+int ramfs_exists(const char *path);
+int ramfs_is_dir(const char *path);
+int ramfs_is_file(const char *path);
+
+int ramfs_mkdir(const char *path);
+int ramfs_rmdir(const char *path);
+int ramfs_rm(const char *path);
+int ramfs_cp(const char *src, const char *dst);
+int ramfs_mv(const char *src, const char *dst);
+
+const char *ramfs_read(const char *path, int *size);
+int ramfs_write(const char *path, const char *data, int len);
+
+int ramfs_list(const char *path, ramfs_dirent_t *out, int max_n);
+int ramfs_node_count(void);
+
+const char *ramfs_strerror(int err);
+
+#endif

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "ramfs.h"
+#include "procsim.h"
 
 // ==============================================================================
 // STRUCTURES ET DÉFINITIONS
@@ -56,6 +58,8 @@ typedef struct {
     int show_colors;
     int ai_mode;
     int debug_mode;
+    int ai_query_count;
+    int cmd_ticks;
 } shell_context_t;
 
 // ==============================================================================
@@ -197,6 +201,61 @@ void print_error(const char* str) {
     print_string("\n");
 }
 
+static int parse_int(const char* s) {
+    int n = 0;
+    int sign = 1;
+    int i = 0;
+    if (!s || s[0] == '\0') return 0;
+    if (s[0] == '-') { sign = -1; i++; }
+    for (; s[i] != '\0'; i++) {
+        if (s[i] < '0' || s[i] > '9') break;
+        n = n * 10 + (s[i] - '0');
+    }
+    return sign * n;
+}
+
+static void print_int(int n) {
+    char buf[16];
+    int i = 0;
+    unsigned int v;
+    if (n < 0) {
+        putc('-');
+        v = (unsigned int)(-n);
+    } else {
+        v = (unsigned int)n;
+    }
+    if (v == 0) {
+        putc('0');
+        return;
+    }
+    while (v > 0 && i < 15) {
+        buf[i++] = (char)('0' + (v % 10));
+        v /= 10;
+    }
+    while (i--) putc(buf[i]);
+}
+
+static char* find_char(const char* s, char c) {
+    if (!s) return 0;
+    while (*s) {
+        if (*s == c) return (char*)s;
+        s++;
+    }
+    return 0;
+}
+
+static void print_ramfs_err(const char* cmd, int err) {
+    print_colored("[ERROR] ", COLOR_RED);
+    print_string(cmd);
+    print_string(": ");
+    print_string(ramfs_strerror(err));
+    print_string("\n");
+}
+
+static void resolve_arg(shell_context_t* ctx, const char* arg, char* out) {
+    ramfs_resolve(ctx->current_dir, arg ? arg : ".", out, RAMFS_PATH_MAX);
+}
+
 // ==============================================================================
 // GESTION DE L'HISTORIQUE ET DE L'ENVIRONNEMENT
 // ==============================================================================
@@ -211,6 +270,8 @@ void init_shell_context(shell_context_t* ctx) {
     ctx->show_colors = 1;
     ctx->ai_mode = 0;
     ctx->debug_mode = 0;
+    ctx->ai_query_count = 0;
+    ctx->cmd_ticks = 0;
     
     // Initialiser quelques variables d'environnement par défaut
     strcpy(ctx->env_vars[0].name, "PATH");
@@ -221,7 +282,12 @@ void init_shell_context(shell_context_t* ctx) {
     strcpy(ctx->env_vars[2].value, "ai-shell");
     strcpy(ctx->env_vars[3].name, "AI_OS_VERSION");
     strcpy(ctx->env_vars[3].value, "6.0");
-    ctx->env_count = 4;
+    strcpy(ctx->env_vars[4].name, "USER");
+    strcpy(ctx->env_vars[4].value, "root");
+    ctx->env_count = 5;
+
+    ramfs_init();
+    procsim_init();
 }
 
 void add_to_history(shell_context_t* ctx, const char* command) {
@@ -322,7 +388,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     
     print_colored("COMMANDES SYSTÈME :\n", COLOR_YELLOW);
     print_string("  ls [path]          - Lister les fichiers et dossiers\n");
-    print_string("  cat <file>         - Afficher le contenu d'un fichier (stub)\n");
+    print_string("  cat <file>         - Afficher le contenu d'un fichier (VFS RAM)\n");
     print_string("  cd <path>          - Changer de répertoire\n");
     print_string("  pwd                - Afficher le répertoire courant\n");
     print_string("  mkdir <dir>        - Créer un répertoire\n");
@@ -373,61 +439,77 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  reboot             - Redémarrer le système\n");
     print_string("  shutdown           - Arrêter le système\n");
     
-    print_colored("\n💡 TIP: Si le mode IA est activé, vous pouvez poser des questions\n", COLOR_GREEN);
-    print_colored("    directement sans utiliser 'ai'. Ex: 'comment ça marche ?'\n\n", COLOR_GREEN);
+    print_colored("\n💡 TIP: mkdir/rm/cat/grep opèrent sur un VFS RAM (pas un disque).\n", COLOR_GREEN);
+    print_colored("    Si le mode IA est activé, posez des questions sans 'ai'.\n\n", COLOR_GREEN);
 }
 
 void cmd_ls(shell_context_t* ctx, char args[][128], int arg_count) {
-    print_colored("\n=== Fichiers dans l'initrd ===\n", COLOR_CYAN);
-    
-    // Liste des fichiers simulée (sera remplacée par un vrai appel système)
-    const char* files[] = {
-        "test.txt", "hello.txt", "config.cfg", "startup.sh",
-        "ai_data.txt", "ai_knowledge.txt", "shell", "fake_ai",
-        "user_program", "docs/", "bin/", "home/"
-    };
-    
-    print_colored("drwxr-xr-x", COLOR_BLUE);
-    print_string(" 2 root root 4096 Aug 21 04:15 ");
-    print_colored("docs/\n", COLOR_BLUE);
-    
-    print_colored("drwxr-xr-x", COLOR_BLUE);
-    print_string(" 2 root root 4096 Aug 21 04:15 ");
-    print_colored("bin/\n", COLOR_BLUE);
-    
-    print_colored("drwxr-xr-x", COLOR_BLUE);
-    print_string(" 2 root root 4096 Aug 21 04:15 ");
-    print_colored("home/\n", COLOR_BLUE);
-    
-    for (int i = 0; i < 9; i++) {
-        if (strstr(files[i], "/") == NULL) {
-            if (strstr(files[i], ".") != NULL) {
-                print_colored("-rw-r--r--", COLOR_WHITE);
-                print_string(" 1 root root  1024 Aug 21 04:15 ");
-                print_string(files[i]);
-                print_string("\n");
-            } else {
-                print_colored("-rwxr-xr-x", COLOR_GREEN);
-                print_string(" 1 root root  8192 Aug 21 04:15 ");
-                print_colored(files[i], COLOR_GREEN);
-                print_string("\n");
-            }
+    char path[RAMFS_PATH_MAX];
+    ramfs_dirent_t ents[RAMFS_MAX_LIST];
+    int n;
+
+    if (arg_count > 0) resolve_arg(ctx, args[0], path);
+    else resolve_arg(ctx, ".", path);
+
+    print_colored("\n=== VFS RAM ===\n", COLOR_CYAN);
+    print_string("chemin: ");
+    print_string(path);
+    print_string("\n");
+
+    if (ramfs_is_file(path)) {
+        print_string("-rw-r--r--  ");
+        print_string(path);
+        print_string("\n\n");
+        return;
+    }
+
+    n = ramfs_list(path, ents, RAMFS_MAX_LIST);
+    if (n < 0) {
+        print_ramfs_err("ls", n);
+        return;
+    }
+    for (int i = 0; i < n; i++) {
+        if (ents[i].is_dir) {
+            print_colored("drwxr-xr-x  ", COLOR_BLUE);
+            print_colored(ents[i].name, COLOR_BLUE);
+            print_string("/\n");
+        } else {
+            print_string("-rw-r--r--  ");
+            print_int(ents[i].size);
+            print_string("  ");
+            print_string(ents[i].name);
+            print_string("\n");
         }
     }
-    
-    print_string("\nTotal: 12 éléments\n\n");
+    print_string("Total: ");
+    print_int(n);
+    print_string(" elements\n\n");
+}
+
+static void print_proc_row(const procsim_entry_t* p) {
+    print_string("  ");
+    print_int(p->pid);
+    print_string("    ");
+    print_int(p->ppid);
+    print_string("    ");
+    putc(p->state);
+    print_string("    ");
+    print_string(p->name);
+    if (!p->alive) print_string(" (zombie)");
+    print_string("\n");
 }
 
 void cmd_ps(shell_context_t* ctx, char args[][128], int arg_count) {
-    print_colored("\n=== Processus Actifs ===\n", COLOR_CYAN);
-    print_colored("  PID  PPID  CPU%  MEM%   TIME  STAT  COMMAND\n", COLOR_YELLOW);
-    print_string("    0     0   0.1   2.1  00:15     R  [kernel]\n");
-    print_string("    1     0   0.0   1.5  00:01     S  init\n");
-    print_string("    2     1   0.2   3.2  00:03     R  ai-shell\n");
-    print_string("    3     2   0.0   0.8  00:00     S  ai-assistant\n");
-    print_string("    4     1   0.0   0.5  00:00     S  memory-manager\n");
-    print_string("\nTotal: 5 processus actifs\n");
-    print_string("Charge moyenne: 0.15, 0.10, 0.08\n\n");
+    (void)ctx; (void)args; (void)arg_count;
+    print_colored("\n=== Processus (table simulee) ===\n", COLOR_CYAN);
+    print_colored("  PID  PPID  STAT  COMMAND\n", COLOR_YELLOW);
+    for (int i = 0; i < procsim_count(); i++) {
+        const procsim_entry_t* p = procsim_get_by_index(i);
+        if (p) print_proc_row(p);
+    }
+    print_string("Actifs: ");
+    print_int(procsim_alive_count());
+    print_string("\n\n");
 }
 
 void cmd_sysinfo(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -540,6 +622,34 @@ void cmd_env(shell_context_t* ctx, char args[][128], int arg_count) {
 }
 
 void cmd_echo(shell_context_t* ctx, char args[][128], int arg_count) {
+    int redir = -1;
+    for (int i = 0; i < arg_count; i++) {
+        if (strcmp(args[i], ">") == 0) {
+            redir = i;
+            break;
+        }
+    }
+    if (redir >= 0) {
+        char path[RAMFS_PATH_MAX];
+        char buf[RAMFS_CONTENT_MAX];
+        int pos = 0;
+        int rc;
+        if (redir + 1 >= arg_count) {
+            print_error("echo: fichier manquant apres >");
+            return;
+        }
+        for (int i = 0; i < redir; i++) {
+            int j = 0;
+            if (i > 0 && pos < RAMFS_CONTENT_MAX - 2) buf[pos++] = ' ';
+            while (args[i][j] && pos < RAMFS_CONTENT_MAX - 2) buf[pos++] = args[i][j++];
+        }
+        buf[pos++] = '\n';
+        buf[pos] = '\0';
+        resolve_arg(ctx, args[redir + 1], path);
+        rc = ramfs_write(path, buf, pos);
+        if (rc != RAMFS_OK) print_ramfs_err("echo", rc);
+        return;
+    }
     for (int i = 0; i < arg_count; i++) {
         print_string(args[i]);
         if (i < arg_count - 1) print_string(" ");
@@ -572,78 +682,554 @@ static void cmd_pwd(shell_context_t* ctx) {
     print_string("\n");
 }
 
-static int is_absolute_path(const char* path) {
-    return path && path[0] == '/';
-}
-
-static void normalize_path(char* out, const char* base, const char* add) {
-    // Très simple: si add est absolu, le copier; sinon concaténer base + '/' + add
-    if (is_absolute_path(add)) {
-        strcpy(out, add);
-    } else {
-        strcpy(out, base);
-        int len = strlen(out);
-        if (len > 1 && out[len-1] == '/') out[len-1] = '\0';
-        if (!(len == 1 && out[0] == '/')) strcat(out, "/");
-        strcat(out, add);
-    }
-    // Retirer les doubles slash basiques
-    char tmp[MAX_PATH_LENGTH];
-    int j = 0;
-    for (int i = 0; out[i] != '\0' && j < MAX_PATH_LENGTH-1; i++) {
-        if (out[i] == '/' && out[i+1] == '/') continue;
-        tmp[j++] = out[i];
-    }
-    tmp[j] = '\0';
-    strcpy(out, tmp);
-}
-
 static void cmd_cd(shell_context_t* ctx, char args[][128], int arg_count) {
+    char newdir[RAMFS_PATH_MAX];
     if (arg_count == 0) {
-        // Aller à HOME
         const char* home = get_env_var(ctx, "HOME");
         if (!home) home = "/";
-        strcpy(ctx->current_dir, home);
-        return;
+        ramfs_resolve("/", home, newdir, RAMFS_PATH_MAX);
+    } else {
+        ramfs_resolve(ctx->current_dir, args[0], newdir, RAMFS_PATH_MAX);
     }
-    char newdir[MAX_PATH_LENGTH];
-    normalize_path(newdir, ctx->current_dir, args[0]);
-    // Pas de FS réel: accepter tout chemin "raisonnable"
-    if (strlen(newdir) == 0) {
-        print_error("cd: chemin invalide");
+    if (!ramfs_is_dir(newdir)) {
+        print_error("cd: repertoire introuvable");
         return;
     }
     strcpy(ctx->current_dir, newdir);
 }
 
 static void cmd_cat(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    const char* data;
+    int size = 0;
     if (arg_count == 0) {
         print_error("cat: fichier manquant");
         return;
     }
-    // Pas d'accès FS direct en userspace: placeholder
-    print_error("cat: non disponible en userspace (pas d'API FS) ");
+    resolve_arg(ctx, args[0], path);
+    if (ramfs_is_dir(path)) {
+        print_error("cat: est un repertoire");
+        return;
+    }
+    data = ramfs_read(path, &size);
+    if (!data) {
+        print_error("cat: fichier introuvable");
+        return;
+    }
+    for (int i = 0; i < size; i++) putc(data[i]);
+    if (size == 0 || data[size - 1] != '\n') print_string("\n");
 }
 
 static int is_builtin(const char* cmd) {
-    return strcmp(cmd, "help")==0 || strcmp(cmd, "ls")==0 || strcmp(cmd, "dir")==0 ||
-           strcmp(cmd, "ps")==0 || strcmp(cmd, "sysinfo")==0 || strcmp(cmd, "info")==0 ||
-           strcmp(cmd, "mem")==0 || strcmp(cmd, "memory")==0 || strcmp(cmd, "history")==0 ||
-           strcmp(cmd, "env")==0 || strcmp(cmd, "echo")==0 || strcmp(cmd, "clear")==0 ||
-           strcmp(cmd, "cls")==0 || strcmp(cmd, "exit")==0 || strcmp(cmd, "quit")==0 ||
-           strcmp(cmd, "ai")==0 || strcmp(cmd, "ai-mode")==0 || strcmp(cmd, "ai-help")==0 ||
-           strcmp(cmd, "cd")==0 || strcmp(cmd, "pwd")==0 || strcmp(cmd, "cat")==0;
+    static const char* names[] = {
+        "help", "ls", "dir", "ps", "sysinfo", "info", "mem", "memory",
+        "history", "env", "echo", "clear", "cls", "exit", "quit",
+        "ai", "ai-mode", "ai-help", "ai-test", "ai-stats",
+        "cd", "pwd", "cat", "mkdir", "rmdir", "cp", "mv", "rm",
+        "kill", "jobs", "top", "uptime", "date", "whoami",
+        "alias", "unalias", "export", "which",
+        "grep", "wc", "sort", "head", "tail",
+        "logout", "reboot", "shutdown",
+        0
+    };
+    for (int i = 0; names[i]; i++) {
+        if (strcmp(cmd, names[i]) == 0) return 1;
+    }
+    return 0;
 }
 
 static void cmd_which(shell_context_t* ctx, const char* cmd) {
+    (void)ctx;
     if (is_builtin(cmd)) {
         print_string("builtin\n");
         return;
     }
-    // Sans API FS: indiquer l'emplacement probable
     print_string("bin/");
     print_string(cmd);
-    print_string(" (non vérifié)\n");
+    print_string(" (non verifie)\n");
+}
+
+static void cmd_mkdir(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    int rc;
+    if (arg_count == 0) {
+        print_error("mkdir: repertoire manquant");
+        return;
+    }
+    resolve_arg(ctx, args[0], path);
+    rc = ramfs_mkdir(path);
+    if (rc != RAMFS_OK) print_ramfs_err("mkdir", rc);
+    else print_success(path);
+}
+
+static void cmd_rmdir(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    int rc;
+    if (arg_count == 0) {
+        print_error("rmdir: repertoire manquant");
+        return;
+    }
+    resolve_arg(ctx, args[0], path);
+    rc = ramfs_rmdir(path);
+    if (rc != RAMFS_OK) print_ramfs_err("rmdir", rc);
+}
+
+static void cmd_rm(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    int rc;
+    if (arg_count == 0) {
+        print_error("rm: fichier manquant");
+        return;
+    }
+    resolve_arg(ctx, args[0], path);
+    rc = ramfs_rm(path);
+    if (rc != RAMFS_OK) print_ramfs_err("rm", rc);
+}
+
+static void cmd_cp(shell_context_t* ctx, char args[][128], int arg_count) {
+    char src[RAMFS_PATH_MAX];
+    char dst[RAMFS_PATH_MAX];
+    int rc;
+    if (arg_count < 2) {
+        print_error("cp: usage cp <src> <dest>");
+        return;
+    }
+    resolve_arg(ctx, args[0], src);
+    resolve_arg(ctx, args[1], dst);
+    rc = ramfs_cp(src, dst);
+    if (rc != RAMFS_OK) print_ramfs_err("cp", rc);
+}
+
+static void cmd_mv(shell_context_t* ctx, char args[][128], int arg_count) {
+    char src[RAMFS_PATH_MAX];
+    char dst[RAMFS_PATH_MAX];
+    int rc;
+    if (arg_count < 2) {
+        print_error("mv: usage mv <src> <dest>");
+        return;
+    }
+    resolve_arg(ctx, args[0], src);
+    resolve_arg(ctx, args[1], dst);
+    rc = ramfs_mv(src, dst);
+    if (rc != RAMFS_OK) print_ramfs_err("mv", rc);
+}
+
+static void cmd_kill(shell_context_t* ctx, char args[][128], int arg_count) {
+    int pid;
+    int rc;
+    (void)ctx;
+    if (arg_count == 0) {
+        print_error("kill: pid manquant");
+        return;
+    }
+    pid = parse_int(args[0]);
+    rc = procsim_kill(pid);
+    if (rc == -2) print_error("kill: processus protege (kernel/init)");
+    else if (rc != 0) print_error("kill: pid introuvable");
+    else {
+        print_string("Processus ");
+        print_int(pid);
+        print_string(" termine (simule)\n");
+    }
+}
+
+static void cmd_jobs(shell_context_t* ctx, char args[][128], int arg_count) {
+    int n = 0;
+    (void)ctx; (void)args; (void)arg_count;
+    print_colored("\n=== Jobs (table simulee) ===\n", COLOR_CYAN);
+    for (int i = 0; i < procsim_count(); i++) {
+        const procsim_entry_t* p = procsim_get_by_index(i);
+        if (!p || !p->alive || p->pid < 2) continue;
+        print_string("[");
+        print_int(p->pid);
+        print_string("]  Running  ");
+        print_string(p->name);
+        print_string("\n");
+        n++;
+    }
+    if (n == 0) print_string("Aucun job.\n");
+    print_string("\n");
+}
+
+static void cmd_top(shell_context_t* ctx, char args[][128], int arg_count) {
+    (void)args; (void)arg_count;
+    print_colored("\n=== top (VFS RAM / processus simules) ===\n", COLOR_CYAN);
+    print_string("uptime ticks: ");
+    print_int(ctx->cmd_ticks);
+    print_string("  tasks: ");
+    print_int(procsim_alive_count());
+    print_string("\n");
+    print_colored("  PID  PPID  STAT  CPU  MEM  COMMAND\n", COLOR_YELLOW);
+    for (int i = 0; i < procsim_count(); i++) {
+        const procsim_entry_t* p = procsim_get_by_index(i);
+        if (!p || !p->alive) continue;
+        print_string("  ");
+        print_int(p->pid);
+        print_string("    ");
+        print_int(p->ppid);
+        print_string("    ");
+        putc(p->state);
+        print_string("     ");
+        print_int(p->cpu);
+        print_string("    ");
+        print_int(p->mem);
+        print_string("   ");
+        print_string(p->name);
+        print_string("\n");
+    }
+    print_string("\n");
+}
+
+static void cmd_uptime(shell_context_t* ctx, char args[][128], int arg_count) {
+    int sec = ctx->cmd_ticks;
+    int h, m, s;
+    (void)args; (void)arg_count;
+    if (sec < 0) sec = 0;
+    h = sec / 3600;
+    m = (sec % 3600) / 60;
+    s = sec % 60;
+    print_string("up ");
+    print_int(h);
+    print_string(":");
+    if (m < 10) putc('0');
+    print_int(m);
+    print_string(":");
+    if (s < 10) putc('0');
+    print_int(s);
+    print_string("  (ticks commandes: ");
+    print_int(ctx->cmd_ticks);
+    print_string(")\n");
+}
+
+static void cmd_date(shell_context_t* ctx, char args[][128], int arg_count) {
+    int sec = ctx->cmd_ticks % 86400;
+    int h = 5 + (sec / 3600);
+    int m = (sec % 3600) / 60;
+    int s = sec % 60;
+    (void)args; (void)arg_count;
+    if (h >= 24) h %= 24;
+    print_string("Thu Aug 13 ");
+    if (h < 10) putc('0');
+    print_int(h);
+    print_string(":");
+    if (m < 10) putc('0');
+    print_int(m);
+    print_string(":");
+    if (s < 10) putc('0');
+    print_int(s);
+    print_string(" UTC 2026\n");
+}
+
+static void cmd_whoami(shell_context_t* ctx, char args[][128], int arg_count) {
+    const char* user = get_env_var(ctx, "USER");
+    (void)args; (void)arg_count;
+    print_string(user ? user : "root");
+    print_string("\n");
+}
+
+static void cmd_alias(shell_context_t* ctx, char args[][128], int arg_count) {
+    if (arg_count == 0) {
+        if (ctx->alias_count == 0) {
+            print_string("Aucun alias.\n");
+            return;
+        }
+        for (int i = 0; i < ctx->alias_count; i++) {
+            print_string("alias ");
+            print_string(ctx->aliases[i].alias);
+            print_string("='");
+            print_string(ctx->aliases[i].command);
+            print_string("'\n");
+        }
+        return;
+    }
+    {
+        char name[64];
+        char value[256];
+        char* eq = find_char(args[0], '=');
+        name[0] = 0;
+        value[0] = 0;
+        if (eq) {
+            int nlen = (int)(eq - args[0]);
+            int i;
+            if (nlen <= 0 || nlen >= 63) {
+                print_error("alias: nom invalide");
+                return;
+            }
+            for (i = 0; i < nlen; i++) name[i] = args[0][i];
+            name[nlen] = 0;
+            strcpy(value, eq + 1);
+            for (int a = 1; a < arg_count; a++) {
+                strcat(value, " ");
+                strcat(value, args[a]);
+            }
+        } else if (arg_count >= 2) {
+            strcpy(name, args[0]);
+            strcpy(value, args[1]);
+            for (int a = 2; a < arg_count; a++) {
+                strcat(value, " ");
+                strcat(value, args[a]);
+            }
+        } else {
+            print_error("alias: usage alias nom=commande");
+            return;
+        }
+        for (int i = 0; i < ctx->alias_count; i++) {
+            if (strcmp(ctx->aliases[i].alias, name) == 0) {
+                strcpy(ctx->aliases[i].command, value);
+                return;
+            }
+        }
+        if (ctx->alias_count >= MAX_ENV_VARS) {
+            print_error("alias: table pleine");
+            return;
+        }
+        strcpy(ctx->aliases[ctx->alias_count].alias, name);
+        strcpy(ctx->aliases[ctx->alias_count].command, value);
+        ctx->alias_count++;
+    }
+}
+
+static void cmd_unalias(shell_context_t* ctx, char args[][128], int arg_count) {
+    if (arg_count == 0) {
+        print_error("unalias: nom manquant");
+        return;
+    }
+    for (int i = 0; i < ctx->alias_count; i++) {
+        if (strcmp(ctx->aliases[i].alias, args[0]) == 0) {
+            for (int j = i; j < ctx->alias_count - 1; j++) {
+                ctx->aliases[j] = ctx->aliases[j + 1];
+            }
+            ctx->alias_count--;
+            return;
+        }
+    }
+    print_error("unalias: alias introuvable");
+}
+
+static void cmd_export(shell_context_t* ctx, char args[][128], int arg_count) {
+    if (arg_count == 0) {
+        cmd_env(ctx, args, arg_count);
+        return;
+    }
+    {
+        char* eq = find_char(args[0], '=');
+        if (eq) {
+            char name[64];
+            int nlen = (int)(eq - args[0]);
+            int i;
+            if (nlen <= 0 || nlen >= 63) {
+                print_error("export: nom invalide");
+                return;
+            }
+            for (i = 0; i < nlen; i++) name[i] = args[0][i];
+            name[nlen] = 0;
+            set_env_var(ctx, name, eq + 1);
+        } else if (arg_count >= 2) {
+            set_env_var(ctx, args[0], args[1]);
+        } else {
+            print_error("export: usage export VAR=valeur");
+        }
+    }
+}
+
+static int load_file_lines(shell_context_t* ctx, const char* filearg,
+                           char lines[][128], int max_lines) {
+    char path[RAMFS_PATH_MAX];
+    const char* data;
+    int size = 0;
+    int pos = 0;
+    int n = 0;
+    resolve_arg(ctx, filearg, path);
+    data = ramfs_read(path, &size);
+    if (!data) return -1;
+    while (pos < size && n < max_lines) {
+        int len = 0;
+        while (pos < size && data[pos] != '\n' && len < 127) {
+            lines[n][len++] = data[pos++];
+        }
+        lines[n][len] = 0;
+        if (pos < size && data[pos] == '\n') pos++;
+        n++;
+    }
+    return n;
+}
+
+static void cmd_grep(shell_context_t* ctx, char args[][128], int arg_count) {
+    char lines[32][128];
+    int n;
+    int hits = 0;
+    if (arg_count < 2) {
+        print_error("grep: usage grep <motif> <fichier>");
+        return;
+    }
+    n = load_file_lines(ctx, args[1], lines, 32);
+    if (n < 0) {
+        print_error("grep: fichier introuvable");
+        return;
+    }
+    for (int i = 0; i < n; i++) {
+        if (strstr(lines[i], args[0])) {
+            print_string(lines[i]);
+            print_string("\n");
+            hits++;
+        }
+    }
+    if (hits == 0) {
+        print_string("(aucune correspondance)\n");
+    }
+}
+
+static void cmd_wc(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    const char* data;
+    int size = 0;
+    int lines = 0, words = 0, chars = 0;
+    int in_word = 0;
+    if (arg_count == 0) {
+        print_error("wc: fichier manquant");
+        return;
+    }
+    resolve_arg(ctx, args[0], path);
+    data = ramfs_read(path, &size);
+    if (!data) {
+        print_error("wc: fichier introuvable");
+        return;
+    }
+    chars = size;
+    for (int i = 0; i < size; i++) {
+        char c = data[i];
+        if (c == '\n') lines++;
+        if (c == ' ' || c == '\t' || c == '\n') in_word = 0;
+        else if (!in_word) {
+            in_word = 1;
+            words++;
+        }
+    }
+    print_int(lines);
+    print_string(" ");
+    print_int(words);
+    print_string(" ");
+    print_int(chars);
+    print_string(" ");
+    print_string(path);
+    print_string("\n");
+}
+
+static void cmd_sort(shell_context_t* ctx, char args[][128], int arg_count) {
+    char lines[32][128];
+    int n;
+    if (arg_count == 0) {
+        print_error("sort: fichier manquant");
+        return;
+    }
+    n = load_file_lines(ctx, args[0], lines, 32);
+    if (n < 0) {
+        print_error("sort: fichier introuvable");
+        return;
+    }
+    for (int i = 0; i < n - 1; i++) {
+        for (int j = 0; j < n - 1 - i; j++) {
+            if (strcmp(lines[j], lines[j + 1]) > 0) {
+                char tmp[128];
+                strcpy(tmp, lines[j]);
+                strcpy(lines[j], lines[j + 1]);
+                strcpy(lines[j + 1], tmp);
+            }
+        }
+    }
+    for (int i = 0; i < n; i++) {
+        print_string(lines[i]);
+        print_string("\n");
+    }
+}
+
+static int parse_line_count(char args[][128], int arg_count, int* file_idx) {
+    int n = 10;
+    *file_idx = 0;
+    if (arg_count >= 2 && strcmp(args[0], "-n") == 0) {
+        n = parse_int(args[1]);
+        *file_idx = 2;
+    } else if (arg_count >= 1 && args[0][0] == '-' && args[0][1] >= '0' && args[0][1] <= '9') {
+        n = parse_int(args[0] + 1);
+        *file_idx = 1;
+    }
+    if (n < 0) n = 0;
+    if (n > 32) n = 32;
+    return n;
+}
+
+static void cmd_head(shell_context_t* ctx, char args[][128], int arg_count) {
+    char lines[32][128];
+    int file_idx = 0;
+    int want;
+    int n;
+    if (arg_count == 0) {
+        print_error("head: fichier manquant");
+        return;
+    }
+    want = parse_line_count(args, arg_count, &file_idx);
+    if (file_idx >= arg_count) {
+        print_error("head: fichier manquant");
+        return;
+    }
+    n = load_file_lines(ctx, args[file_idx], lines, 32);
+    if (n < 0) {
+        print_error("head: fichier introuvable");
+        return;
+    }
+    if (want > n) want = n;
+    for (int i = 0; i < want; i++) {
+        print_string(lines[i]);
+        print_string("\n");
+    }
+}
+
+static void cmd_tail(shell_context_t* ctx, char args[][128], int arg_count) {
+    char lines[32][128];
+    int file_idx = 0;
+    int want;
+    int n;
+    int start;
+    if (arg_count == 0) {
+        print_error("tail: fichier manquant");
+        return;
+    }
+    want = parse_line_count(args, arg_count, &file_idx);
+    if (file_idx >= arg_count) {
+        print_error("tail: fichier manquant");
+        return;
+    }
+    n = load_file_lines(ctx, args[file_idx], lines, 32);
+    if (n < 0) {
+        print_error("tail: fichier introuvable");
+        return;
+    }
+    if (want > n) want = n;
+    start = n - want;
+    for (int i = start; i < n; i++) {
+        print_string(lines[i]);
+        print_string("\n");
+    }
+}
+
+static void cmd_ai_stats(shell_context_t* ctx, char args[][128], int arg_count) {
+    (void)args; (void)arg_count;
+    print_colored("\n=== Statistiques IA ===\n", COLOR_CYAN);
+    print_string("Requêtes ai : ");
+    print_int(ctx->ai_query_count);
+    print_string("\nMode IA     : ");
+    print_string(ctx->ai_mode ? "active" : "desactive");
+    print_string("\nMoteur      : simulateur mots-cles (fake_ai)\n\n");
+}
+
+static void cmd_reboot(shell_context_t* ctx, char args[][128], int arg_count) {
+    (void)ctx; (void)args; (void)arg_count;
+    print_warning("reboot: simule (QEMU reste actif, tapez exit pour quitter le shell)");
+}
+
+static void cmd_shutdown(shell_context_t* ctx, char args[][128], int arg_count) {
+    (void)ctx; (void)args; (void)arg_count;
+    print_warning("shutdown: simule (QEMU reste actif, tapez exit pour quitter le shell)");
 }
 
 void cmd_exit(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -707,6 +1293,7 @@ void cmd_ai(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("question: ");
     print_string(full_query);
     print_string("\n");
+    ctx->ai_query_count++;
     call_ai_assistant(ctx, full_query);
 }
 
@@ -834,6 +1421,75 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
     } else if (strcmp(command, "ai-test") == 0) {
         cmd_ai_test(ctx);
         return 1;
+    } else if (strcmp(command, "mkdir") == 0) {
+        cmd_mkdir(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "rmdir") == 0) {
+        cmd_rmdir(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "rm") == 0) {
+        cmd_rm(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "cp") == 0) {
+        cmd_cp(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "mv") == 0) {
+        cmd_mv(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "kill") == 0) {
+        cmd_kill(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "jobs") == 0) {
+        cmd_jobs(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "top") == 0) {
+        cmd_top(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "uptime") == 0) {
+        cmd_uptime(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "date") == 0) {
+        cmd_date(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "whoami") == 0) {
+        cmd_whoami(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "alias") == 0) {
+        cmd_alias(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "unalias") == 0) {
+        cmd_unalias(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "export") == 0) {
+        cmd_export(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "grep") == 0) {
+        cmd_grep(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "wc") == 0) {
+        cmd_wc(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "sort") == 0) {
+        cmd_sort(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "head") == 0) {
+        cmd_head(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "tail") == 0) {
+        cmd_tail(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "ai-stats") == 0) {
+        cmd_ai_stats(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "logout") == 0) {
+        cmd_exit(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "reboot") == 0) {
+        cmd_reboot(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "shutdown") == 0) {
+        cmd_shutdown(ctx, args, arg_count);
+        return 1;
     }
     
     return 0; // Commande non trouvée
@@ -902,6 +1558,27 @@ void handle_line(shell_context_t* ctx, char* input_buffer) {
     // Parser la commande
     if (!parse_command(input_buffer, command, args, &arg_count)) {
         return;
+    }
+
+    ctx->cmd_ticks++;
+
+    // Expansion d'alias (une seule fois)
+    for (int i = 0; i < ctx->alias_count; i++) {
+        if (strcmp(command, ctx->aliases[i].alias) == 0) {
+            char rebuilt[MAX_COMMAND_LENGTH];
+            int pos = 0;
+            const char* ac = ctx->aliases[i].command;
+            int j = 0;
+            while (ac[j] && pos < MAX_COMMAND_LENGTH - 2) rebuilt[pos++] = ac[j++];
+            for (int a = 0; a < arg_count; a++) {
+                if (pos < MAX_COMMAND_LENGTH - 2) rebuilt[pos++] = ' ';
+                j = 0;
+                while (args[a][j] && pos < MAX_COMMAND_LENGTH - 2) rebuilt[pos++] = args[a][j++];
+            }
+            rebuilt[pos] = '\0';
+            parse_command(rebuilt, command, args, &arg_count);
+            break;
+        }
     }
 
     // Exécuter la commande builtin


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Les commandes listées par `help` (`mkdir`, `rmdir`, `cp`, `mv`, `rm`, `kill`, `jobs`, `top`, `uptime`, `date`, `whoami`, `alias`, `unalias`, `export`, `grep`, `wc`, `sort`, `head`, `tail`, `ai-stats`, `logout`, `reboot`, `shutdown`) n’étaient pas gérées par `execute_builtin_command()` : le shell répondait « commande non trouvée ».

## Approche (sans régression noyau)

Pas de nouveau syscall. Tout reste dans le processus shell :

- **VFS RAM** (`userspace/ramfs.c`) : arborescence en mémoire, préremplie comme l’initrd (`test.txt`, `hello.txt`, `bin/`, `home/user/`, …). `ls` / `cat` / `mkdir` / `rm` / `cp` / `mv` / `grep` / `wc` / `sort` / `head` / `tail` s’en servent. `echo texte > fichier` écrit dans ce VFS.
- **Table de processus simulée** (`userspace/procsim.c`) : `ps` / `jobs` / `top` / `kill` (pid 0 et 1 protégés). `kill` ne touche pas le scheduler.
- **Shell** : `alias`/`unalias`/`export`/`whoami`/`uptime`/`date`/`ai-stats`. `reboot`/`shutdown` affichent un message (QEMU n’est pas arrêté).

Ce n’est pas un disque persistant ni l’initrd réel.

## Tests unitaires

`make test-all` : `test_pmm`, `test_syscall`, `test_task`, `test_shell` (25) inchangés, plus `test_ramfs` (10). Aucune régression.

## Captures QEMU GTK (`sendkey` + `screendump`)

Séquence réelle dans le guest : `ls`, `mkdir testdir`, `ls`, `cat hello.txt`, `grep fichier hello.txt`, `wc hello.txt`, `ps`, `kill 3`, `top`, `date`, `whoami`.

[ls VFS RAM](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai-os-ls.png)
[mkdir testdir puis ls](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai-os-mkdir.png)
[cat et grep](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai-os-grep.png)
[ps kill top](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai-os-top.png)
[date whoami](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai-os-whoami.png)
[Fenêtre QEMU GTK](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai-os-gtk-window.png)

Vidéo : `/opt/cursor/artifacts/ai-os-builtins-demo.mp4`

## Fichiers principaux

- `userspace/shell.c`, `userspace/ramfs.c`, `userspace/procsim.c`
- `tests/unit/userspace/test_ramfs.c`
- `docs/ETAT_REEL.md` mis à jour


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

