### PR TITLE
spawn/kill : tâche idle réelle dans ps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ userspace/shell
 userspace/fake_ai
 userspace/test_program
 userspace/ai_assistant
+userspace/idle
 userspace/*.o
 userspace/*.bin
 

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ pack-initrd: userspace-all
 	@cp -f userspace/fake_ai $(BIN_DEST_DIR)/fake_ai
 	@cp -f userspace/ai_assistant $(BIN_DEST_DIR)/ai_assistant
 	@cp -f userspace/test_program $(BIN_DEST_DIR)/user_program
+	@cp -f userspace/idle $(BIN_DEST_DIR)/idle
 	@tar -C $(INITRD_DIR) -cf $(INITRD_IMAGE) .
 	@echo "[mkinitrd] Packed executables into $(INITRD_IMAGE)"
 
@@ -215,7 +216,7 @@ iso-clean:
 	@rm -rf build/isodir $(ISO_IMAGE)
 
 # Compile tous les programmes utilisateur
-user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant: userspace-all
+user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle: userspace-all
 
 # Cible pour exécuter l'OS dans QEMU avec initrd (mode console corrigé)
 run: $(OS_IMAGE) pack-initrd

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (syscalls initrd + processus ; CI sendkey ls/cat/ps/uptime)  
+**Code de référence :** `master` (syscalls initrd + spawn/kill ; CI sendkey ls/cat/ps/spawn/kill/uptime)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -56,7 +56,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 36/36 |
+| `test_syscall` | 37/37 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
@@ -77,7 +77,7 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture **initrd** (`SYS_READFILE`) puis VFS RAM |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans le VFS RAM |
 | `cd` / `pwd` | Chemin shell ; `cd` accepte un dossier VFS RAM **ou** un préfixe initrd (`cd bin`) |
-| `ps` / `jobs` / `top` / `kill` | Table des tâches **noyau** (`SYS_PS` / `SYS_KILL`). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`) |
+| `ps` / `jobs` / `top` / `kill` / `spawn` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY (pas de changement de contexte). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`) |
 | `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT |
 | `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) |
 | `whoami` / `env` / `export` | Variables d’environnement du shell (`USER=root` par défaut) |
@@ -124,13 +124,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/uptime (initrd + noyau)
+make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/uptime
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps` et `uptime` via `sendkey` et exige les marqueurs initrd/noyau dans le log série.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2` et `uptime` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -180,7 +180,8 @@ int sys_exec(const char* path, char* argv[]) {
     return 0; // Succès
 }
 
-// Non-bloquant: cree la tache et retourne immediatement 0 si ok, -1 sinon
+// Non-bloquant: cree la tache et retourne son pid, -1 sinon.
+// Pas de reschedule : le shell garde le CPU (tache fille en TASK_READY).
 int sys_spawn(const char* path, char* argv[]) {
     task_t* new_task = create_task_from_initrd_file(path);
     if (!new_task) {
@@ -211,10 +212,7 @@ int sys_spawn(const char* path, char* argv[]) {
             new_task->cpu_state.ebx = (uint32_t)(0xB0000000 - 512);
         }
     }
-    // Demander un reschedule immediat pour afficher rapidement la sortie
-    extern volatile int g_reschedule_needed;
-    g_reschedule_needed = 1;
-    return 0;
+    return new_task->id;
 }
 
 

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -164,7 +164,31 @@ void task_exit() {
 }
 
 task_t* create_task_from_initrd_file(const char* filename) {
-    uint8_t* file_data = (uint8_t*)initrd_read_file(filename);
+    uint8_t* file_data;
+    const char* name_src;
+    char alt[256];
+
+    file_data = (uint8_t*)initrd_read_file(filename);
+    name_src = filename;
+    if (!file_data && filename && filename[0] && filename[0] != '/') {
+        int slash = 0;
+        int i = 0;
+        while (filename[i]) {
+            if (filename[i] == '/') slash = 1;
+            i++;
+        }
+        if (!slash) {
+            alt[0] = 'b'; alt[1] = 'i'; alt[2] = 'n'; alt[3] = '/';
+            i = 0;
+            while (filename[i] && i < 250) {
+                alt[4 + i] = filename[i];
+                i++;
+            }
+            alt[4 + i] = '\0';
+            file_data = (uint8_t*)initrd_read_file(alt);
+            if (file_data) name_src = alt;
+        }
+    }
     if (!file_data) {
         print_string_serial("ERREUR: Fichier non trouve dans l'initrd\n");
         return NULL;
@@ -209,7 +233,7 @@ task_t* create_task_from_initrd_file(const char* filename) {
     new_task->vmm_dir = vmm_dir;
     {
         int i = 0;
-        const char* n = filename ? filename : "user";
+        const char* n = name_src ? name_src : "user";
         const char* base = n;
         while (*n) {
             if (*n == '/') base = n + 1;

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -21,7 +21,7 @@ export KERNEL INITRD
 export LOG="${LOG:-test_logs/ci-qemu-serial.log}"
 export PYTHONUNBUFFERED=1
 
-if ! strings userspace/shell | grep -q "Initrd / VFS"; then
+if ! grep -a -qF "Initrd / VFS" userspace/shell; then
     echo "ERROR: userspace/shell is stale (no syscall ls). Expected 'make -C userspace all'."
     file userspace/shell || true
     exit 1

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -42,7 +42,7 @@ def err_text():
         return f.read()
 
 
-def wait_needle(needle, timeout, proc):
+def wait_needle_from(needle, timeout, proc, start):
     t0 = time.time()
     while time.time() - t0 < timeout:
         if proc.poll() is not None:
@@ -50,10 +50,15 @@ def wait_needle(needle, timeout, proc):
                 "QEMU exited early with code %s\nstderr: %s"
                 % (proc.returncode, err_text()[-1500:])
             )
-        if needle in log_text():
-            return
+        text = log_text()
+        if needle in text[start:]:
+            return len(text)
         time.sleep(0.15)
     raise RuntimeError("timeout waiting for %r in serial log" % needle)
+
+
+def wait_needle(needle, timeout, proc):
+    wait_needle_from(needle, timeout, proc, 0)
 
 
 def monitor_connect(retries=50):
@@ -137,7 +142,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/ps/uptime) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/uptime) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -159,12 +164,38 @@ def main():
              "demonstration"),
             ("ls bin", ["l", "s", "spc", "b", "i", "n", "ret"], "fake_ai"),
             ("ps", ["p", "s", "ret"], "Processus (noyau)"),
-            ("uptime", ["u", "p", "t", "i", "m", "e", "ret"], "PIT ticks"),
         ]
         for name, keys, needle in commands:
             say("typing %s ..." % name)
             sendkeys(mon, keys)
             wait_needle(needle, CMD_TIMEOUT, proc)
+
+        say("typing spawn idle ...")
+        mark = len(log_text())
+        sendkeys(mon, ["s", "p", "a", "w", "n", "spc", "i", "d", "l", "e", "ret"])
+        wait_needle_from("spawn ok pid", CMD_TIMEOUT, proc, mark)
+
+        say("typing ps (after spawn) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["p", "s", "ret"])
+        wait_needle_from("user  idle", CMD_TIMEOUT, proc, mark)
+
+        say("typing kill 2 ...")
+        mark = len(log_text())
+        sendkeys(mon, ["k", "i", "l", "l", "spc", "2", "ret"])
+        wait_needle_from("Processus 2 termine", CMD_TIMEOUT, proc, mark)
+
+        say("typing ps (after kill) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["p", "s", "ret"])
+        wait_needle_from("Processus (noyau)", CMD_TIMEOUT, proc, mark)
+        after_kill_ps = log_text()[mark:]
+        if "user  idle" in after_kill_ps:
+            raise RuntimeError("idle still listed in ps after kill 2")
+
+        say("typing uptime ...")
+        sendkeys(mon, ["u", "p", "t", "i", "m", "e", "ret"])
+        wait_needle("PIT ticks", CMD_TIMEOUT, proc)
 
         text = log_text()
         checks = [
@@ -176,6 +207,9 @@ def main():
             ("ps kernel table", "Processus (noyau)"),
             ("ps kernel", "kern"),
             ("ps shell", "shell"),
+            ("spawn idle", "spawn ok pid"),
+            ("ps shows idle", "user  idle"),
+            ("kill 2", "Processus 2 termine"),
             ("uptime", "PIT ticks"),
         ]
         fail = 0

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -583,6 +583,54 @@ void test_sys_kill_unknown_pid(void) {
     TEST_ASSERT_EQUAL(-1, (int)cpu.eax);
 }
 
+void test_sys_kill_removes_ready_task(void) {
+    task_t* old_queue = task_queue;
+    task_t* old_current = current_task;
+    task_t* shell;
+    task_t* child;
+    os_proc_t procs[8];
+    cpu_state_t cpu = {0};
+    int n;
+    int found_child;
+
+    task_queue = NULL;
+    current_task = NULL;
+    shell = create_task(dummy_task_function);
+    child = create_task(dummy_task_function);
+    TEST_ASSERT_NOT_NULL(shell);
+    TEST_ASSERT_NOT_NULL(child);
+    shell->id = 1;
+    child->id = 2;
+    child->type = TASK_TYPE_USER;
+    child->name[0] = 'i';
+    child->name[1] = 'd';
+    child->name[2] = 'l';
+    child->name[3] = 'e';
+    child->name[4] = '\0';
+    add_task_to_queue(shell);
+    add_task_to_queue(child);
+    current_task = shell;
+
+    cpu.eax = SYS_KILL;
+    cpu.ebx = 2;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_PS;
+    cpu.ebx = (uint32_t)procs;
+    cpu.ecx = 8;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    found_child = 0;
+    for (int i = 0; i < n; i++) {
+        if (procs[i].pid == 2) found_child = 1;
+    }
+    TEST_ASSERT_EQUAL(0, found_child);
+
+    task_queue = old_queue;
+    current_task = old_current;
+}
+
 // === RUNNER PRINCIPAL ===
 
 int main(void) {
@@ -637,6 +685,7 @@ int main(void) {
     RUN_TEST(test_sys_meminfo);
     RUN_TEST(test_sys_ps_lists_task);
     RUN_TEST(test_sys_kill_unknown_pid);
+    RUN_TEST(test_sys_kill_removes_ready_task);
     
     unity_print_results();
     unity_cleanup();

--- a/userspace/Makefile
+++ b/userspace/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -nostdlib -Ttext=0x40000000
 ASFLAGS = --32
 
 # Programmes à compiler
-PROGRAMS = shell fake_ai test_program ai_assistant
+PROGRAMS = shell fake_ai test_program ai_assistant idle
 
 all: $(PROGRAMS)
 
@@ -26,6 +26,10 @@ ai_assistant: ai_assistant.o start.o
 
 test_program: test_program.o start.o
 	@echo "Linking test_program..."
+	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
+
+idle: idle.o start.o
+	@echo "Linking idle..."
 	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
 
 %.o: %.c

--- a/userspace/idle.c
+++ b/userspace/idle.c
@@ -1,0 +1,13 @@
+/* idle.c — tâche userspace de fond. Reste en file jusqu'à kill.
+ * Ne pas la lancer via exec (bloquant). spawn ne change pas de contexte :
+ * le shell garde le CPU, idle reste TASK_READY. */
+
+void yield(void) {
+    asm volatile("int $0x80" : : "a"(4));
+}
+
+void main(void) {
+    for (;;) {
+        yield();
+    }
+}

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -442,6 +442,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     
     print_colored("\nCOMMANDES PROCESSUS :\n", COLOR_YELLOW);
     print_string("  ps                 - Afficher les processus\n");
