### PR TITLE
Syscalls noyau : ls/cat (initrd) et ps/kill/mem/uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ make run-gui
 
 ## ⭐ Fonctionnalités Principales
 
-- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. Les commandes de `help` sont branchées (`mkdir`, `rm`, `grep`, `kill`, `top`, …) sur un **VFS RAM** et une table de processus simulée, pas un disque ni le scheduler.
+- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd ; `ps`/`kill`/`mem`/`uptime` interrogent le noyau. `mkdir`/`rm` restent un VFS RAM (pas de disque persistant).
 - **🤖 Simulateur d'IA Intégré** - Réponses préprogrammées par mots-clés (`fake_ai.c`), pas un modèle ML
 - **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
 - **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
-- **💾 Système de Fichiers** - Initrd TAR en RAM uniquement (pas de disque persistant). `ls` du shell est encore une liste figée.
+- **💾 Système de Fichiers** - Initrd TAR en RAM uniquement (pas de disque persistant). `ls` liste l’initrd via `SYS_LISTDIR`.
 - **🧠 Gestion Mémoire** - VMM/PMM avec paging (cible ~128 MB RAM sous QEMU)
 - **🔌 Gestion Interruptions** - PIC, clavier PS/2, timer PIT
 
@@ -177,7 +177,7 @@ ai-os/
 - ✅ **Interruptions clavier (IRQ1) générées par QEMU**
 - ✅ **Fin des boucles infinies** sur appels système
 - ✅ **IA accessible** via interface clavier
-- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `grep`, `kill`, `top`, `ai`, etc. — VFS RAM / table simulée, voir `docs/ETAT_REEL.md`)
+- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `grep`, `kill`, `top`, `ai`, etc. — `ls`/`ps`/`kill`/`mem` via syscalls noyau, `mkdir`/`rm` sur VFS RAM, voir `docs/ETAT_REEL.md`)
 
 ### ✅ Corrections Antérieures
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** branche `cursor/shell-missing-builtins-6f7a` (builtins shell + VFS RAM)  
+**Code de référence :** branche `cursor/kernel-syscalls-fs-ps-6f7a` (syscalls initrd + processus)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -30,7 +30,7 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - Initrd format TAR POSIX (`fs/initrd.c`)
 - Chargeur ELF 32-bit
 - Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
-- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`
+- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO` (ABI : `include/os_syscalls.h`)
 
 ### Espace utilisateur
 
@@ -56,7 +56,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 30/30 |
+| `test_syscall` | 36/36 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
@@ -67,19 +67,19 @@ Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. Ce n’est **pas** un vrai disque ni le scheduler du noyau : fichiers et processus vivent dans le processus shell (`userspace/ramfs.c`, `userspace/procsim.c`).
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `mkdir` / `rm` / `echo >` restent un VFS RAM dans le processus shell (`userspace/ramfs.c`). `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
 | `help` | Aide |
-| `ls` / `dir` | Listing du **VFS RAM** (répertoire courant ou argument) |
-| `mkdir` / `rmdir` / `rm` / `cp` / `mv` | Mutation du VFS RAM |
-| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture du VFS RAM |
+| `ls` / `dir` | Listing **initrd** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
+| `mkdir` / `rmdir` / `rm` / `cp` / `mv` | Mutation du VFS RAM (pas d’écriture initrd) |
+| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture **initrd** (`SYS_READFILE`) puis VFS RAM |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans le VFS RAM |
 | `cd` / `pwd` | Chemin en RAM, `cd` refuse un dossier absent du VFS |
-| `ps` / `jobs` / `top` / `kill` | Table de processus **simulée** (`kill` ne touche pas le noyau ; pid 0/1 protégés) |
-| `sysinfo` / `info` / `mem` / `memory` | Texte fixe (128 MB, etc.) |
-| `uptime` / `date` | Horloge pédagogique (compteur de commandes, pas de RTC) |
+| `ps` / `jobs` / `top` / `kill` | Table des tâches **noyau** (`SYS_PS` / `SYS_KILL`). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`) |
+| `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT |
+| `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) |
 | `whoami` / `env` / `export` | Variables d’environnement du shell (`USER=root` par défaut) |
 | `alias` / `unalias` | Table d’alias, expansion avant exécution |
 | `history` | Historique en mémoire |

--- a/docs/analyse_logique_docs.md
+++ b/docs/analyse_logique_docs.md
@@ -1,6 +1,6 @@
 # Analyse de la Logique du Projet AI-OS
 
-> **État réel (août 2026).** Les étapes 1 à 7 existent dans le code (noyau + shell + simulateur IA). Les syscalls sont au nombre de **8** (dont exec/spawn). Voir [ETAT_REEL.md](ETAT_REEL.md).
+> **État réel (août 2026).** Les étapes 1 à 7 existent dans le code (noyau + shell + simulateur IA). Les syscalls sont au nombre de **15** (dont listdir/readfile, ps/kill, ticks/meminfo). Voir [ETAT_REEL.md](ETAT_REEL.md).
 
 ## Vue d'Ensemble du Projet
 
@@ -26,7 +26,7 @@ AI-OS est un système d'exploitation spécialement conçu pour héberger et exé
 - **Système de tâches** : Multitâche préemptif avec ordonnanceur Round-Robin
 - **Changement de contexte** : Optimisé en assembleur
 - **Séparation Ring 0/3** : Isolation kernel/utilisateur
