### PR TITLE
Overlay FS noyau : mkdir/rm visibles par ls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 # Liste des fichiers objets - MISE À JOUR avec tous les nouveaux fichiers
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
-          build/syscall.o build/elf.o build/initrd.o build/interrupts.o \
+          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/interrupts.o \
           build/keyboard.o build/timer.o build/multiboot.o build/kernel.o build/kbd_buffer.o
 
 # Cible par défaut : construire le système complet (noyau + initrd)
@@ -120,6 +120,10 @@ build/syscall.o: kernel/syscall/syscall.c kernel/syscall/syscall.h
 
 # Règles de compilation pour le système de fichiers
 build/initrd.o: fs/initrd.c fs/initrd.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/overlay.o: fs/overlay.c fs/overlay.h fs/initrd.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ make run-gui
 
 ## ⭐ Fonctionnalités Principales
 
-- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd ; `ps`/`kill`/`mem`/`uptime` interrogent le noyau. `mkdir`/`rm` restent un VFS RAM (pas de disque persistant).
+- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd + overlay noyau ; `mkdir`/`rm` mutent l’overlay (pas de disque persistant). `ps`/`kill`/`mem`/`uptime` interrogent le noyau.
 - **🤖 Simulateur d'IA Intégré** - Réponses préprogrammées par mots-clés (`fake_ai.c`), pas un modèle ML
 - **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
 - **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
-- **💾 Système de Fichiers** - Initrd TAR en RAM uniquement (pas de disque persistant). `ls` liste l’initrd via `SYS_LISTDIR`.
+- **💾 Système de Fichiers** - Initrd TAR en lecture seule + overlay RAM (`mkdir`/`rm`). Pas de disque persistant. `ls` fusionne les deux via `SYS_LISTDIR`.
 - **🧠 Gestion Mémoire** - VMM/PMM avec paging (cible ~128 MB RAM sous QEMU)
 - **🔌 Gestion Interruptions** - PIC, clavier PS/2, timer PIT
 
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **93 tests** répartis dans `test_pmm` (17), `test_syscall` (30), `test_task` (21), `test_shell` (25). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **103 tests** répartis dans `test_pmm` (17), `test_syscall` (40), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash
@@ -177,7 +177,7 @@ ai-os/
 - ✅ **Interruptions clavier (IRQ1) générées par QEMU**
 - ✅ **Fin des boucles infinies** sur appels système
 - ✅ **IA accessible** via interface clavier
-- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `grep`, `kill`, `top`, `ai`, etc. — `ls`/`ps`/`kill`/`mem` via syscalls noyau, `mkdir`/`rm` sur VFS RAM, voir `docs/ETAT_REEL.md`)
+- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `grep`, `kill`, `top`, `ai`, etc. — `ls`/`mkdir`/`rm`/`ps`/`kill`/`mem` via syscalls noyau, `cp`/`mv` sur VFS RAM, voir `docs/ETAT_REEL.md`)
 
 ### ✅ Corrections Antérieures
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (syscalls initrd + spawn/kill ; CI sendkey ls/cat/ps/spawn/kill/uptime)  
+**Code de référence :** `master` (overlay FS mkdir/rm + syscalls initrd/spawn/kill ; CI sendkey ls/cat/ps/spawn/kill/mkdir/rmdir/uptime)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -30,7 +30,8 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - Initrd format TAR POSIX (`fs/initrd.c`)
 - Chargeur ELF 32-bit
 - Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
-- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO` (ABI : `include/os_syscalls.h`)
+- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT` (ABI : `include/os_syscalls.h`)
+- Overlay RAM (`fs/overlay.c`) : `mkdir` / `rm` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule
 
 ### Espace utilisateur
 
@@ -56,7 +57,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 37/37 |
+| `test_syscall` | 40/40 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
@@ -67,16 +68,17 @@ Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `mkdir` / `rm` / `echo >` restent un VFS RAM dans le processus shell (`userspace/ramfs.c`). `procsim.c` n’est plus utilisé par `ps`/`kill`.
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `mkdir` / `rmdir` / `rm` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` écrit dans l’overlay noyau. `cp` / `mv` restent un VFS RAM dans le processus shell (`userspace/ramfs.c`). `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
 | `help` | Aide |
-| `ls` / `dir` | Listing **initrd** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
-| `mkdir` / `rmdir` / `rm` / `cp` / `mv` | Mutation du VFS RAM (pas d’écriture initrd) |
-| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture **initrd** (`SYS_READFILE`) puis VFS RAM |
-| `echo` | Affichage ; `echo texte > fichier` écrit dans le VFS RAM |
-| `cd` / `pwd` | Chemin shell ; `cd` accepte un dossier VFS RAM **ou** un préfixe initrd (`cd bin`) |
+| `ls` / `dir` | Listing **initrd + overlay** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
+| `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l’initrd ne peut pas être modifié (`PROTECTED`) |
+| `cp` / `mv` | Mutation du VFS RAM local (pas d’écriture initrd) |
+| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM |
+| `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau |
+| `cd` / `pwd` | Chemin shell ; `cd` accepte un dossier overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`) |
 | `ps` / `jobs` / `top` / `kill` / `spawn` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY (pas de changement de contexte). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`) |
 | `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT |
 | `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) |