+    print_string("  spawn <prog>       - Lancer un programme en arriere-plan\n");
     print_string("  kill <pid>         - Terminer un processus\n");
     print_string("  jobs               - Afficher les tâches\n");
     print_string("  top                - Moniteur système\n");
@@ -829,7 +830,7 @@ static int is_builtin(const char* cmd) {
         "history", "env", "echo", "clear", "cls", "exit", "quit",
         "ai", "ai-mode", "ai-help", "ai-test", "ai-stats",
         "cd", "pwd", "cat", "mkdir", "rmdir", "cp", "mv", "rm",
-        "kill", "jobs", "top", "uptime", "date", "whoami",
+        "kill", "spawn", "jobs", "top", "uptime", "date", "whoami",
         "alias", "unalias", "export", "which",
         "grep", "wc", "sort", "head", "tail",
         "logout", "reboot", "shutdown",
@@ -935,6 +936,36 @@ static void cmd_kill(shell_context_t* ctx, char args[][128], int arg_count) {
         print_int(pid);
         print_string(" termine\n");
     }
+}
+
+static void cmd_spawn(shell_context_t* ctx, char args[][128], int arg_count) {
+    int pid;
+    (void)ctx;
+    if (arg_count == 0) {
+        print_error("spawn: programme manquant");
+        return;
+    }
+    pid = spawn(args[0], 0);
+    if (pid < 0) {
+        char alt[80];
+        int i = 0;
+        alt[0] = 'b'; alt[1] = 'i'; alt[2] = 'n'; alt[3] = '/';
+        while (args[0][i] && i < 70) {
+            alt[4 + i] = args[0][i];
+            i++;
+        }
+        alt[4 + i] = '\0';
+        pid = spawn(alt, 0);
+    }
+    if (pid < 0) {
+        print_error("spawn: programme introuvable");
+        return;
+    }
+    print_string("spawn ok pid ");
+    print_int(pid);
+    print_string(" ");
+    print_string(args[0]);
+    print_string("\n");
 }
 
 static void cmd_jobs(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -1473,7 +1504,7 @@ static void cmd_ai_test(shell_context_t* ctx) {
     print_colored("\n[AI-TEST] Starting healthcheck...\n", COLOR_CYAN);
     char* argv[2]; argv[0] = "healthcheck"; argv[1] = 0;
     int rc = spawn("bin/ai_assistant", argv);
-    if (rc == 0) {
+    if (rc >= 0) {
         print_string("AI HEALTH: OK\n");
         print_colored("[AI-TEST] OK\n", COLOR_GREEN);
     } else {
@@ -1562,6 +1593,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "kill") == 0) {
         cmd_kill(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "spawn") == 0) {
+        cmd_spawn(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "jobs") == 0) {
         cmd_jobs(ctx, args, arg_count);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`ps` ne montrait que `kernel` + `shell`, donc `kill` n’était pas observable.

## Comportement

- Nouveau programme `idle` (ELF dans `bin/idle`)
- Builtin `spawn <prog>` → `SYS_SPAWN` retourne le **pid**
- **Pas de changement de contexte** : le shell garde le CPU, idle reste `TASK_READY` (évite de coincer `SYS_GETS`)
- `ps` affiche `user  idle` ; `kill 2` l’enlève de la table noyau

## CI

Après `ls` / `cat` / `ps`, le smoke tape :

1. `spawn idle` — `spawn ok pid`
2. `ps` — `user  idle`
3. `kill 2` — `Processus 2 termine`
4. `ps` — idle absent du dernier listing
5. `uptime`

## Tests

`test_syscall` 37/37 (kill d’une tâche READY). `make qemu-smoke` OK en local (~8 s).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

