### PR TITLE
Overlay : cd/pwd et cp/mv visibles par ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make run-gui
 
 ## ⭐ Fonctionnalités Principales
 
-- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd + overlay noyau ; `mkdir`/`rm` mutent l’overlay (pas de disque persistant). `ps`/`kill`/`mem`/`uptime` interrogent le noyau.
+- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd + overlay noyau ; `mkdir`/`rm`/`cp`/`mv` mutent l’overlay (pas de disque persistant). `ps`/`kill`/`mem`/`uptime` interrogent le noyau.
 - **🤖 Simulateur d'IA Intégré** - Réponses préprogrammées par mots-clés (`fake_ai.c`), pas un modèle ML
 - **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
 - **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **103 tests** répartis dans `test_pmm` (17), `test_syscall` (40), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **104 tests** répartis dans `test_pmm` (17), `test_syscall` (41), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash
@@ -177,7 +177,7 @@ ai-os/
 - ✅ **Interruptions clavier (IRQ1) générées par QEMU**
 - ✅ **Fin des boucles infinies** sur appels système
 - ✅ **IA accessible** via interface clavier
-- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `grep`, `kill`, `top`, `ai`, etc. — `ls`/`mkdir`/`rm`/`ps`/`kill`/`mem` via syscalls noyau, `cp`/`mv` sur VFS RAM, voir `docs/ETAT_REEL.md`)
+- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `cp`, `grep`, `kill`, `top`, `ai`, etc. — `ls`/`mkdir`/`rm`/`cp`/`mv`/`ps`/`kill`/`mem` via syscalls noyau, voir `docs/ETAT_REEL.md`)
 
 ### ✅ Corrections Antérieures
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (overlay FS mkdir/rm + syscalls initrd/spawn/kill ; CI sendkey ls/cat/ps/spawn/kill/mkdir/rmdir/uptime)  
+**Code de référence :** `master` (overlay FS mkdir/cd/cp/rm + syscalls initrd/spawn/kill ; CI sendkey ls/cat/ps/spawn/kill/mkdir/cd/cp/rmdir/uptime)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -57,7 +57,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 40/40 |
+| `test_syscall` | 41/41 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
@@ -68,17 +68,17 @@ Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `mkdir` / `rmdir` / `rm` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` écrit dans l’overlay noyau. `cp` / `mv` restent un VFS RAM dans le processus shell (`userspace/ramfs.c`). `procsim.c` n’est plus utilisé par `ps`/`kill`.
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` écrit dans l’overlay noyau. `cp`/`mv` de répertoires restent un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
 | `help` | Aide |
 | `ls` / `dir` | Listing **initrd + overlay** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
 | `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l’initrd ne peut pas être modifié (`PROTECTED`) |
-| `cp` / `mv` | Mutation du VFS RAM local (pas d’écriture initrd) |
+| `cp` / `mv` | Copie overlay (`SYS_READFILE` + `SYS_WRITEFILE`) ; `mv` refuse l’initrd (rollback) ; répertoires : VFS RAM local |
 | `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau |
-| `cd` / `pwd` | Chemin shell ; `cd` accepte un dossier overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`) |
+| `cd` / `pwd` | Chemin shell ; `cd` accepte overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`). Succès : `cd ok <arg>` |
 | `ps` / `jobs` / `top` / `kill` / `spawn` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY (pas de changement de contexte). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`) |
 | `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT |
 | `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) |
@@ -126,13 +126,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/rmdir/uptime
+make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/cd/cp/rmdir/uptime
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2`, `uptime`, `mkdir mydir` et `rmdir mydir` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2`, `uptime`, `mkdir mydir`, `cd mydir`, `cp hello.txt copy.txt` et `rmdir mydir` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,7 +51,7 @@
 ### Reste ouvert (hors périmètre « shell qui démarre »)
 - [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
 - [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
-- [x] Overlay noyau RAM : `mkdir` / `rm` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
+- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` / `mv` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
 - [ ] FS persistant sur disque (l’overlay RAM n’est pas persisté)
 - [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
 - [ ] Réseau, vrai moteur IA — voir roadmap README / dossier `US/`

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -10,7 +10,7 @@ cd "$ROOT"
 
 KERNEL="${KERNEL:-build/ai_os.bin}"
 INITRD="${INITRD:-my_initrd.tar}"
-SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-75}"
+SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-90}"
 
 if [ ! -f "$KERNEL" ] || [ ! -f "$INITRD" ]; then
     echo "ERROR: missing $KERNEL or $INITRD — run 'make all' first"

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -142,7 +142,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/mkdir/uptime) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/mkdir/cd/cp/uptime) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -202,13 +202,60 @@ def main():
         sendkeys(mon, ["m", "k", "d", "i", "r", "spc", "m", "y", "d", "i", "r", "ret"])
         wait_needle_from("mkdir ok mydir", CMD_TIMEOUT, proc, mark)
 