@@ -124,13 +126,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/uptime
+make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/rmdir/uptime
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2` et `uptime` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2`, `uptime`, `mkdir mydir` et `rmdir mydir` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,9 +51,10 @@
 ### Reste ouvert (hors périmètre « shell qui démarre »)
 - [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
 - [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
-- [ ] API FS userspace en écriture vers l’initrd / un disque (le VFS RAM n’est pas persistant)
+- [x] Overlay noyau RAM : `mkdir` / `rm` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
+- [ ] FS persistant sur disque (l’overlay RAM n’est pas persisté)
 - [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
-- [ ] FS persistant, réseau, vrai moteur IA — voir roadmap README / dossier `US/`
+- [ ] Réseau, vrai moteur IA — voir roadmap README / dossier `US/`
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)
 - [x] Tests complets du système corrigé (`make test-all` : tests unitaires kernel + shell + ramfs)

--- a/fs/initrd.c
+++ b/fs/initrd.c
@@ -403,3 +403,66 @@ int initrd_listdir(const char* path, os_dirent_t* out, int max_n) {
     return count;
 }
 
+int initrd_is_file(const char* path) {
+    return ird_find(path) != 0;
+}
+
+int initrd_is_dir(const char* path) {
+    char prefix[256];
+    int plen;
+    if (!current_initrd || !path) return 0;
+    ird_normalize(path, prefix, 256);
+    if (!prefix[0]) return 1;
+    plen = 0;
+    while (prefix[plen]) plen++;
+    for (uint32_t i = 0; i < current_initrd->file_count; i++) {
+        char have[256];
+        int j = 0;
+        ird_normalize(current_initrd->files[i].name, have, 256);
+        if (strcmp(have, prefix) == 0) {
+            /* TAR directory entries are not stored as files; a file
+             * with the exact directory name is not a directory. */
+            continue;
+        }
+        while (j < plen && have[j] == prefix[j]) j++;
+        if (j == plen && have[j] == '/') return 1;
+    }
+    return 0;
+}
+
+int initrd_stat(const char* path, os_dirent_t* out) {
+    const initrd_file_t* f;
+    char want[256];
+    const char* base;
+    int i;
+    if (!path || !out) return -1;
+    ird_normalize(path, want, 256);
+    if (!want[0]) {
+        out->name[0] = '/';
+        out->name[1] = '\0';
+        out->size = 0;
+        out->flags = OS_DIRENT_DIR;
+        return 0;
+    }
+    if (initrd_is_dir(want)) {
+        base = want;
+        for (i = 0; want[i]; i++) {
+            if (want[i] == '/') base = want + i + 1;
+        }
+        ird_copy_name(out->name, base, OS_NAME_MAX);
+        out->size = 0;
+        out->flags = OS_DIRENT_DIR;
+        return 0;
+    }
+    f = ird_find(want);
+    if (!f) return -1;
+    base = want;
+    for (i = 0; want[i]; i++) {
+        if (want[i] == '/') base = want + i + 1;
+    }
+    ird_copy_name(out->name, base, OS_NAME_MAX);
+    out->size = f->size;
+    out->flags = OS_DIRENT_FILE;
+    return 0;
+}
+

--- a/fs/initrd.h
+++ b/fs/initrd.h
@@ -49,6 +49,9 @@ int initrd_file_exists(const char* filename);
 uint32_t initrd_get_file_count();
 int initrd_listdir(const char* path, os_dirent_t* out, int max_n);
 int initrd_read_into(const char* path, char* buf, uint32_t max);
+int initrd_is_dir(const char* path);
+int initrd_is_file(const char* path);
+int initrd_stat(const char* path, os_dirent_t* out);
 
 // Fonctions utilitaires
 int oct2bin(char *str, int size);

--- a/fs/overlay.c
+++ b/fs/overlay.c
@@ -1,0 +1,297 @@
+#include "overlay.h"
+#include "initrd.h"
+
+#define OV_MAX_NODES 32
+#define OV_PATH_MAX  64
+#define OV_DATA_MAX  256
+
+typedef struct {
+    int used;
+    int is_dir;
+    char path[OV_PATH_MAX];
+    char data[OV_DATA_MAX];
+    uint32_t size;
+} ov_node_t;
+
+static ov_node_t g_ov[OV_MAX_NODES];
+
+static int ov_len(const char* s) {
+    int n = 0;
+    if (!s) return 0;
+    while (s[n]) n++;
+    return n;
+}
+
+static void ov_copy(char* dest, const char* src, int max) {
+    int i = 0;
+    if (!src) src = "";
+    while (src[i] && i < max - 1) {
+        dest[i] = src[i];
+        i++;
+    }
+    dest[i] = '\0';
+}
+
+static int ov_eq(const char* a, const char* b) {
+    int i = 0;
+    if (!a) a = "";
+    if (!b) b = "";
+    while (a[i] && b[i]) {
+        if (a[i] != b[i]) return 0;
+        i++;
+    }
+    return a[i] == b[i];
+}
+
+static void ov_normalize(const char* in, char* out, int max) {
+    if (!in) {
+        out[0] = '\0';
+        return;
+    }
+    if (in[0] == '.' && in[1] == '/') in += 2;
+    while (*in == '/') in++;
+    ov_copy(out, in, max);
+    {
+        int n = ov_len(out);
+        while (n > 0 && out[n - 1] == '/') {
+            out[n - 1] = '\0';
+            n--;
+        }
+    }
+}
+
+static void ov_parent(const char* path, char* out, int max) {
+    int n = ov_len(path);
+    int slash = -1;
+    int i;
+    for (i = 0; i < n; i++) {
+        if (path[i] == '/') slash = i;
+    }
+    if (slash < 0) {
+        out[0] = '\0';
+        return;
+    }
+    if (slash >= max) slash = max - 1;
+    for (i = 0; i < slash; i++) out[i] = path[i];
+    out[slash] = '\0';
+}
+
+static ov_node_t* ov_find(const char* path) {
+    char want[OV_PATH_MAX];
+    int i;
+    ov_normalize(path, want, OV_PATH_MAX);
+    if (!want[0]) return 0;
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        if (g_ov[i].used && ov_eq(g_ov[i].path, want)) {
+            return &g_ov[i];
+        }
+    }
+    return 0;
+}
+
+static ov_node_t* ov_alloc(void) {
+    int i;
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        if (!g_ov[i].used) return &g_ov[i];
+    }
+    return 0;
+}
+
+static int ov_has_children(const char* path) {
+    char want[OV_PATH_MAX];
+    int plen;
+    int i;
+    ov_normalize(path, want, OV_PATH_MAX);
+    plen = ov_len(want);
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        if (!g_ov[i].used) continue;
+        if (plen == 0) {
+            if (g_ov[i].path[0]) return 1;
+        } else {
+            int j = 0;
+            while (j < plen && g_ov[i].path[j] == want[j]) j++;
+            if (j == plen && g_ov[i].path[j] == '/') return 1;
+        }
+    }
+    return 0;
+}
+
+static int ov_parent_is_dir(const char* path) {
+    char parent[OV_PATH_MAX];
+    ov_parent(path, parent, OV_PATH_MAX);
+    if (!parent[0]) return 1;
+    if (overlay_is_dir(parent)) return 1;
+    if (initrd_is_dir(parent)) return 1;
+    return 0;
+}
+
+static int ov_direct_child(const char* prefix, const char* path, char* name, int nmax) {
+    int plen = ov_len(prefix);
+    const char* rest;
+    int i;
+    if (plen == 0) {
+        rest = path;
+    } else {
+        int j = 0;
+        while (j < plen && path[j] == prefix[j]) j++;
+        if (j != plen || path[j] != '/') return 0;
+        rest = path + plen + 1;
+    }
+    if (!rest[0]) return 0;
+    for (i = 0; rest[i]; i++) {
+        if (rest[i] == '/') return 0;
+    }
+    ov_copy(name, rest, nmax);
+    return 1;
+}
+
+void overlay_init(void) {
+    int i;
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        g_ov[i].used = 0;
+        g_ov[i].path[0] = '\0';
+        g_ov[i].size = 0;
+        g_ov[i].is_dir = 0;
+    }
+}
+
+int overlay_is_dir(const char* path) {
+    ov_node_t* n;
+    char want[OV_PATH_MAX];
+    ov_normalize(path, want, OV_PATH_MAX);
+    if (!want[0]) return 1;
+    n = ov_find(want);
+    return n && n->is_dir;
+}
+
+int overlay_stat(const char* path, os_dirent_t* out) {
+    ov_node_t* n;
+    char want[OV_PATH_MAX];
+    const char* base;
+    int i;
+    ov_normalize(path, want, OV_PATH_MAX);
+    if (!want[0]) {
+        if (out) {
+            out->name[0] = '/';
+            out->name[1] = '\0';
+            out->size = 0;
+            out->flags = OS_DIRENT_DIR;
+        }
+        return OV_OK;
+    }
+    n = ov_find(want);
+    if (!n) return OV_ERR_NOTFOUND;
+    if (out) {
+        base = want;
+        for (i = 0; want[i]; i++) {
+            if (want[i] == '/') base = want + i + 1;
+        }
+        ov_copy(out->name, base, OS_NAME_MAX);
+        out->size = n->is_dir ? 0 : n->size;
+        out->flags = n->is_dir ? OS_DIRENT_DIR : OS_DIRENT_FILE;
+    }
+    return OV_OK;
+}
+
+int overlay_mkdir(const char* path) {
+    ov_node_t* n;
+    char want[OV_PATH_MAX];
+    ov_normalize(path, want, OV_PATH_MAX);
+    if (!want[0]) return OV_ERR_EXISTS;
+    if (ov_find(want)) return OV_ERR_EXISTS;
+    if (initrd_is_file(want)) return OV_ERR_EXISTS;
+    if (!ov_parent_is_dir(want)) return OV_ERR_NOTDIR;
+    n = ov_alloc();
+    if (!n) return OV_ERR_NOSPACE;
+    n->used = 1;
+    n->is_dir = 1;
+    n->size = 0;
+    n->data[0] = '\0';
+    ov_copy(n->path, want, OV_PATH_MAX);
+    return OV_OK;
+}
+
+int overlay_write(const char* path, const char* data, uint32_t n) {
+    ov_node_t* node;
+    char want[OV_PATH_MAX];
+    uint32_t i;
+    ov_normalize(path, want, OV_PATH_MAX);
+    if (!want[0] || !data) return OV_ERR_INVAL;
+    node = ov_find(want);
+    if (node && node->is_dir) return OV_ERR_ISDIR;
+    if (initrd_is_dir(want)) return OV_ERR_ISDIR;
+    if (!node) {
+        if (!ov_parent_is_dir(want)) return OV_ERR_NOTDIR;
+        node = ov_alloc();
+        if (!node) return OV_ERR_NOSPACE;
+        node->used = 1;
+        node->is_dir = 0;
+        ov_copy(node->path, want, OV_PATH_MAX);
+    }
+    if (n > OV_DATA_MAX) n = OV_DATA_MAX;
+    for (i = 0; i < n; i++) node->data[i] = data[i];
+    node->size = n;
+    return (int)n;
+}
+
+int overlay_read(const char* path, char* buf, uint32_t max) {
+    ov_node_t* n;
+    uint32_t i;
+    uint32_t copy;
+    n = ov_find(path);
+    if (!n) return OV_ERR_NOTFOUND;
+    if (n->is_dir) return OV_ERR_ISDIR;
+    if (!buf || max == 0) return OV_ERR_INVAL;
+    copy = n->size;
+    if (copy > max) copy = max;
+    for (i = 0; i < copy; i++) buf[i] = n->data[i];
+    return (int)copy;
+}
+
+int overlay_unlink(const char* path) {
+    ov_node_t* n;
+    char want[OV_PATH_MAX];
+    ov_normalize(path, want, OV_PATH_MAX);
+    if (!want[0]) return OV_ERR_INVAL;
+    n = ov_find(want);
+    if (!n) {
+        if (initrd_is_file(want) || initrd_is_dir(want)) return OV_ERR_PROTECTED;
+        return OV_ERR_NOTFOUND;
+    }
+    if (n->is_dir && ov_has_children(want)) return OV_ERR_NOTEMPTY;
+    n->used = 0;
+    n->path[0] = '\0';
+    n->size = 0;
+    return OV_OK;
+}
+
+int overlay_listdir(const char* path, os_dirent_t* out, int start, int max_n) {
+    char prefix[OV_PATH_MAX];
+    int count = start;
+    int i;
+    if (!out || max_n <= 0) return start < 0 ? 0 : start;
+    if (start < 0) start = 0;
+    count = start;
+    ov_normalize(path ? path : "/", prefix, OV_PATH_MAX);
+    for (i = 0; i < OV_MAX_NODES && count < max_n; i++) {
+        char name[OS_NAME_MAX];
+        int e;
+        int dup = 0;
+        if (!g_ov[i].used) continue;
+        if (!ov_direct_child(prefix, g_ov[i].path, name, OS_NAME_MAX)) continue;
+        for (e = 0; e < count; e++) {
+            if (ov_eq(out[e].name, name)) {
+                out[e].flags = g_ov[i].is_dir ? OS_DIRENT_DIR : OS_DIRENT_FILE;
+                out[e].size = g_ov[i].is_dir ? 0 : g_ov[i].size;
+                dup = 1;
+                break;
+            }
+        }
+        if (dup) continue;
+        ov_copy(out[count].name, name, OS_NAME_MAX);
+        out[count].flags = g_ov[i].is_dir ? OS_DIRENT_DIR : OS_DIRENT_FILE;
+        out[count].size = g_ov[i].is_dir ? 0 : g_ov[i].size;
+        count++;
+    }
+    return count;
+}