-- **Appels système** : Interface sécurisée (**8** syscalls : exit, putc, getc, puts, yield, gets, exec, spawn ; le chiffre 5 ci-dessous est l’état à l’étape 5–6 d’origine)
+- **Appels système** : Interface sécurisée (**15** syscalls : exit, putc, getc, puts, yield, gets, exec, spawn, listdir, readfile, getpid, ps, kill, ticks, meminfo ; le chiffre 5 ci-dessous est l’état à l’étape 5–6 d’origine)
 - **Chargeur ELF** : Exécution de programmes externes
 
 ## Logique Technique Détaillée

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -50,8 +50,8 @@
 
 ### Reste ouvert (hors périmètre « shell qui démarre »)
 - [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
-- [ ] `ls` / `ps` / `sysinfo` : remplacer VFS RAM / table simulée par de vrais syscalls noyau
-- [ ] API FS userspace vers l’initrd / un disque (le VFS RAM n’est pas persistant)
+- [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
+- [ ] API FS userspace en écriture vers l’initrd / un disque (le VFS RAM n’est pas persistant)
 - [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
 - [ ] FS persistant, réseau, vrai moteur IA — voir roadmap README / dossier `US/`
 

--- a/fs/initrd.c
+++ b/fs/initrd.c
@@ -288,3 +288,118 @@ void initrd_print_file_info(const char* filename) {
     print_string_serial("\n");
 }
 
+static void ird_copy_name(char* dest, const char* src, int max) {
+    int i = 0;
+    if (!src) src = "";
+    while (src[i] && i < max - 1) {
+        dest[i] = src[i];
+        i++;
+    }
+    dest[i] = '\0';
+}
+
+static void ird_normalize(const char* in, char* out, int max) {
+    if (!in) {
+        out[0] = '\0';
+        return;
+    }
+    if (in[0] == '.' && in[1] == '/') in += 2;
+    while (*in == '/') in++;
+    ird_copy_name(out, in, max);
+    {
+        int n = 0;
+        while (out[n]) n++;
+        while (n > 0 && out[n - 1] == '/') {
+            out[n - 1] = '\0';
+            n--;
+        }
+    }
+}
+
+static const initrd_file_t* ird_find(const char* filename) {
+    char want[256];
+    char have[256];
+    if (!current_initrd || !filename) return 0;
+    ird_normalize(filename, want, 256);
+    for (uint32_t i = 0; i < current_initrd->file_count; i++) {
+        ird_normalize(current_initrd->files[i].name, have, 256);
+        if (strcmp(have, want) == 0) {
+            return &current_initrd->files[i];
+        }
+    }
+    return 0;
+}
+
+int initrd_read_into(const char* path, char* buf, uint32_t max) {
+    const initrd_file_t* f = ird_find(path);
+    uint32_t n;
+    if (!f || !buf || max == 0) return -1;
+    n = f->size;
+    if (n > max) n = max;
+    memcpy(buf, f->data, n);
+    return (int)n;
+}
+
+int initrd_listdir(const char* path, os_dirent_t* out, int max_n) {
+    char prefix[256];
+    int plen;
+    int count = 0;
+    if (!current_initrd || !out || max_n <= 0) return -1;
+    ird_normalize(path ? path : "/", prefix, 256);
+    plen = 0;
+    while (prefix[plen]) plen++;
+
+    for (uint32_t i = 0; i < current_initrd->file_count && count < max_n; i++) {
+        char have[256];
+        const char* rest;
+        ird_normalize(current_initrd->files[i].name, have, 256);
+        if (plen == 0) {
+            rest = have;
+        } else {
+            int j = 0;
+            while (j < plen && have[j] == prefix[j]) j++;
+            if (j != plen || have[j] != '/') continue;
+            rest = have + plen + 1;
+        }
+        if (rest[0] == '\0') continue;
+
+        {
+            int slash = -1;
+            int k = 0;
+            while (rest[k]) {
+                if (rest[k] == '/') {
+                    slash = k;
+                    break;
+                }
+                k++;
+            }
+            if (slash >= 0) {
+                char dname[OS_NAME_MAX];
+                int dup = 0;
+                int nlen = slash;
+                if (nlen >= OS_NAME_MAX) nlen = OS_NAME_MAX - 1;
+                for (int t = 0; t < nlen; t++) dname[t] = rest[t];
+                dname[nlen] = '\0';
+                for (int e = 0; e < count; e++) {
+                    if (out[e].flags == OS_DIRENT_DIR && strcmp(out[e].name, dname) == 0) {
+                        dup = 1;
+                        break;
+                    }
+                }
+                if (!dup) {
+                    ird_copy_name(out[count].name, dname, OS_NAME_MAX);
+                    out[count].size = 0;
+                    out[count].flags = OS_DIRENT_DIR;
+                    count++;
+                }
+            } else {
+                ird_copy_name(out[count].name, rest, OS_NAME_MAX);
+                out[count].size = current_initrd->files[i].size;
+                out[count].flags = OS_DIRENT_FILE;
+                count++;
+            }
+        }
+    }
+    return count;
+}
+

--- a/fs/initrd.h
+++ b/fs/initrd.h
@@ -2,6 +2,7 @@
 #define INITRD_H
 
 #include <stdint.h>
+#include "os_syscalls.h"
 
 // Structure pour un en-tête TAR (format POSIX)
 typedef struct {
@@ -46,6 +47,8 @@ char* initrd_read_file(const char* filename);
 uint32_t initrd_get_file_size(const char* filename);
 int initrd_file_exists(const char* filename);
 uint32_t initrd_get_file_count();
+int initrd_listdir(const char* path, os_dirent_t* out, int max_n);
+int initrd_read_into(const char* path, char* buf, uint32_t max);
 
 // Fonctions utilitaires
 int oct2bin(char *str, int size);

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -1,0 +1,59 @@
+/* os_syscalls.h - ABI Ring 3 / noyau (numéros et structures POD uniquement) */
+
+#ifndef OS_SYSCALLS_H
+#define OS_SYSCALLS_H
+
+#include <stdint.h>
+
+#define SYS_EXIT     0
+#define SYS_PUTC     1
+#define SYS_GETC     2
+#define SYS_PUTS     3
+#define SYS_YIELD    4
+#define SYS_GETS     5
+#define SYS_EXEC     6
+#define SYS_SPAWN    7
+#define SYS_LISTDIR  8
+#define SYS_READFILE 9
+#define SYS_GETPID   10
+#define SYS_PS       11
+#define SYS_KILL     12
+#define SYS_TICKS    13
+#define SYS_MEMINFO  14
+
+#define MAX_SYSCALLS 15
+
+#define OS_NAME_MAX 64
+#define OS_PROC_NAME_MAX 32
+
+#define OS_DIRENT_FILE 0
+#define OS_DIRENT_DIR  1
+
+#define OS_TASK_RUNNING   0
+#define OS_TASK_READY     1
+#define OS_TASK_WAITING   2
+#define OS_TASK_TERMINATED 4
+
+#define OS_TASK_KERNEL 0
+#define OS_TASK_USER   1
+
+typedef struct {
+    char name[OS_NAME_MAX];
+    uint32_t size;
+    uint32_t flags; /* OS_DIRENT_FILE / OS_DIRENT_DIR */
+} os_dirent_t;
+
+typedef struct {
+    int32_t pid;
+    int32_t state;
+    int32_t type;
+    char name[OS_PROC_NAME_MAX];
+} os_proc_t;
+
+typedef struct {
+    uint32_t total_pages;
+    uint32_t used_pages;
+    uint32_t free_pages;
+} os_meminfo_t;
+
+#endif

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -7,6 +7,8 @@
 #include "../../fs/initrd.h"
 #include "../mem/string.h"
 #include "../mem/vmm.h"
+#include "../mem/pmm.h"
+#include "../timer.h"
 // Externs VMM
 extern vmm_directory_t* current_directory;
 extern void vmm_switch_page_directory(uint32_t phys_addr);
@@ -97,6 +99,27 @@ void syscall_handler(cpu_state_t* cpu) {
             print_string_serial("[SPAWN] starting child\n");
             cpu->eax = sys_spawn((const char*)cpu->ebx, (char**)cpu->ecx);
             print_string_serial("[SPAWN] child created\n");
+            break;
+        case SYS_LISTDIR:
+            cpu->eax = (uint32_t)sys_listdir((const char*)cpu->ebx, (os_dirent_t*)cpu->ecx, (int)cpu->edx);
+            break;
+        case SYS_READFILE:
+            cpu->eax = (uint32_t)sys_readfile((const char*)cpu->ebx, (char*)cpu->ecx, cpu->edx);
+            break;
+        case SYS_GETPID:
+            cpu->eax = (uint32_t)sys_getpid();
+            break;
+        case SYS_PS:
+            cpu->eax = (uint32_t)sys_ps((os_proc_t*)cpu->ebx, (int)cpu->ecx);
+            break;
+        case SYS_KILL:
+            cpu->eax = (uint32_t)sys_kill((int)cpu->ebx);
+            break;
+        case SYS_TICKS:
+            cpu->eax = sys_ticks();
+            break;
+        case SYS_MEMINFO:
+            cpu->eax = (uint32_t)sys_meminfo((os_meminfo_t*)cpu->ebx);
             break;
             
         default:
@@ -239,5 +262,41 @@ void sys_gets(char* buffer, uint32_t size) {
     print_string_serial("SYS_GETS: buffer plein, ligne lue: ");
     print_string_serial(buffer);
     print_string_serial("\n");
+}
+
+int sys_listdir(const char* path, os_dirent_t* out, int max_n) {
+    if (!path || !out || max_n <= 0) return -1;
+    return initrd_listdir(path, out, max_n);
+}
+
+int sys_readfile(const char* path, char* buf, uint32_t max) {
+    if (!path || !buf || max == 0) return -1;
+    return initrd_read_into(path, buf, max);
+}
+
+int sys_getpid(void) {
+    if (!current_task) return -1;
+    return current_task->id;
+}
+
+int sys_ps(os_proc_t* out, int max_n) {
+    if (!out || max_n <= 0) return -1;
+    return task_fill_ps(out, max_n);
+}
+
+int sys_kill(int pid) {
+    return task_kill(pid);
+}
+
+uint32_t sys_ticks(void) {
+    return timer_get_ticks();
+}
+
+int sys_meminfo(os_meminfo_t* info) {
+    if (!info) return -1;
+    info->total_pages = pmm_get_total_pages();
+    info->used_pages = pmm_get_used_pages();
+    info->free_pages = pmm_get_free_pages();
+    return 0;
 }
 

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -3,43 +3,33 @@
 
 #include <stdint.h>
 #include "../task/task.h"
+#include "os_syscalls.h"
 
-// Numéros des appels système
-#define SYS_EXIT    0
-#define SYS_PUTC    1
-#define SYS_GETC    2
-#define SYS_PUTS    3
-#define SYS_YIELD   4
-#define SYS_GETS    5  // Nouveau: Lire une ligne depuis le clavier
-#define SYS_EXEC    6  // Nouveau: Exécuter un programme (bloquant)
-#define SYS_SPAWN   7  // Nouveau: Lancer un programme (non-bloquant)
-
-// Nombre total d'appels système
-#define MAX_SYSCALLS 8
-
-// Structure pour passer les paramètres des syscalls
 typedef struct {
     uint32_t eax, ebx, ecx, edx, esi, edi;
 } syscall_params_t;
 
-// Fonctions publiques
 void syscall_init();
 void syscall_handler(cpu_state_t* cpu);
 
-// Fonctions utilitaires pour les syscalls existants
 void sys_exit(uint32_t exit_code);
 void sys_putc(char c);
 char sys_getc();
 void sys_puts(const char* str);
 void sys_yield();
 
-// Nouveaux appels système
 void sys_gets(char* buffer, uint32_t size);
 int sys_exec(const char* path, char* argv[]);
 int sys_spawn(const char* path, char* argv[]);
 
-// Ajoute un caractère au buffer d'entrée global du clavier.
+int sys_listdir(const char* path, os_dirent_t* out, int max_n);
+int sys_readfile(const char* path, char* buf, uint32_t max);
+int sys_getpid(void);
+int sys_ps(os_proc_t* out, int max_n);
+int sys_kill(int pid);
+uint32_t sys_ticks(void);
+int sys_meminfo(os_meminfo_t* info);
+
 void keyboard_add_char_to_buffer(char c);
 
 #endif
-

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -32,6 +32,14 @@ void tasking_init() {
     current_task->state = TASK_RUNNING;
     current_task->type = TASK_TYPE_KERNEL;
     current_task->vmm_dir = kernel_directory;
+    current_task->kernel_stack_p = 0;
+    current_task->name[0] = 'k';
+    current_task->name[1] = 'e';
+    current_task->name[2] = 'r';
+    current_task->name[3] = 'n';
+    current_task->name[4] = 'e';
+    current_task->name[5] = 'l';
+    current_task->name[6] = '\0';
     current_task->next = current_task;
     current_task->prev = current_task;
     task_queue = current_task;
@@ -199,6 +207,21 @@ task_t* create_task_from_initrd_file(const char* filename) {
     new_task->state = TASK_READY;
     new_task->type = TASK_TYPE_USER;
     new_task->vmm_dir = vmm_dir;
+    {
+        int i = 0;
+        const char* n = filename ? filename : "user";
+        const char* base = n;
+        while (*n) {
+            if (*n == '/') base = n + 1;
+            n++;
+        }
+        if (!base[0]) base = "user";
+        while (base[i] && i < 31) {
+            new_task->name[i] = base[i];
+            i++;
+        }
+        new_task->name[i] = '\0';
+    }
 
     // Allouer une pile noyau pour cette tâche
     new_task->kernel_stack_p = (uint32_t)kmalloc(4096) + 4096;
@@ -319,4 +342,72 @@ task_t* find_task_waiting_for_input() {
     } while (temp != task_queue);
 
     return NULL;
+}
+
+task_t* get_task_by_id(int id) {
+    task_t* t;
+    if (!task_queue) return NULL;
+    t = task_queue;
+    do {
+        if (t->id == id) return t;
+        t = t->next;
+    } while (t && t != task_queue);
+    return NULL;
+}
+
+int get_task_count(void) {
+    int n = 0;
+    task_t* t;
+    if (!task_queue) return 0;
+    t = task_queue;
+    do {
+        n++;
+        t = t->next;
+    } while (t && t != task_queue);
+    return n;
+}
+
+int task_kill(int pid) {
+    task_t* t;
+    if (pid == 0) return -2;
+    t = get_task_by_id(pid);
+    if (!t) return -1;
+    if (current_task && t->id == current_task->id) return -3;
+    t->state = TASK_TERMINATED;
+    unlink_task(t);
+    return 0;
+}
+
+static int32_t map_task_state(task_state_t s) {
+    if (s == TASK_RUNNING) return OS_TASK_RUNNING;
+    if (s == TASK_READY) return OS_TASK_READY;
+    if (s == TASK_TERMINATED) return OS_TASK_TERMINATED;
+    return OS_TASK_WAITING;
+}
+
+int task_fill_ps(os_proc_t* out, int max_n) {
+    int count = 0;
+    task_t* t;
+    if (!out || max_n <= 0 || !task_queue) return 0;
+    t = task_queue;
+    do {
+        int i;
+        if (count >= max_n) break;
+        out[count].pid = t->id;
+        out[count].state = map_task_state(t->state);
+        out[count].type = (t->type == TASK_TYPE_USER) ? OS_TASK_USER : OS_TASK_KERNEL;
+        i = 0;
+        while (t->name[i] && i < OS_PROC_NAME_MAX - 1) {
+            out[count].name[i] = t->name[i];
+            i++;
+        }
+        out[count].name[i] = '\0';
+        if (out[count].name[0] == '\0') {
+            out[count].name[0] = '?';
+            out[count].name[1] = '\0';
+        }
+        count++;
+        t = t->next;
+    } while (t && t != task_queue);
+    return count;
 }

--- a/kernel/task/task.h
+++ b/kernel/task/task.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "kernel/mem/vmm.h" // Inclure pour vmm_directory_t
+#include "os_syscalls.h"
 
 // États possibles d'une tâche
 typedef enum {
@@ -40,6 +41,7 @@ typedef struct task {
     task_type_t type;          // Type de tâche (kernel/user)
     vmm_directory_t* vmm_dir;  // Répertoire de pages de la tâche
     uint32_t kernel_stack_p;   // Pointeur vers le sommet de la pile noyau
+    char name[32];
     struct task* next;         // Pour la liste chaînée de tâches
     struct task* prev;         // Liste doublement chaînée
 } task_t;
@@ -66,6 +68,8 @@ void remove_task(task_t* task);
 void add_task_to_queue(task_t* task);
 int get_task_count();
 task_t* find_task_waiting_for_input();
+int task_kill(int pid);
+int task_fill_ps(os_proc_t* out, int max_n);
 
 #endif
 

--- a/tests/framework/kernel_mocks.c
+++ b/tests/framework/kernel_mocks.c
@@ -102,6 +102,39 @@ int get_task_count(void) {
     return count;
 }
 
+int task_kill(int pid) {
+    task_t* t;
+    if (pid == 0) return -2;
+    t = get_task_by_id(pid);
+    if (!t) return -1;
+    if (current_task && t->id == current_task->id) return -3;
+    t->state = TASK_TERMINATED;
+    remove_task(t);
+    return 0;
+}
+
+int task_fill_ps(os_proc_t* out, int max_n) {
+    int count = 0;
+    task_t* t = task_queue;
+    if (!out || max_n <= 0) return 0;
+    while (t && count < max_n) {
+        int i = 0;
+        out[count].pid = t->id;
+        out[count].state = (t->state == TASK_RUNNING) ? OS_TASK_RUNNING :
+                           (t->state == TASK_READY) ? OS_TASK_READY :
+                           (t->state == TASK_TERMINATED) ? OS_TASK_TERMINATED : OS_TASK_WAITING;
+        out[count].type = (t->type == TASK_TYPE_USER) ? OS_TASK_USER : OS_TASK_KERNEL;
+        while (t->name[i] && i < OS_PROC_NAME_MAX - 1) {
+            out[count].name[i] = t->name[i];
+            i++;
+        }
+        out[count].name[i] = '\0';
+        count++;
+        t = t->next;
+    }
+    return count;
+}
+
 void schedule(cpu_state_t* cpu) {
     mock_task_switch_called++;
     if (!current_task || !task_queue) return;
@@ -187,10 +220,100 @@ void sys_gets(char* buffer, uint32_t size) {
 }
 
 int sys_exec(const char* path, char* argv[]) {
-    // Mock simple - retourne toujours une erreur
     (void)path;
     (void)argv;
     return -1;
+}
+
+static struct {
+    const char* name;
+    const char* data;
+    uint32_t size;
+} mock_initrd[] = {
+    {"hello.txt", "hello from initrd\n", 18},
+    {"bin/shell", "ELF", 3},
+};
+
+int sys_listdir(const char* path, os_dirent_t* out, int max_n) {
+    int count = 0;
+    const char* p = path ? path : "/";
+    if (!out || max_n <= 0) return -1;
+    if (p[0] == '/') p++;
+    if (p[0] == '\0' || (p[0] == '.' && p[1] == '\0')) {
+        int has_bin = 0;
+        for (unsigned i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]) && count < max_n; i++) {
+            const char* n = mock_initrd[i].name;
+            const char* slash = 0;
+            const char* s = n;
+            while (*s) {
+                if (*s == '/') slash = s;
+                s++;
+            }
+            if (slash) {
+                if (!has_bin && count < max_n) {
+                    out[count].name[0] = 'b';
+                    out[count].name[1] = 'i';
+                    out[count].name[2] = 'n';
+                    out[count].name[3] = '\0';
+                    out[count].size = 0;
+                    out[count].flags = OS_DIRENT_DIR;
+                    count++;
+                    has_bin = 1;
+                }
+            } else {
+                int k = 0;
+                while (n[k] && k < OS_NAME_MAX - 1) {
+                    out[count].name[k] = n[k];
+                    k++;
+                }
+                out[count].name[k] = '\0';
+                out[count].size = mock_initrd[i].size;
+                out[count].flags = OS_DIRENT_FILE;
+                count++;
+            }
+        }
+        return count;
+    }
+    return 0;
+}
+
+int sys_readfile(const char* path, char* buf, uint32_t max) {
+    const char* p = path ? path : "";
+    if (!buf || max == 0) return -1;
+    if (p[0] == '/') p++;
+    for (unsigned i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]); i++) {
+        if (strcmp(p, mock_initrd[i].name) == 0) {
+            uint32_t n = mock_initrd[i].size;
+            if (n > max) n = max;
+            memcpy(buf, mock_initrd[i].data, n);
+            return (int)n;
+        }
+    }
+    return -1;
+}
+
+int sys_getpid(void) {
+    return current_task ? current_task->id : 0;
+}
+
+int sys_ps(os_proc_t* out, int max_n) {
+    return task_fill_ps(out, max_n);
+}
+
+int sys_kill(int pid) {
+    return task_kill(pid);
+}
+
+uint32_t sys_ticks(void) {
+    return 42;
+}
+
+int sys_meminfo(os_meminfo_t* info) {
+    if (!info) return -1;
+    info->total_pages = 32768;
+    info->used_pages = 100;
+    info->free_pages = 32668;
+    return 0;
 }
 
 void sys_puts(const char* str) {
@@ -235,6 +358,27 @@ void syscall_handler(cpu_state_t* state) {
             break;
         case SYS_YIELD:
             sys_yield();
+            break;
+        case SYS_LISTDIR:
+            state->eax = (uint32_t)sys_listdir((const char*)state->ebx, (os_dirent_t*)state->ecx, (int)state->edx);
+            break;
+        case SYS_READFILE:
+            state->eax = (uint32_t)sys_readfile((const char*)state->ebx, (char*)state->ecx, state->edx);
+            break;
+        case SYS_GETPID:
+            state->eax = (uint32_t)sys_getpid();
+            break;
+        case SYS_PS:
+            state->eax = (uint32_t)sys_ps((os_proc_t*)state->ebx, (int)state->ecx);
+            break;
+        case SYS_KILL:
+            state->eax = (uint32_t)sys_kill((int)state->ebx);
+            break;
+        case SYS_TICKS:
+            state->eax = sys_ticks();
+            break;
+        case SYS_MEMINFO:
+            state->eax = (uint32_t)sys_meminfo((os_meminfo_t*)state->ebx);
             break;
         default:
             break;

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -468,6 +468,139 @@ void test_syscall_privilege_escalation_prevention(void) {
     TEST_ASSERT_TRUE(1); // Test passe si pas de crash
 }
 
+void test_sys_getpid_and_ticks(void) {
+    test_task_t* task = test_create_task(dummy_task_function, "shell", 1);
+    current_task = (task_t*)task;
+    current_task->id = 2;
+
+    cpu_state_t cpu = {0};
+    cpu.eax = SYS_GETPID;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(2, (int)cpu.eax);
+
+    cpu.eax = SYS_TICKS;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(42, (int)cpu.eax);
+
+    test_destroy_task(task);
+}
+
+void test_sys_readfile_and_listdir(void) {
+    char buf[64];
+    os_dirent_t ents[8];
+    cpu_state_t cpu = {0};
+    int n;
+    int found_hello = 0;
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"hello.txt";
+    cpu.ecx = (uint32_t)buf;
+    cpu.edx = sizeof(buf);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(18, (int)cpu.eax);
+    buf[18] = '\0';
+    TEST_ASSERT_EQUAL_STRING("hello from initrd\n", buf);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"/";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 8;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    TEST_ASSERT(n > 0);
+    for (int i = 0; i < n; i++) {
+        if (ents[i].name[0] == 'h') found_hello = 1;
+    }
+    TEST_ASSERT(found_hello);
+}
+
+void test_sys_kill_protects_kernel(void) {
+    cpu_state_t cpu = {0};
+    cpu.eax = SYS_KILL;
+    cpu.ebx = 0;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(-2, (int)cpu.eax);
+}
+
+void test_sys_meminfo(void) {
+    os_meminfo_t info;
+    cpu_state_t cpu = {0};
+    cpu.eax = SYS_MEMINFO;
+    cpu.ebx = (uint32_t)&info;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(32768, (int)info.total_pages);
+    TEST_ASSERT(info.free_pages > 0);
+}
+
+void test_sys_ps_lists_task(void) {
+    task_t* old_queue = task_queue;
+    task_t* old_current = current_task;
+    task_t* t;
+    os_proc_t procs[8];
+    cpu_state_t cpu = {0};
+    int n;
+    int found = 0;
+
+    task_queue = NULL;
+    current_task = NULL;
+    t = create_task(dummy_task_function);
+    TEST_ASSERT_NOT_NULL(t);
+    t->id = 3;
+    t->type = TASK_TYPE_USER;
+    t->name[0] = 's';
+    t->name[1] = 'h';
+    t->name[2] = 'e';
+    t->name[3] = 'l';
+    t->name[4] = 'l';
+    t->name[5] = '\0';
+    add_task_to_queue(t);
+    current_task = t;
+
+    cpu.eax = SYS_PS;
+    cpu.ebx = (uint32_t)procs;
+    cpu.ecx = 8;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    TEST_ASSERT(n >= 1);
+    for (int i = 0; i < n; i++) {
+        if (procs[i].pid == 3) {
+            found = 1;
+            TEST_ASSERT_EQUAL_STRING("shell", procs[i].name);
+        }
+    }
+    TEST_ASSERT(found);
+
+    task_queue = old_queue;
+    current_task = old_current;
+}
+
+    cpu.eax = SYS_PS;
+    cpu.ebx = (uint32_t)procs;
+    cpu.ecx = 8;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    TEST_ASSERT(n >= 1);
+    for (int i = 0; i < n; i++) {
+        if (procs[i].pid == 3) {
+            found = 1;
+            TEST_ASSERT_EQUAL_STRING("shell", procs[i].name);
+        }
+    }
+    TEST_ASSERT(found);
+
+    task_queue = old_queue;
+    current_task = old_current;
+}
+
+void test_sys_kill_unknown_pid(void) {
+    cpu_state_t cpu = {0};
+    cpu.eax = SYS_KILL;
+    cpu.ebx = 9999;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(-1, (int)cpu.eax);
+}
+
 // === RUNNER PRINCIPAL ===
 
 int main(void) {
@@ -516,6 +649,12 @@ int main(void) {
     // Tests de sécurité
     RUN_TEST(test_syscall_ring_isolation);
     RUN_TEST(test_syscall_privilege_escalation_prevention);
+    RUN_TEST(test_sys_getpid_and_ticks);
+    RUN_TEST(test_sys_readfile_and_listdir);
+    RUN_TEST(test_sys_kill_protects_kernel);
+    RUN_TEST(test_sys_meminfo);
+    RUN_TEST(test_sys_ps_lists_task);
+    RUN_TEST(test_sys_kill_unknown_pid);
     
     unity_print_results();
     unity_cleanup();

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -575,24 +575,6 @@ void test_sys_ps_lists_task(void) {
     current_task = old_current;
 }
 
-    cpu.eax = SYS_PS;
-    cpu.ebx = (uint32_t)procs;
-    cpu.ecx = 8;
-    syscall_handler(&cpu);
-    n = (int)cpu.eax;
-    TEST_ASSERT(n >= 1);
-    for (int i = 0; i < n; i++) {
-        if (procs[i].pid == 3) {
-            found = 1;
-            TEST_ASSERT_EQUAL_STRING("shell", procs[i].name);
-        }
-    }
-    TEST_ASSERT(found);
-
-    task_queue = old_queue;
-    current_task = old_current;
-}
-
 void test_sys_kill_unknown_pid(void) {
     cpu_state_t cpu = {0};
     cpu.eax = SYS_KILL;

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include "ramfs.h"
 #include "procsim.h"
+#include "os_syscalls.h"
 
 // ==============================================================================
 // STRUCTURES ET DÉFINITIONS
@@ -99,6 +100,48 @@ int spawn(const char* path, char* argv[]) {
 
 void yield() {
     asm volatile("int $0x80" : : "a"(4));
+}
+
+int sys_listdir(const char* path, os_dirent_t* out, int max_n) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_LISTDIR), "b"(path), "c"(out), "d"(max_n));
+    return result;
+}
+
+int sys_readfile(const char* path, char* buf, int max) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_READFILE), "b"(path), "c"(buf), "d"(max));
+    return result;
+}
+
+int sys_getpid(void) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_GETPID));
+    return result;
+}
+
+int sys_ps(os_proc_t* out, int max_n) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_PS), "b"(out), "c"(max_n));
+    return result;
+}
+
+int sys_kill_pid(int pid) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_KILL), "b"(pid));
+    return result;
+}
+
+unsigned int sys_ticks(void) {
+    unsigned int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_TICKS));
+    return result;
+}
+
+int sys_meminfo(os_meminfo_t* info) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_MEMINFO), "b"(info));
+    return result;
 }
 
 // ==============================================================================