-        say("typing ls (after mkdir) ...")
+        say("typing cd mydir ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "m", "y", "d", "i", "r", "ret"])
+        wait_needle_from("cd ok mydir", CMD_TIMEOUT, proc, mark)
+
+        say("typing pwd ...")
+        mark = len(log_text())
+        sendkeys(mon, ["p", "w", "d", "ret"])
+        wait_needle_from("/mydir", CMD_TIMEOUT, proc, mark)
+
+        say("typing cd .. ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "dot", "dot", "ret"])
+        wait_needle_from("cd ok ..", CMD_TIMEOUT, proc, mark)
+
+        say("typing cp hello.txt copy.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "c", "p", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t",
+            "spc", "c", "o", "p", "y", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("cp ok copy.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls (after cp) ...")
         mark = len(log_text())
         sendkeys(mon, ["l", "s", "ret"])
-        wait_needle_from("mydir", CMD_TIMEOUT, proc, mark)
-        after_mkdir_ls = log_text()[mark:]
-        if "hello.txt" not in after_mkdir_ls:
-            raise RuntimeError("ls after mkdir missing hello.txt")
+        wait_needle_from("copy.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing cat copy.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "c", "a", "t", "spc", "c", "o", "p", "y", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("demonstration", CMD_TIMEOUT, proc, mark)
+
+        say("typing rm copy.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "r", "m", "spc", "c", "o", "p", "y", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("rm ok copy.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls (after rm copy) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "ret"])
+        wait_needle_from("Initrd / VFS", CMD_TIMEOUT, proc, mark)
+        wait_needle_from("Total:", CMD_TIMEOUT, proc, mark)
+        after_rm_copy = log_text()[mark:]
+        if "copy.txt" in after_rm_copy:
+            raise RuntimeError("copy.txt still listed in ls after rm")
+        if "mydir" not in after_rm_copy:
+            raise RuntimeError("ls after cd/cp missing mydir")
+        if "hello.txt" not in after_rm_copy:
+            raise RuntimeError("ls after cd/cp missing hello.txt")
 
         say("typing rmdir mydir ...")
         mark = len(log_text())
@@ -239,6 +286,11 @@ def main():
             ("kill 2", "Processus 2 termine"),
             ("uptime", "PIT ticks"),
             ("mkdir overlay", "mkdir ok mydir"),
+            ("cd overlay", "cd ok mydir"),
+            ("pwd overlay", "/mydir"),
+            ("cd parent", "cd ok .."),
+            ("cp overlay", "cp ok copy.txt"),
+            ("rm overlay", "rm ok copy.txt"),
             ("rmdir overlay", "rmdir ok mydir"),
         ]
         fail = 0

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -738,6 +738,58 @@ void test_sys_overlay_protects_initrd(void) {
     TEST_ASSERT_EQUAL(OV_ERR_NOTDIR, (int)cpu.eax);
 }
 
+void test_sys_overlay_copy_from_initrd(void) {
+    char src[64];
+    char dst[64];
+    os_dirent_t ents[16];
+    cpu_state_t cpu = {0};
+    int n;
+    int found;
+    int i;
+
+    overlay_init();
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"hello.txt";
+    cpu.ecx = (uint32_t)src;
+    cpu.edx = sizeof(src);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(18, (int)cpu.eax);
+
+    cpu.eax = SYS_WRITEFILE;
+    cpu.ebx = (uint32_t)"copy.txt";
+    cpu.ecx = (uint32_t)src;
+    cpu.edx = 18;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(18, (int)cpu.eax);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"/";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 16;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    found = 0;
+    for (i = 0; i < n; i++) {
+        if (strcmp(ents[i].name, "copy.txt") == 0) found = 1;
+    }
+    TEST_ASSERT(found);
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"copy.txt";
+    cpu.ecx = (uint32_t)dst;
+    cpu.edx = sizeof(dst);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(18, (int)cpu.eax);
+    dst[18] = '\0';
+    TEST_ASSERT_EQUAL_STRING("hello from initrd\n", dst);
+
+    cpu.eax = SYS_UNLINK;
+    cpu.ebx = (uint32_t)"copy.txt";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+}
+
 // === RUNNER PRINCIPAL ===
 
 int main(void) {
@@ -796,6 +848,7 @@ int main(void) {
     RUN_TEST(test_sys_overlay_mkdir_listdir_unlink);
     RUN_TEST(test_sys_overlay_write_read);
     RUN_TEST(test_sys_overlay_protects_initrd);
+    RUN_TEST(test_sys_overlay_copy_from_initrd);
     
     unity_print_results();
     unity_cleanup();

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -462,8 +462,8 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  pwd                - Afficher le répertoire courant\n");
     print_string("  mkdir <dir>        - Créer un répertoire (overlay noyau)\n");
     print_string("  rmdir <dir>        - Supprimer un répertoire vide\n");
-    print_string("  cp <src> <dest>    - Copier un fichier\n");
-    print_string("  mv <src> <dest>    - Déplacer/renommer un fichier\n");
+    print_string("  cp <src> <dest>    - Copier un fichier (overlay noyau)\n");
+    print_string("  mv <src> <dest>    - Déplacer un fichier overlay\n");
     print_string("  rm <file>          - Supprimer un fichier\n");
     
     print_colored("\nCOMMANDES PROCESSUS :\n", COLOR_YELLOW);
@@ -509,7 +509,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  reboot             - Redémarrer le système\n");
     print_string("  shutdown           - Arrêter le système\n");
     
-    print_colored("\nTIP: ls/cat/mkdir/rm parlent au noyau (initrd + overlay RAM). cp/mv restent un VFS local.\n", COLOR_GREEN);
+    print_colored("\nTIP: ls/cat/mkdir/rm/cp/mv parlent au noyau (initrd + overlay RAM).\n", COLOR_GREEN);
     print_colored("    Si le mode IA est activé, posez des questions sans 'ai'.\n\n", COLOR_GREEN);
 }
 
@@ -818,6 +818,10 @@ static void cmd_cd(shell_context_t* ctx, char args[][128], int arg_count) {
         }
     }
     strcpy(ctx->current_dir, newdir);
+    print_string("cd ok ");
+    if (arg_count == 0) print_string(ctx->current_dir);
+    else print_string(args[0]);
+    print_string("\n");
 }
 
 static void cmd_cat(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -956,10 +960,57 @@ static void cmd_rm(shell_context_t* ctx, char args[][128], int arg_count) {
             print_fs_err("rm", rc);
             return;
         }
+        print_string("rm ok ");
+        print_string(args[0]);
+        print_string("\n");
         return;
     }
     rc = ramfs_rm(path);
     if (rc != RAMFS_OK) print_ramfs_err("rm", rc);
+}
+
+static const char* fs_basename(const char* path) {
+    const char* b = path ? path : "";
+    int i = 0;
+    while (path && path[i]) {
+        if (path[i] == '/') b = path + i + 1;
+        i++;
+    }
+    return (b && b[0]) ? b : "/";
+}
+
+static void fs_join(char* out, int max, const char* dir, const char* name) {
+    int i = 0;
+    int j = 0;
+    if (!dir) dir = "/";
+    if (!name) name = "";
+    while (dir[i] && i < max - 2) {
+        out[i] = dir[i];
+        i++;
+    }
+    if (i > 0 && out[i - 1] != '/') out[i++] = '/';
+    while (name[j] && i < max - 1) out[i++] = name[j++];
+    out[i] = '\0';
+}
+
+static int kernel_copy_file(const char* src, char* dest, int dest_max) {
+    os_dirent_t st;
+    char buf[256];
+    int n;
+    int w;
+    (void)dest_max;
+    if (sys_stat(src, &st) != 0) return -1;
+    if (st.flags == OS_DIRENT_DIR) return -4;
+    n = sys_readfile(src, buf, (int)sizeof(buf));
+    if (n < 0) return n;
+    if (sys_stat(dest, &st) == 0 && st.flags == OS_DIRENT_DIR) {
+        char joined[RAMFS_PATH_MAX];
+        fs_join(joined, RAMFS_PATH_MAX, dest, fs_basename(src));
+        strcpy(dest, joined);
+    }
+    w = sys_writefile(dest, buf, n);
+    if (w < 0) return w;
+    return 0;
 }
 
 static void cmd_cp(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -972,6 +1023,13 @@ static void cmd_cp(shell_context_t* ctx, char args[][128], int arg_count) {
     }
     resolve_arg(ctx, args[0], src);
     resolve_arg(ctx, args[1], dst);
+    rc = kernel_copy_file(src, dst, RAMFS_PATH_MAX);
+    if (rc == 0) {
+        print_string("cp ok ");
+        print_string(fs_basename(dst));
+        print_string("\n");
+        return;
+    }
     rc = ramfs_cp(src, dst);
     if (rc != RAMFS_OK) print_ramfs_err("cp", rc);
 }