--- a/fs/overlay.h
+++ b/fs/overlay.h
@@ -1,0 +1,26 @@
+#ifndef OVERLAY_H
+#define OVERLAY_H
+
+#include <stdint.h>
+#include "os_syscalls.h"
+
+#define OV_OK            0
+#define OV_ERR_NOTFOUND -1
+#define OV_ERR_EXISTS   -2
+#define OV_ERR_NOTDIR   -3
+#define OV_ERR_ISDIR    -4
+#define OV_ERR_NOTEMPTY -5
+#define OV_ERR_NOSPACE  -6
+#define OV_ERR_INVAL    -7
+#define OV_ERR_PROTECTED -8
+
+void overlay_init(void);
+int overlay_mkdir(const char* path);
+int overlay_write(const char* path, const char* data, uint32_t n);
+int overlay_unlink(const char* path);
+int overlay_read(const char* path, char* buf, uint32_t max);
+int overlay_stat(const char* path, os_dirent_t* out);
+int overlay_listdir(const char* path, os_dirent_t* out, int start, int max_n);
+int overlay_is_dir(const char* path);
+
+#endif

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -20,8 +20,12 @@
 #define SYS_KILL     12
 #define SYS_TICKS    13
 #define SYS_MEMINFO  14
+#define SYS_MKDIR    15
+#define SYS_UNLINK   16
+#define SYS_WRITEFILE 17
+#define SYS_STAT     18
 