@@ -387,8 +430,8 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_colored("\n=== AI-OS Shell v6.0 - Aide Complète ===\n", COLOR_CYAN);
     
     print_colored("COMMANDES SYSTÈME :\n", COLOR_YELLOW);
-    print_string("  ls [path]          - Lister les fichiers et dossiers\n");
-    print_string("  cat <file>         - Afficher le contenu d'un fichier (VFS RAM)\n");
+    print_string("  ls [path]          - Lister initrd (noyau) + VFS RAM\n");
+    print_string("  cat <file>         - Afficher un fichier (initrd puis VFS RAM)\n");
     print_string("  cd <path>          - Changer de répertoire\n");
     print_string("  pwd                - Afficher le répertoire courant\n");
     print_string("  mkdir <dir>        - Créer un répertoire\n");
@@ -439,76 +482,107 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  reboot             - Redémarrer le système\n");
     print_string("  shutdown           - Arrêter le système\n");
     
-    print_colored("\n💡 TIP: mkdir/rm/cat/grep opèrent sur un VFS RAM (pas un disque).\n", COLOR_GREEN);
+    print_colored("\n💡 TIP: ls/cat lisent l'initrd (noyau). mkdir/rm restent un VFS RAM.\n", COLOR_GREEN);
     print_colored("    Si le mode IA est activé, posez des questions sans 'ai'.\n\n", COLOR_GREEN);
 }
 
 void cmd_ls(shell_context_t* ctx, char args[][128], int arg_count) {
     char path[RAMFS_PATH_MAX];
-    ramfs_dirent_t ents[RAMFS_MAX_LIST];
-    int n;
+    os_dirent_t kents[32];
+    ramfs_dirent_t rents[RAMFS_MAX_LIST];
+    int kn, rn;
+    int shown = 0;
 
     if (arg_count > 0) resolve_arg(ctx, args[0], path);
     else resolve_arg(ctx, ".", path);
 
-    print_colored("\n=== VFS RAM ===\n", COLOR_CYAN);
+    print_colored("\n=== Initrd / VFS ===\n", COLOR_CYAN);
     print_string("chemin: ");
     print_string(path);
     print_string("\n");
 
-    if (ramfs_is_file(path)) {
-        print_string("-rw-r--r--  ");
-        print_string(path);
-        print_string("\n\n");
-        return;
-    }
-
-    n = ramfs_list(path, ents, RAMFS_MAX_LIST);
-    if (n < 0) {
-        print_ramfs_err("ls", n);
-        return;
-    }
-    for (int i = 0; i < n; i++) {
-        if (ents[i].is_dir) {
-            print_colored("drwxr-xr-x  ", COLOR_BLUE);
-            print_colored(ents[i].name, COLOR_BLUE);
-            print_string("/\n");
-        } else {
-            print_string("-rw-r--r--  ");
-            print_int(ents[i].size);
-            print_string("  ");
-            print_string(ents[i].name);
-            print_string("\n");
+    kn = sys_listdir(path, kents, 32);
+    if (kn > 0) {
+        for (int i = 0; i < kn; i++) {
+            if (kents[i].flags == OS_DIRENT_DIR) {
+                print_colored("drwxr-xr-x  ", COLOR_BLUE);
+                print_colored(kents[i].name, COLOR_BLUE);
+                print_string("/\n");
+            } else {
+                print_string("-rw-r--r--  ");
+                print_int((int)kents[i].size);
+                print_string("  ");
+                print_string(kents[i].name);
+                print_string("\n");
+            }
+            shown++;
         }
     }
+
+    rn = ramfs_list(path, rents, RAMFS_MAX_LIST);
+    if (rn > 0) {
+        for (int i = 0; i < rn; i++) {
+            int dup = 0;
+            if (kn > 0) {
+                for (int k = 0; k < kn; k++) {
+                    if (strcmp(rents[i].name, kents[k].name) == 0) {
+                        dup = 1;
+                        break;
+                    }
+                }
+            }
+            if (dup) continue;
+            if (rents[i].is_dir) {
+                print_colored("drwxr-xr-x  ", COLOR_BLUE);
+                print_colored(rents[i].name, COLOR_BLUE);
+                print_string("/\n");
+            } else {
+                print_string("-rw-r--r--  ");
+                print_int(rents[i].size);
+                print_string("  ");
+                print_string(rents[i].name);
+                print_string("\n");
+            }
+            shown++;
+        }
+    }
+
+    if (shown == 0 && kn < 0 && rn < 0) {
+        print_error("ls: repertoire introuvable");
+        return;
+    }
     print_string("Total: ");
-    print_int(n);
+    print_int(shown);
     print_string(" elements\n\n");
 }
 
-static void print_proc_row(const procsim_entry_t* p) {
-    print_string("  ");
-    print_int(p->pid);
-    print_string("    ");
-    print_int(p->ppid);
-    print_string("    ");
-    putc(p->state);
-    print_string("    ");
-    print_string(p->name);
-    if (!p->alive) print_string(" (zombie)");
-    print_string("\n");
+static const char* proc_state_str(int st) {
+    if (st == OS_TASK_RUNNING) return "R";
+    if (st == OS_TASK_READY) return "S";
+    if (st == OS_TASK_TERMINATED) return "Z";
+    return "W";
 }
 
 void cmd_ps(shell_context_t* ctx, char args[][128], int arg_count) {
+    os_proc_t procs[16];
+    int n;
     (void)ctx; (void)args; (void)arg_count;
-    print_colored("\n=== Processus (table simulee) ===\n", COLOR_CYAN);
-    print_colored("  PID  PPID  STAT  COMMAND\n", COLOR_YELLOW);
-    for (int i = 0; i < procsim_count(); i++) {
-        const procsim_entry_t* p = procsim_get_by_index(i);
-        if (p) print_proc_row(p);
+    n = sys_ps(procs, 16);
+    print_colored("\n=== Processus (noyau) ===\n", COLOR_CYAN);
+    print_colored("  PID  STAT  TYPE  COMMAND\n", COLOR_YELLOW);
+    if (n < 0) n = 0;
+    for (int i = 0; i < n; i++) {
+        print_string("  ");
+        print_int(procs[i].pid);
+        print_string("    ");
+        print_string(proc_state_str(procs[i].state));
+        print_string("     ");
+        print_string(procs[i].type == OS_TASK_USER ? "user  " : "kern  ");
+        print_string(procs[i].name);
+        print_string("\n");
     }
-    print_string("Actifs: ");
-    print_int(procsim_alive_count());
+    print_string("Total: ");
+    print_int(n);
     print_string("\n\n");
 }
 
@@ -525,10 +599,26 @@ void cmd_sysinfo(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("Intel compatible x86\n");
     
     print_colored("Mémoire totale : ", COLOR_YELLOW);
-    print_string("128 MB\n");
-    
+    {
+        os_meminfo_t mi;
+        if (sys_meminfo(&mi) == 0) {
+            print_int((int)((mi.total_pages * 4) / 1024));
+            print_string(" MB (PMM)\n");
+        } else {
+            print_string("inconnue\n");
+        }
+    }
+
     print_colored("Mémoire utilisée : ", COLOR_YELLOW);
-    print_string("24 MB (18.7%)\n");
+    {
+        os_meminfo_t mi;
+        if (sys_meminfo(&mi) == 0) {
+            print_int((int)((mi.used_pages * 4) / 1024));
+            print_string(" MB\n");
+        } else {
+            print_string("inconnue\n");
+        }
+    }
     
     print_colored("Noyau : ", COLOR_YELLOW);
     print_string("AI-OS Kernel v6.0 (Multitâche préemptif)\n");
@@ -543,27 +633,29 @@ void cmd_sysinfo(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("PMM, VMM, Multitâche, IA, Ring 0/3\n");
     
     print_colored("Uptime : ", COLOR_YELLOW);
-    print_string("Depuis le démarrage\n\n");
+    {
+        unsigned int ticks = sys_ticks();
+        print_int((int)(ticks / 100));
+        print_string(" s (PIT)\n\n");
+    }
 }
 
 void cmd_mem(shell_context_t* ctx, char args[][128], int arg_count) {
-    print_colored("\n=== Utilisation Mémoire ===\n", COLOR_CYAN);
-    
-    print_colored("Mémoire physique :\n", COLOR_YELLOW);
-    print_string("  Total :      131,072 KB (128 MB)\n");
-    print_string("  Utilisée :    24,576 KB ( 24 MB)\n");
-    print_string("  Libre :      106,496 KB (104 MB)\n");
-    print_string("  Pourcentage :     18.7%\n\n");
-    
-    print_colored("Gestion des pages :\n", COLOR_YELLOW);
-    print_string("  Pages totales :   32,768 pages (4KB chacune)\n");
-    print_string("  Pages allouées :   6,144 pages\n");
-    print_string("  Pages libres :    26,624 pages\n\n");
-    
-    print_colored("Mémoire virtuelle :\n", COLOR_YELLOW);
-    print_string("  Espace kernel :    0x00000000 - 0x3FFFFFFF\n");
-    print_string("  Espace utilisateur : 0x40000000 - 0xFFFFFFFF\n");
-    print_string("  Paging :           Activé\n\n");
+    os_meminfo_t mi;
+    (void)ctx; (void)args; (void)arg_count;
+    print_colored("\n=== Utilisation Mémoire (PMM) ===\n", COLOR_CYAN);
+    if (sys_meminfo(&mi) != 0) {
+        print_error("mem: syscall indisponible");
+        return;
+    }
+    print_colored("Pages physiques :\n", COLOR_YELLOW);
+    print_string("  Total : ");
+    print_int((int)mi.total_pages);
+    print_string("\n  Utilisees : ");
+    print_int((int)mi.used_pages);
+    print_string("\n  Libres : ");
+    print_int((int)mi.free_pages);
+    print_string("\n  Taille page : 4 KB\n\n");
 }
 
 void cmd_history(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -700,13 +792,21 @@ static void cmd_cd(shell_context_t* ctx, char args[][128], int arg_count) {
 
 static void cmd_cat(shell_context_t* ctx, char args[][128], int arg_count) {
     char path[RAMFS_PATH_MAX];
+    char kbuf[1024];
     const char* data;
     int size = 0;
+    int kn;
     if (arg_count == 0) {
         print_error("cat: fichier manquant");
         return;
     }
     resolve_arg(ctx, args[0], path);
+    kn = sys_readfile(path, kbuf, sizeof(kbuf));
+    if (kn >= 0) {
+        for (int i = 0; i < kn; i++) putc(kbuf[i]);
+        if (kn == 0 || kbuf[kn - 1] != '\n') print_string("\n");
+        return;
+    }
     if (ramfs_is_dir(path)) {
         print_error("cat: est un repertoire");
         return;
@@ -823,67 +923,71 @@ static void cmd_kill(shell_context_t* ctx, char args[][128], int arg_count) {
         return;
     }
     pid = parse_int(args[0]);
-    rc = procsim_kill(pid);
-    if (rc == -2) print_error("kill: processus protege (kernel/init)");
+    rc = sys_kill_pid(pid);
+    if (rc == -2) print_error("kill: processus protege (kernel)");
+    else if (rc == -3) print_error("kill: impossible de tuer le shell courant (exit)");
     else if (rc != 0) print_error("kill: pid introuvable");
     else {
         print_string("Processus ");
         print_int(pid);
-        print_string(" termine (simule)\n");
+        print_string(" termine\n");
     }
 }
 
 static void cmd_jobs(shell_context_t* ctx, char args[][128], int arg_count) {
-    int n = 0;
+    os_proc_t procs[16];
+    int n;
+    int shown = 0;
     (void)ctx; (void)args; (void)arg_count;
-    print_colored("\n=== Jobs (table simulee) ===\n", COLOR_CYAN);
-    for (int i = 0; i < procsim_count(); i++) {
-        const procsim_entry_t* p = procsim_get_by_index(i);
-        if (!p || !p->alive || p->pid < 2) continue;
+    n = sys_ps(procs, 16);
+    print_colored("\n=== Jobs ===\n", COLOR_CYAN);
+    for (int i = 0; i < n; i++) {
+        if (procs[i].type != OS_TASK_USER) continue;
         print_string("[");
-        print_int(p->pid);
-        print_string("]  Running  ");
-        print_string(p->name);
+        print_int(procs[i].pid);
+        print_string("]  ");
+        print_string(proc_state_str(procs[i].state));
+        print_string("  ");
+        print_string(procs[i].name);
         print_string("\n");
-        n++;
+        shown++;
     }
-    if (n == 0) print_string("Aucun job.\n");
+    if (shown == 0) print_string("Aucun job utilisateur.\n");
     print_string("\n");
 }
 
 static void cmd_top(shell_context_t* ctx, char args[][128], int arg_count) {
+    os_proc_t procs[16];
+    int n;
     (void)args; (void)arg_count;
-    print_colored("\n=== top (VFS RAM / processus simules) ===\n", COLOR_CYAN);
-    print_string("uptime ticks: ");
-    print_int(ctx->cmd_ticks);
+    n = sys_ps(procs, 16);
+    print_colored("\n=== top (noyau) ===\n", COLOR_CYAN);
+    print_string("ticks: ");
+    print_int((int)sys_ticks());
+    print_string("  pid: ");
+    print_int(sys_getpid());
     print_string("  tasks: ");
-    print_int(procsim_alive_count());
+    print_int(n < 0 ? 0 : n);
     print_string("\n");
-    print_colored("  PID  PPID  STAT  CPU  MEM  COMMAND\n", COLOR_YELLOW);
-    for (int i = 0; i < procsim_count(); i++) {
-        const procsim_entry_t* p = procsim_get_by_index(i);
-        if (!p || !p->alive) continue;
+    print_colored("  PID  STAT  TYPE  COMMAND\n", COLOR_YELLOW);
+    for (int i = 0; i < n; i++) {
         print_string("  ");
-        print_int(p->pid);
+        print_int(procs[i].pid);
         print_string("    ");
-        print_int(p->ppid);
-        print_string("    ");
-        putc(p->state);
+        print_string(proc_state_str(procs[i].state));
         print_string("     ");
-        print_int(p->cpu);
-        print_string("    ");
-        print_int(p->mem);
-        print_string("   ");
-        print_string(p->name);
+        print_string(procs[i].type == OS_TASK_USER ? "user  " : "kern  ");
+        print_string(procs[i].name);
         print_string("\n");
     }
     print_string("\n");
 }
 
 static void cmd_uptime(shell_context_t* ctx, char args[][128], int arg_count) {
-    int sec = ctx->cmd_ticks;
+    unsigned int ticks = sys_ticks();
+    int sec = (int)(ticks / 100);
     int h, m, s;
-    (void)args; (void)arg_count;
+    (void)ctx; (void)args; (void)arg_count;
     if (sec < 0) sec = 0;
     h = sec / 3600;
     m = (sec % 3600) / 60;
@@ -896,17 +1000,18 @@ static void cmd_uptime(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string(":");
     if (s < 10) putc('0');
     print_int(s);
-    print_string("  (ticks commandes: ");
-    print_int(ctx->cmd_ticks);
+    print_string("  (PIT ticks: ");
+    print_int((int)ticks);
     print_string(")\n");
 }
 
 static void cmd_date(shell_context_t* ctx, char args[][128], int arg_count) {
-    int sec = ctx->cmd_ticks % 86400;
+    unsigned int ticks = sys_ticks();
+    int sec = (int)((ticks / 100) % 86400);
     int h = 5 + (sec / 3600);
     int m = (sec % 3600) / 60;
     int s = sec % 60;
-    (void)args; (void)arg_count;
+    (void)ctx; (void)args; (void)arg_count;
     if (h >= 24) h %= 24;
     print_string("Thu Aug 13 ");
     if (h < 10) putc('0');
@@ -1035,13 +1140,21 @@ static void cmd_export(shell_context_t* ctx, char args[][128], int arg_count) {
 static int load_file_lines(shell_context_t* ctx, const char* filearg,
                            char lines[][128], int max_lines) {
     char path[RAMFS_PATH_MAX];
+    char kbuf[1024];
     const char* data;
     int size = 0;
     int pos = 0;
     int n = 0;
+    int kn;
     resolve_arg(ctx, filearg, path);
-    data = ramfs_read(path, &size);
-    if (!data) return -1;
+    kn = sys_readfile(path, kbuf, (int)sizeof(kbuf));
+    if (kn >= 0) {
+        data = kbuf;
+        size = kn;
+    } else {
+        data = ramfs_read(path, &size);
+        if (!data) return -1;
+    }
     while (pos < size && n < max_lines) {
         int len = 0;
         while (pos < size && data[pos] != '\n' && len < 127) {
@@ -1081,19 +1194,27 @@ static void cmd_grep(shell_context_t* ctx, char args[][128], int arg_count) {
 
 static void cmd_wc(shell_context_t* ctx, char args[][128], int arg_count) {
     char path[RAMFS_PATH_MAX];
+    char kbuf[1024];
     const char* data;
     int size = 0;
     int lines = 0, words = 0, chars = 0;
     int in_word = 0;
+    int kn;
     if (arg_count == 0) {
         print_error("wc: fichier manquant");
         return;
     }
     resolve_arg(ctx, args[0], path);
-    data = ramfs_read(path, &size);
-    if (!data) {
-        print_error("wc: fichier introuvable");
-        return;
+    kn = sys_readfile(path, kbuf, (int)sizeof(kbuf));
+    if (kn >= 0) {
+        data = kbuf;
+        size = kn;
+    } else {
+        data = ramfs_read(path, &size);
+        if (!data) {
+            print_error("wc: fichier introuvable");
+            return;
+        }
     }
     chars = size;
     for (int i = 0; i < size; i++) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Les builtins `ls` / `cat` / `ps` / `kill` / `mem` / `uptime` parlaient encore au VFS RAM et à la table `procsim` du processus shell. Ils passent maintenant par de vrais appels système.

## Syscalls ajoutés (`include/os_syscalls.h`)

| Numéro | Nom | Rôle |
|---|---|---|
| 8 | `SYS_LISTDIR` | Listing initrd TAR (dossiers inférés, ex. `bin/` depuis `bin/shell`) |
| 9 | `SYS_READFILE` | Lecture d’un fichier initrd |
| 10 | `SYS_GETPID` | PID de la tâche courante |
| 11 | `SYS_PS` | Table des tâches noyau |
| 12 | `SYS_KILL` | Termine une tâche (pid 0 protégé ; suicide refusé → `exit`) |
| 13 | `SYS_TICKS` | Compteur PIT 100 Hz |
| 14 | `SYS_MEMINFO` | Pages PMM (total / used / free) |

`mkdir` / `rm` / `echo >` restent un VFS RAM : pas d’écriture vers l’initrd.

## Shell

- `ls` : initrd + extras RAM (sans doublons)
- `cat` / `grep` / `wc` / `sort` / `head` / `tail` : initrd d’abord, puis RAM
- `ps` / `jobs` / `top` / `kill` : `task.c`
- `mem` / `sysinfo` / `uptime` : PMM + PIT

## Tests

- `make test-all` : `test_pmm` 17, `test_syscall` **36**, `test_task` 21, `test_shell` 25, `test_ramfs` 10
- `make qemu-smoke` : prompt `(-.-)` OK

## Démo QEMU (`sendkey`)

Séquence réelle : `ls`, `cat hello.txt`, `ps`, `mem`.

- `ls` liste l’initrd (`hello.txt`, `startup.sh`, `bin`, …) plus les dossiers RAM (`docs`, `home`)
- `cat hello.txt` affiche `Un autre fichier de demonstration.`
- `ps` : pid 0 `kernel` (kern) + pid 1 `shell` (user)
- `mem` : pages PMM réelles (ex. total 32895, utilisées 369)

<pre>
=== Initrd / VFS ===
chemin: /
-rw-r--r--  48  startup.sh
drwxr-xr-x  bin/
-rw-r--r--  35  hello.txt
...
=== Processus (noyau) ===
  PID  STAT  TYPE  COMMAND
  0    S     kern  kernel
  1    R     user  shell
=== Utilisation Mémoire (PMM) ===
  Total : 32895
  Utilisees : 369
  Libres : 32526
</pre>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