@@ -979,6 +1037,7 @@ static void cmd_cp(shell_context_t* ctx, char args[][128], int arg_count) {
 static void cmd_mv(shell_context_t* ctx, char args[][128], int arg_count) {
     char src[RAMFS_PATH_MAX];
     char dst[RAMFS_PATH_MAX];
+    os_dirent_t st;
     int rc;
     if (arg_count < 2) {
         print_error("mv: usage mv <src> <dest>");
@@ -986,6 +1045,31 @@ static void cmd_mv(shell_context_t* ctx, char args[][128], int arg_count) {
     }
     resolve_arg(ctx, args[0], src);
     resolve_arg(ctx, args[1], dst);
+    if (sys_stat(src, &st) == 0) {
+        if (st.flags == OS_DIRENT_DIR) {
+            print_error("mv: repertoire non supporte");
+            return;
+        }
+        rc = kernel_copy_file(src, dst, RAMFS_PATH_MAX);
+        if (rc != 0) {
+            print_fs_err("mv", rc);
+            return;
+        }
+        rc = sys_unlink(src);
+        if (rc == -8) {
+            sys_unlink(dst);
+            print_fs_err("mv", rc);
+            return;
+        }
+        if (rc != 0) {
+            print_fs_err("mv", rc);
+            return;
+        }
+        print_string("mv ok ");
+        print_string(fs_basename(dst));
+        print_string("\n");
+        return;
+    }
     rc = ramfs_mv(src, dst);
     if (rc != RAMFS_OK) print_ramfs_err("mv", rc);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objectif

Après l’overlay `mkdir`/`rm`, `cd` n’était pas vérifié sous QEMU et `cp`/`mv` restaient un VFS RAM local au shell : `cp hello.txt copy.txt` n’apparaissait pas dans `ls`.

## Comportement

- `cd mydir` → `cd ok mydir` (utilise `SYS_STAT` pour les dossiers overlay vides)
- `pwd` affiche `/mydir`
- `cd ..` → `cd ok ..`
- `cp hello.txt copy.txt` lit l’initrd (`SYS_READFILE`) et écrit l’overlay (`SYS_WRITEFILE`) → `cp ok copy.txt`
- `rm copy.txt` → `rm ok copy.txt`
- `mv` = copie + `unlink` ; un fichier initrd est protégé (la copie est annulée)
- `mv` d’un répertoire reste sur le VFS RAM local

Pas de nouveau syscall. L’initrd reste en lecture seule. Pas de disque persistant.

## CI

Après mkdir, le smoke tape :

1. `cd mydir` / `pwd` / `cd ..`
2. `cp hello.txt copy.txt` / `ls` / `cat copy.txt` / `rm copy.txt`
3. `rmdir mydir`

Pas de `>` ni `_` au clavier sendkey (`dot` pour `..` et `.txt`).

## Tests

`test_syscall` : copie initrd → overlay via READFILE/WRITEFILE (41 tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