-#define MAX_SYSCALLS 15
+#define MAX_SYSCALLS 19
 
 #define OS_NAME_MAX 64
 #define OS_PROC_NAME_MAX 32

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -9,6 +9,7 @@
 #include "syscall/syscall.h"
 #include "elf.h"
 #include "../fs/initrd.h"
+#include "../fs/overlay.h"
 #include "keyboard.h"
 #include <stddef.h>
 
@@ -492,6 +493,9 @@ void kmain(uint32_t multiboot_magic, uint32_t multiboot_addr) {
             initrd_init(initrd_location, initrd_size);
         }
     }
+
+    overlay_init();
+    print_string("Overlay FS initialise (mkdir/rm en RAM).\n");
 
     // NOUVEAU: Initialisation du système de tâches
     print_string("Initialisation du systeme de taches...\n");

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -5,6 +5,7 @@
 #include "../keyboard.h"
 #include "../elf.h"
 #include "../../fs/initrd.h"
+#include "../../fs/overlay.h"
 #include "../mem/string.h"
 #include "../mem/vmm.h"
 #include "../mem/pmm.h"
@@ -120,6 +121,18 @@ void syscall_handler(cpu_state_t* cpu) {
             break;
         case SYS_MEMINFO:
             cpu->eax = (uint32_t)sys_meminfo((os_meminfo_t*)cpu->ebx);
+            break;
+        case SYS_MKDIR:
+            cpu->eax = (uint32_t)sys_mkdir((const char*)cpu->ebx);
+            break;
+        case SYS_UNLINK:
+            cpu->eax = (uint32_t)sys_unlink((const char*)cpu->ebx);
+            break;
+        case SYS_WRITEFILE:
+            cpu->eax = (uint32_t)sys_writefile((const char*)cpu->ebx, (const char*)cpu->ecx, cpu->edx);
+            break;
+        case SYS_STAT:
+            cpu->eax = (uint32_t)sys_stat((const char*)cpu->ebx, (os_dirent_t*)cpu->ecx);
             break;
             
         default:
@@ -263,13 +276,42 @@ void sys_gets(char* buffer, uint32_t size) {
 }
 
 int sys_listdir(const char* path, os_dirent_t* out, int max_n) {
+    int n;
     if (!path || !out || max_n <= 0) return -1;
-    return initrd_listdir(path, out, max_n);
+    if (!overlay_is_dir(path) && !initrd_is_dir(path)) return -1;
+    n = initrd_listdir(path, out, max_n);
+    if (n < 0) n = 0;
+    return overlay_listdir(path, out, n, max_n);
 }
 
 int sys_readfile(const char* path, char* buf, uint32_t max) {
+    int n;
     if (!path || !buf || max == 0) return -1;
+    n = overlay_read(path, buf, max);
+    if (n >= 0) return n;
+    if (n == OV_ERR_ISDIR) return n;
     return initrd_read_into(path, buf, max);
+}
+
+int sys_mkdir(const char* path) {
+    if (!path) return -1;
+    return overlay_mkdir(path);
+}
+
+int sys_unlink(const char* path) {
+    if (!path) return -1;
+    return overlay_unlink(path);
+}
+
+int sys_writefile(const char* path, const char* buf, uint32_t n) {
+    if (!path || !buf) return -1;
+    return overlay_write(path, buf, n);
+}
+
+int sys_stat(const char* path, os_dirent_t* out) {
+    if (!path || !out) return -1;
+    if (overlay_stat(path, out) == OV_OK) return 0;
+    return initrd_stat(path, out);
 }
 
 int sys_getpid(void) {

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -29,6 +29,10 @@ int sys_ps(os_proc_t* out, int max_n);
 int sys_kill(int pid);
 uint32_t sys_ticks(void);
 int sys_meminfo(os_meminfo_t* info);
+int sys_mkdir(const char* path);
+int sys_unlink(const char* path);
+int sys_writefile(const char* path, const char* buf, uint32_t n);
+int sys_stat(const char* path, os_dirent_t* out);
 
 void keyboard_add_char_to_buffer(char c);
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,7 +18,7 @@ BUILD_DIR = ../build
 LOG_DIR = ../test_logs
 
 # Fichiers du framework
-FRAMEWORK_SOURCES = $(FRAMEWORK_DIR)/unity.c $(FRAMEWORK_DIR)/test_kernel.c $(FRAMEWORK_DIR)/kernel_mocks.c
+FRAMEWORK_SOURCES = $(FRAMEWORK_DIR)/unity.c $(FRAMEWORK_DIR)/test_kernel.c $(FRAMEWORK_DIR)/kernel_mocks.c ../fs/overlay.c
 FRAMEWORK_HEADERS = $(FRAMEWORK_DIR)/unity.h $(FRAMEWORK_DIR)/test_kernel.h
 
 # Listes des tests

--- a/tests/framework/kernel_mocks.c
+++ b/tests/framework/kernel_mocks.c
@@ -6,6 +6,7 @@
 #include "kernel/mem/vmm.h"
 #include "kernel/task/task.h"
 #include "kernel/syscall/syscall.h"
+#include "fs/overlay.h"
 
 // === GESTION MÉMOIRE MOCKS ===
 extern void* test_malloc(size_t size);
@@ -186,7 +187,7 @@ void sys_yield(void) {
 }
 
 void syscall_init(void) {
-    // Mock simple - ne fait rien
+    overlay_init();
 }
 
 void sys_putc(char c) {
@@ -234,62 +235,212 @@ static struct {
     {"bin/shell", "ELF", 3},
 };
 
-int sys_listdir(const char* path, os_dirent_t* out, int max_n) {
-    int count = 0;
-    const char* p = path ? path : "/";
-    if (!out || max_n <= 0) return -1;
-    if (p[0] == '/') p++;
-    if (p[0] == '\0' || (p[0] == '.' && p[1] == '\0')) {
-        int has_bin = 0;
-        for (unsigned i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]) && count < max_n; i++) {
-            const char* n = mock_initrd[i].name;
-            const char* slash = 0;
-            const char* s = n;
-            while (*s) {
-                if (*s == '/') slash = s;
-                s++;
-            }
-            if (slash) {
-                if (!has_bin && count < max_n) {
-                    out[count].name[0] = 'b';
-                    out[count].name[1] = 'i';
-                    out[count].name[2] = 'n';
-                    out[count].name[3] = '\0';
-                    out[count].size = 0;
-                    out[count].flags = OS_DIRENT_DIR;
-                    count++;
-                    has_bin = 1;
-                }
-            } else {
-                int k = 0;
-                while (n[k] && k < OS_NAME_MAX - 1) {
-                    out[count].name[k] = n[k];
-                    k++;
-                }
-                out[count].name[k] = '\0';
-                out[count].size = mock_initrd[i].size;
-                out[count].flags = OS_DIRENT_FILE;
-                count++;
-            }
-        }
-        return count;
+static void mock_ird_norm(const char* in, char* out, int max) {
+    int i = 0;
+    if (!in) {
+        out[0] = '\0';
+        return;
+    }
+    if (in[0] == '.' && in[1] == '/') in += 2;
+    while (*in == '/') in++;
+    while (in[i] && i < max - 1) {
+        out[i] = in[i];
+        i++;
+    }
+    out[i] = '\0';
+    while (i > 0 && out[i - 1] == '/') {
+        out[--i] = '\0';
+    }
+}
+
+static void mock_ird_basename(const char* path, char* out, int max) {
+    const char* base = path ? path : "";
+    int i;
+    for (i = 0; path && path[i]; i++) {
+        if (path[i] == '/') base = path + i + 1;
+    }
+    i = 0;
+    while (base[i] && i < max - 1) {
+        out[i] = base[i];
+        i++;
+    }
+    out[i] = '\0';
+}
+
+int initrd_is_file(const char* path) {
+    char want[64];
+    unsigned i;
+    mock_ird_norm(path, want, 64);
+    if (!want[0]) return 0;
+    for (i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]); i++) {
+        if (strcmp(want, mock_initrd[i].name) == 0) return 1;
     }
     return 0;
 }
 
-int sys_readfile(const char* path, char* buf, uint32_t max) {
-    const char* p = path ? path : "";
-    if (!buf || max == 0) return -1;
-    if (p[0] == '/') p++;
-    for (unsigned i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]); i++) {
-        if (strcmp(p, mock_initrd[i].name) == 0) {
-            uint32_t n = mock_initrd[i].size;
-            if (n > max) n = max;
-            memcpy(buf, mock_initrd[i].data, n);
-            return (int)n;
+int initrd_is_dir(const char* path) {
+    char want[64];
+    unsigned i;
+    int plen;
+    mock_ird_norm(path, want, 64);
+    if (!want[0]) return 1;
+    plen = (int)strlen(want);
+    for (i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]); i++) {
+        const char* n = mock_initrd[i].name;
+        int j = 0;
+        while (j < plen && n[j] == want[j]) j++;
+        if (j == plen && n[j] == '/') return 1;
+    }
+    return 0;
+}
+
+int initrd_stat(const char* path, os_dirent_t* out) {
+    char want[64];
+    unsigned i;
+    if (!path || !out) return -1;
+    mock_ird_norm(path, want, 64);
+    if (!want[0]) {
+        out->name[0] = '/';
+        out->name[1] = '\0';
+        out->size = 0;
+        out->flags = OS_DIRENT_DIR;
+        return 0;
+    }
+    if (initrd_is_dir(want)) {
+        mock_ird_basename(want, out->name, OS_NAME_MAX);
+        out->size = 0;
+        out->flags = OS_DIRENT_DIR;
+        return 0;
+    }
+    for (i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]); i++) {
+        if (strcmp(want, mock_initrd[i].name) == 0) {
+            mock_ird_basename(want, out->name, OS_NAME_MAX);
+            out->size = mock_initrd[i].size;
+            out->flags = OS_DIRENT_FILE;
+            return 0;
         }
     }
     return -1;
+}
+
+static int mock_initrd_listdir(const char* path, os_dirent_t* out, int max_n) {
+    char prefix[64];
+    int plen;
+    int count = 0;
+    unsigned i;
+    if (!out || max_n <= 0) return -1;
+    mock_ird_norm(path ? path : "/", prefix, 64);
+    plen = (int)strlen(prefix);
+    for (i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]) && count < max_n; i++) {
+        const char* have = mock_initrd[i].name;
+        const char* rest;
+        int slash = -1;
+        int k;
+        if (plen == 0) {
+            rest = have;
+        } else {
+            int j = 0;
+            while (j < plen && have[j] == prefix[j]) j++;
+            if (j != plen || have[j] != '/') continue;
+            rest = have + plen + 1;
+        }
+        if (!rest[0]) continue;
+        k = 0;
+        while (rest[k]) {
+            if (rest[k] == '/') {
+                slash = k;
+                break;
+            }
+            k++;
+        }
+        if (slash >= 0) {
+            char dname[OS_NAME_MAX];
+            int dup = 0;
+            int e;
+            int nlen = slash;
+            if (nlen >= OS_NAME_MAX) nlen = OS_NAME_MAX - 1;
+            for (e = 0; e < nlen; e++) dname[e] = rest[e];
+            dname[nlen] = '\0';
+            for (e = 0; e < count; e++) {
+                if (out[e].flags == OS_DIRENT_DIR && strcmp(out[e].name, dname) == 0) {
+                    dup = 1;
+                    break;
+                }
+            }
+            if (!dup) {
+                int t = 0;
+                while (dname[t] && t < OS_NAME_MAX - 1) {
+                    out[count].name[t] = dname[t];
+                    t++;
+                }
+                out[count].name[t] = '\0';
+                out[count].size = 0;
+                out[count].flags = OS_DIRENT_DIR;
+                count++;
+            }
+        } else {
+            int t = 0;
+            while (rest[t] && t < OS_NAME_MAX - 1) {
+                out[count].name[t] = rest[t];
+                t++;
+            }
+            out[count].name[t] = '\0';
+            out[count].size = mock_initrd[i].size;
+            out[count].flags = OS_DIRENT_FILE;
+            count++;
+        }
+    }
+    return count;
+}
+
+int sys_listdir(const char* path, os_dirent_t* out, int max_n) {
+    int n;
+    if (!path || !out || max_n <= 0) return -1;
+    if (!overlay_is_dir(path) && !initrd_is_dir(path)) return -1;
+    n = mock_initrd_listdir(path, out, max_n);
+    if (n < 0) n = 0;
+    return overlay_listdir(path, out, n, max_n);
+}
+
+int sys_readfile(const char* path, char* buf, uint32_t max) {
+    int n;
+    char want[64];
+    unsigned i;
+    if (!path || !buf || max == 0) return -1;
+    n = overlay_read(path, buf, max);
+    if (n >= 0) return n;
+    if (n == OV_ERR_ISDIR) return n;
+    mock_ird_norm(path, want, 64);
+    for (i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]); i++) {
+        if (strcmp(want, mock_initrd[i].name) == 0) {
+            uint32_t copy = mock_initrd[i].size;
+            if (copy > max) copy = max;
+            memcpy(buf, mock_initrd[i].data, copy);
+            return (int)copy;
+        }
+    }
+    return -1;
+}
+
+int sys_mkdir(const char* path) {
+    if (!path) return -1;
+    return overlay_mkdir(path);
+}
+
+int sys_unlink(const char* path) {
+    if (!path) return -1;
+    return overlay_unlink(path);
+}
+
+int sys_writefile(const char* path, const char* buf, uint32_t n) {
+    if (!path || !buf) return -1;
+    return overlay_write(path, buf, n);
+}
+
+int sys_stat(const char* path, os_dirent_t* out) {
+    if (!path || !out) return -1;
+    if (overlay_stat(path, out) == OV_OK) return 0;
+    return initrd_stat(path, out);
 }
 
 int sys_getpid(void) {
@@ -379,6 +530,18 @@ void syscall_handler(cpu_state_t* state) {
             break;
         case SYS_MEMINFO:
             state->eax = (uint32_t)sys_meminfo((os_meminfo_t*)state->ebx);
+            break;
+        case SYS_MKDIR:
+            state->eax = (uint32_t)sys_mkdir((const char*)state->ebx);
+            break;
+        case SYS_UNLINK:
+            state->eax = (uint32_t)sys_unlink((const char*)state->ebx);
+            break;
+        case SYS_WRITEFILE:
+            state->eax = (uint32_t)sys_writefile((const char*)state->ebx, (const char*)state->ecx, state->edx);
+            break;
+        case SYS_STAT:
+            state->eax = (uint32_t)sys_stat((const char*)state->ebx, (os_dirent_t*)state->ecx);
             break;
         default:
             break;

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -10,7 +10,7 @@ cd "$ROOT"
 
 KERNEL="${KERNEL:-build/ai_os.bin}"
 INITRD="${INITRD:-my_initrd.tar}"
-SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-60}"
+SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-75}"
 
 if [ ! -f "$KERNEL" ] || [ ! -f "$INITRD" ]; then
     echo "ERROR: missing $KERNEL or $INITRD — run 'make all' first"

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -142,7 +142,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/uptime) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/mkdir/uptime) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -197,6 +197,33 @@ def main():
         sendkeys(mon, ["u", "p", "t", "i", "m", "e", "ret"])
         wait_needle("PIT ticks", CMD_TIMEOUT, proc)
 
+        say("typing mkdir mydir ...")
+        mark = len(log_text())
+        sendkeys(mon, ["m", "k", "d", "i", "r", "spc", "m", "y", "d", "i", "r", "ret"])
+        wait_needle_from("mkdir ok mydir", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls (after mkdir) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "ret"])
+        wait_needle_from("mydir", CMD_TIMEOUT, proc, mark)
+        after_mkdir_ls = log_text()[mark:]
+        if "hello.txt" not in after_mkdir_ls:
+            raise RuntimeError("ls after mkdir missing hello.txt")
+
+        say("typing rmdir mydir ...")
+        mark = len(log_text())
+        sendkeys(mon, ["r", "m", "d", "i", "r", "spc", "m", "y", "d", "i", "r", "ret"])
+        wait_needle_from("rmdir ok mydir", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls (after rmdir) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "ret"])
+        wait_needle_from("Initrd / VFS", CMD_TIMEOUT, proc, mark)
+        wait_needle_from("Total:", CMD_TIMEOUT, proc, mark)
+        after_rmdir_ls = log_text()[mark:]
+        if "mydir" in after_rmdir_ls:
+            raise RuntimeError("mydir still listed in ls after rmdir")
+
         text = log_text()
         checks = [
             ("syscall ls", "Initrd / VFS"),
@@ -211,6 +238,8 @@ def main():
             ("ps shows idle", "user  idle"),
             ("kill 2", "Processus 2 termine"),
             ("uptime", "PIT ticks"),
+            ("mkdir overlay", "mkdir ok mydir"),
+            ("rmdir overlay", "rmdir ok mydir"),
         ]
         fail = 0
         for label, needle in checks:

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -66,7 +66,7 @@ run_test() {
     
     # Flags de compilation spécialisés selon le type de test
     local cflags="-I$TEST_DIR -I$BASE_DIR -I$BASE_DIR/kernel -I$BASE_DIR/include -Wall -Wextra -std=c99 -DKERNEL_TEST=1"
-    local extra_src=""
+    local extra_src="$BASE_DIR/fs/overlay.c"
     
     if [ "$test_type" == "kernel" ]; then
         cflags="$cflags -m32 -ffreestanding -nostdlib -fno-pie"
@@ -75,7 +75,7 @@ run_test() {
     fi
 
     if [ "$(basename "$test_file")" = "test_ramfs.c" ]; then
-        extra_src="$BASE_DIR/userspace/ramfs.c $BASE_DIR/userspace/procsim.c"
+        extra_src="$extra_src $BASE_DIR/userspace/ramfs.c $BASE_DIR/userspace/procsim.c"
         cflags="$cflags -I$BASE_DIR/userspace"
     fi
     

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -6,6 +6,7 @@
 
 // Include du module à tester
 #include "../../../kernel/syscall/syscall.h"
+#include "../../../fs/overlay.h"
 // Ne pas inclure les en-têtes réels du kernel pour éviter les conflits de types
 
 // === MOCK DATA ET HELPERS ===
@@ -631,6 +632,112 @@ void test_sys_kill_removes_ready_task(void) {
     current_task = old_current;
 }
 
+void test_sys_overlay_mkdir_listdir_unlink(void) {
+    os_dirent_t ents[16];
+    os_dirent_t st;
+    cpu_state_t cpu = {0};
+    int n;
+    int found;
+    int i;
+
+    overlay_init();
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"mydir";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"mydir";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_DIR, (int)st.flags);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"/";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 16;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    found = 0;
+    TEST_ASSERT(n > 0);
+    for (i = 0; i < n; i++) {
+        if (strcmp(ents[i].name, "mydir") == 0 && ents[i].flags == OS_DIRENT_DIR) {
+            found = 1;
+        }
+    }
+    TEST_ASSERT(found);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"mydir";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 16;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_UNLINK;
+    cpu.ebx = (uint32_t)"mydir";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"/";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 16;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    found = 0;
+    for (i = 0; i < n; i++) {
+        if (strcmp(ents[i].name, "mydir") == 0) found = 1;
+    }
+    TEST_ASSERT_EQUAL(0, found);
+}
+
+void test_sys_overlay_write_read(void) {
+    char buf[64];
+    cpu_state_t cpu = {0};
+    const char* payload = "hello overlay\n";
+
+    overlay_init();
+
+    cpu.eax = SYS_WRITEFILE;
+    cpu.ebx = (uint32_t)"notes.txt";
+    cpu.ecx = (uint32_t)payload;
+    cpu.edx = 14;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(14, (int)cpu.eax);
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"notes.txt";
+    cpu.ecx = (uint32_t)buf;
+    cpu.edx = sizeof(buf);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(14, (int)cpu.eax);
+    buf[14] = '\0';
+    TEST_ASSERT_EQUAL_STRING("hello overlay\n", buf);
+
+    cpu.eax = SYS_UNLINK;
+    cpu.ebx = (uint32_t)"notes.txt";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+}
+
+void test_sys_overlay_protects_initrd(void) {
+    cpu_state_t cpu = {0};
+    overlay_init();
+
+    cpu.eax = SYS_UNLINK;
+    cpu.ebx = (uint32_t)"hello.txt";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_PROTECTED, (int)cpu.eax);
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"no/such/dir";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_NOTDIR, (int)cpu.eax);
+}
+
 // === RUNNER PRINCIPAL ===
 
 int main(void) {
@@ -686,6 +793,9 @@ int main(void) {
     RUN_TEST(test_sys_ps_lists_task);
     RUN_TEST(test_sys_kill_unknown_pid);
     RUN_TEST(test_sys_kill_removes_ready_task);
+    RUN_TEST(test_sys_overlay_mkdir_listdir_unlink);
+    RUN_TEST(test_sys_overlay_write_read);
+    RUN_TEST(test_sys_overlay_protects_initrd);
     
     unity_print_results();
     unity_cleanup();

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -144,6 +144,32 @@ int sys_meminfo(os_meminfo_t* info) {
     return result;
 }
 
+int sys_mkdir(const char* path) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_MKDIR), "b"(path));
+    return result;
+}
+
+int sys_unlink(const char* path) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_UNLINK), "b"(path));
+    return result;
+}
+
+int sys_writefile(const char* path, const char* buf, int n) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_WRITEFILE), "b"(path), "c"(buf), "d"(n));
+    return result;
+}
+
+int sys_stat(const char* path, os_dirent_t* out) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_STAT), "b"(path), "c"(out));
+    return result;
+}
+
+static void print_fs_err(const char* cmd, int rc);
+
 // ==============================================================================
 // FONCTIONS UTILITAIRES MODERNES
 // ==============================================================================
@@ -430,11 +456,11 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_colored("\n=== AI-OS Shell v6.0 - Aide Complète ===\n", COLOR_CYAN);
     
     print_colored("COMMANDES SYSTÈME :\n", COLOR_YELLOW);
-    print_string("  ls [path]          - Lister initrd (noyau) + VFS RAM\n");
-    print_string("  cat <file>         - Afficher un fichier (initrd puis VFS RAM)\n");
+    print_string("  ls [path]          - Lister initrd + overlay noyau\n");
+    print_string("  cat <file>         - Afficher un fichier (overlay puis initrd)\n");
     print_string("  cd <path>          - Changer de répertoire\n");
     print_string("  pwd                - Afficher le répertoire courant\n");
-    print_string("  mkdir <dir>        - Créer un répertoire\n");
+    print_string("  mkdir <dir>        - Créer un répertoire (overlay noyau)\n");
     print_string("  rmdir <dir>        - Supprimer un répertoire vide\n");
     print_string("  cp <src> <dest>    - Copier un fichier\n");
     print_string("  mv <src> <dest>    - Déplacer/renommer un fichier\n");
@@ -483,7 +509,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  reboot             - Redémarrer le système\n");
     print_string("  shutdown           - Arrêter le système\n");
     
-    print_colored("\n💡 TIP: ls/cat lisent l'initrd (noyau). mkdir/rm restent un VFS RAM.\n", COLOR_GREEN);
+    print_colored("\nTIP: ls/cat/mkdir/rm parlent au noyau (initrd + overlay RAM). cp/mv restent un VFS local.\n", COLOR_GREEN);
     print_colored("    Si le mode IA est activé, posez des questions sans 'ai'.\n\n", COLOR_GREEN);
 }
 
@@ -628,7 +654,7 @@ void cmd_sysinfo(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("AI-Shell v6.0 (IA intégrée)\n");
     
     print_colored("Système de fichiers : ", COLOR_YELLOW);
-    print_string("InitRD (RAM Disk)\n");
+    print_string("Initrd TAR + overlay RAM\n");
     
     print_colored("Fonctionnalités : ", COLOR_YELLOW);
     print_string("PMM, VMM, Multitâche, IA, Ring 0/3\n");
@@ -739,8 +765,8 @@ void cmd_echo(shell_context_t* ctx, char args[][128], int arg_count) {
         buf[pos++] = '\n';
         buf[pos] = '\0';
         resolve_arg(ctx, args[redir + 1], path);
-        rc = ramfs_write(path, buf, pos);
-        if (rc != RAMFS_OK) print_ramfs_err("echo", rc);
+        rc = sys_writefile(path, buf, pos);
+        if (rc < 0) print_fs_err("echo", rc);
         return;
     }
     for (int i = 0; i < arg_count; i++) {
@@ -785,8 +811,8 @@ static void cmd_cd(shell_context_t* ctx, char args[][128], int arg_count) {
         ramfs_resolve(ctx->current_dir, args[0], newdir, RAMFS_PATH_MAX);
     }
     if (!ramfs_is_dir(newdir)) {
-        os_dirent_t tmp[1];
-        if (sys_listdir(newdir, tmp, 1) <= 0) {
+        os_dirent_t st;
+        if (sys_stat(newdir, &st) != 0 || st.flags != OS_DIRENT_DIR) {
             print_error("cd: repertoire introuvable");
             return;
         }
@@ -853,6 +879,18 @@ static void cmd_which(shell_context_t* ctx, const char* cmd) {
     print_string(" (non verifie)\n");
 }
 
+static void print_fs_err(const char* cmd, int rc) {
+    print_string(cmd);
+    print_string(": ");
+    if (rc == -2) print_string("existe deja\n");
+    else if (rc == -3) print_string("parent invalide\n");
+    else if (rc == -4) print_string("est un repertoire\n");
+    else if (rc == -5) print_string("repertoire non vide\n");
+    else if (rc == -6) print_string("plus de place\n");
+    else if (rc == -8) print_string("protege (initrd)\n");
+    else print_string("echec\n");
+}
+
 static void cmd_mkdir(shell_context_t* ctx, char args[][128], int arg_count) {
     char path[RAMFS_PATH_MAX];
     int rc;
@@ -861,31 +899,65 @@ static void cmd_mkdir(shell_context_t* ctx, char args[][128], int arg_count) {
         return;
     }
     resolve_arg(ctx, args[0], path);
-    rc = ramfs_mkdir(path);
-    if (rc != RAMFS_OK) print_ramfs_err("mkdir", rc);
-    else print_success(path);
+    rc = sys_mkdir(path);
+    if (rc != 0) {
+        print_fs_err("mkdir", rc);
+        return;
+    }
+    print_string("mkdir ok ");
+    print_string(args[0]);
+    print_string("\n");
 }
 
 static void cmd_rmdir(shell_context_t* ctx, char args[][128], int arg_count) {
     char path[RAMFS_PATH_MAX];
+    os_dirent_t st;
     int rc;
     if (arg_count == 0) {
         print_error("rmdir: repertoire manquant");
         return;
     }
     resolve_arg(ctx, args[0], path);
+    if (sys_stat(path, &st) == 0) {
+        if (st.flags != OS_DIRENT_DIR) {
+            print_error("rmdir: n'est pas un repertoire");
+            return;
+        }
+        rc = sys_unlink(path);
+        if (rc != 0) {
+            print_fs_err("rmdir", rc);
+            return;
+        }
+        print_string("rmdir ok ");
+        print_string(args[0]);
+        print_string("\n");
+        return;
+    }
     rc = ramfs_rmdir(path);
     if (rc != RAMFS_OK) print_ramfs_err("rmdir", rc);
 }
 
 static void cmd_rm(shell_context_t* ctx, char args[][128], int arg_count) {
     char path[RAMFS_PATH_MAX];
+    os_dirent_t st;
     int rc;
     if (arg_count == 0) {
         print_error("rm: fichier manquant");
         return;
     }
     resolve_arg(ctx, args[0], path);
+    if (sys_stat(path, &st) == 0) {
+        if (st.flags == OS_DIRENT_DIR) {
+            print_error("rm: est un repertoire");
+            return;
+        }
+        rc = sys_unlink(path);
+        if (rc != 0) {
+            print_fs_err("rm", rc);
+            return;
+        }
+        return;
+    }
     rc = ramfs_rm(path);
     if (rc != RAMFS_OK) print_ramfs_err("rm", rc);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objectif

`ls`/`cat` parlaient à l’initrd (syscalls) alors que `mkdir`/`rm`/`echo >` restaient un VFS RAM local au shell. Un `mkdir mydir` n’apparaissait donc pas dans `ls` sous QEMU.

Cette PR unifie l’arbre via un **overlay RAM noyau** : l’initrd reste en lecture seule, les créations/suppressions vivent dans `fs/overlay.c` et sont fusionnées par `SYS_LISTDIR` / `SYS_READFILE`.

## ABI (`include/os_syscalls.h`)

| Numéro | Syscall | Rôle |
|---|---|---|
| 15 | `SYS_MKDIR` | Créer un dossier overlay |
| 16 | `SYS_UNLINK` | Supprimer un nœud overlay (initrd protégé) |
| 17 | `SYS_WRITEFILE` | Écrire/créer un fichier overlay |
| 18 | `SYS_STAT` | Type/taille (nécessaire pour `cd` dans un dossier overlay vide) |

`MAX_SYSCALLS` = 19.

## Shell

- `mkdir mydir` → `mkdir ok mydir` (aiguille CI)
- `rmdir mydir` → `rmdir ok mydir`
- `ls` liste initrd **+** overlay
- `echo >` et `cat` passent par l’overlay puis l’initrd
- `cd` utilise `SYS_STAT` (un dossier overlay vide a `listdir == 0`)
- `cp`/`mv` restent sur le VFS RAM du processus

## Tests / CI

- `test_syscall` : 40 tests (mkdir+listdir+unlink, write/read overlay, unlink initrd protégé)
- Smoke QEMU : après spawn/kill/uptime, `mkdir mydir` / `ls` / `rmdir mydir` / `ls` (plus de `mydir`)
- Pas de `>` ni `_` au clavier sendkey (Shift QEMU)

## Hors périmètre

Pas de disque persistant. L’overlay est volatil (RAM). Ne pas réactiver le round-robin à chaque tick PIT.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

