### PR TITLE
Overlay : dossiers imbriqués, rmdir non vide, mv

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **104 tests** répartis dans `test_pmm` (17), `test_syscall` (41), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **105 tests** répartis dans `test_pmm` (17), `test_syscall` (42), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (overlay FS mkdir/cd/cp/rm + syscalls initrd/spawn/kill ; CI sendkey ls/cat/ps/spawn/kill/mkdir/cd/cp/rmdir/uptime)  
+**Code de référence :** `master` (overlay nested mkdir/mv + syscalls initrd/spawn/kill ; CI sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/rmdir/uptime)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -31,7 +31,7 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - Chargeur ELF 32-bit
 - Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
 - Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT` (ABI : `include/os_syscalls.h`)
-- Overlay RAM (`fs/overlay.c`) : `mkdir` / `rm` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule
+- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` / `mv` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
 
 ### Espace utilisateur
 
@@ -57,7 +57,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 41/41 |
+| `test_syscall` | 42/42 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
@@ -74,7 +74,7 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 |---|---|
 | `help` | Aide |
 | `ls` / `dir` | Listing **initrd + overlay** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
-| `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l’initrd ne peut pas être modifié (`PROTECTED`) |
+| `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l’initrd ne peut pas être modifié (`PROTECTED`) ; `rmdir` d’un dossier non vide échoue (`NOTEMPTY`) |
 | `cp` / `mv` | Copie overlay (`SYS_READFILE` + `SYS_WRITEFILE`) ; `mv` refuse l’initrd (rollback) ; répertoires : VFS RAM local |
 | `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau |
@@ -126,13 +126,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/cd/cp/rmdir/uptime
+make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/rmdir/uptime
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2`, `uptime`, `mkdir mydir`, `cd mydir`, `cp hello.txt copy.txt` et `rmdir mydir` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2`, `uptime`, `mkdir mydir`, `cd mydir`, `mkdir sub`, `mv copy.txt notes.txt` et `rmdir mydir` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -10,7 +10,7 @@ cd "$ROOT"
 
 KERNEL="${KERNEL:-build/ai_os.bin}"
 INITRD="${INITRD:-my_initrd.tar}"
-SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-90}"
+SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-100}"
 
 if [ ! -f "$KERNEL" ] || [ ! -f "$INITRD" ]; then
     echo "ERROR: missing $KERNEL or $INITRD — run 'make all' first"

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -142,7 +142,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/mkdir/cd/cp/uptime) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/uptime) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -212,6 +212,51 @@ def main():
         sendkeys(mon, ["p", "w", "d", "ret"])
         wait_needle_from("/mydir", CMD_TIMEOUT, proc, mark)
 
+        say("typing mkdir sub ...")
+        mark = len(log_text())
+        sendkeys(mon, ["m", "k", "d", "i", "r", "spc", "s", "u", "b", "ret"])
+        wait_needle_from("mkdir ok sub", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls (inside mydir) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "ret"])
+        wait_needle_from("sub", CMD_TIMEOUT, proc, mark)
+
+        say("typing cd sub ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "s", "u", "b", "ret"])
+        wait_needle_from("cd ok sub", CMD_TIMEOUT, proc, mark)
+
+        say("typing pwd (nested) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["p", "w", "d", "ret"])
+        wait_needle_from("/mydir/sub", CMD_TIMEOUT, proc, mark)
+
+        say("typing cd .. (from sub) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "dot", "dot", "ret"])
+        wait_needle_from("cd ok ..", CMD_TIMEOUT, proc, mark)
+
+        say("typing cd .. (to root) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "dot", "dot", "ret"])
+        wait_needle_from("cd ok ..", CMD_TIMEOUT, proc, mark)
+
+        say("typing rmdir mydir (not empty) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["r", "m", "d", "i", "r", "spc", "m", "y", "d", "i", "r", "ret"])
+        wait_needle_from("repertoire non vide", CMD_TIMEOUT, proc, mark)
+
+        say("typing cd mydir (cleanup sub) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "m", "y", "d", "i", "r", "ret"])
+        wait_needle_from("cd ok mydir", CMD_TIMEOUT, proc, mark)
+
+        say("typing rmdir sub ...")
+        mark = len(log_text())
+        sendkeys(mon, ["r", "m", "d", "i", "r", "spc", "s", "u", "b", "ret"])
+        wait_needle_from("rmdir ok sub", CMD_TIMEOUT, proc, mark)
+
         say("typing cd .. ...")
         mark = len(log_text())
         sendkeys(mon, ["c", "d", "spc", "dot", "dot", "ret"])
@@ -225,37 +270,48 @@ def main():
         ])
         wait_needle_from("cp ok copy.txt", CMD_TIMEOUT, proc, mark)
 
-        say("typing ls (after cp) ...")
-        mark = len(log_text())
-        sendkeys(mon, ["l", "s", "ret"])
-        wait_needle_from("copy.txt", CMD_TIMEOUT, proc, mark)
-
-        say("typing cat copy.txt ...")
+        say("typing mv copy.txt notes.txt ...")
         mark = len(log_text())
         sendkeys(mon, [
-            "c", "a", "t", "spc", "c", "o", "p", "y", "dot", "t", "x", "t", "ret",
+            "m", "v", "spc", "c", "o", "p", "y", "dot", "t", "x", "t",
+            "spc", "n", "o", "t", "e", "s", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("mv ok notes.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls (after mv) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "ret"])
+        wait_needle_from("notes.txt", CMD_TIMEOUT, proc, mark)
+        after_mv_ls = log_text()[mark:]
+        if "copy.txt" in after_mv_ls:
+            raise RuntimeError("copy.txt still listed after mv")
+
+        say("typing cat notes.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "c", "a", "t", "spc", "n", "o", "t", "e", "s", "dot", "t", "x", "t", "ret",
         ])
         wait_needle_from("demonstration", CMD_TIMEOUT, proc, mark)
 
-        say("typing rm copy.txt ...")
+        say("typing rm notes.txt ...")
         mark = len(log_text())
         sendkeys(mon, [
-            "r", "m", "spc", "c", "o", "p", "y", "dot", "t", "x", "t", "ret",
+            "r", "m", "spc", "n", "o", "t", "e", "s", "dot", "t", "x", "t", "ret",
         ])
-        wait_needle_from("rm ok copy.txt", CMD_TIMEOUT, proc, mark)
+        wait_needle_from("rm ok notes.txt", CMD_TIMEOUT, proc, mark)
 
-        say("typing ls (after rm copy) ...")
+        say("typing ls (after rm notes) ...")
         mark = len(log_text())
         sendkeys(mon, ["l", "s", "ret"])
         wait_needle_from("Initrd / VFS", CMD_TIMEOUT, proc, mark)
         wait_needle_from("Total:", CMD_TIMEOUT, proc, mark)
-        after_rm_copy = log_text()[mark:]
-        if "copy.txt" in after_rm_copy:
-            raise RuntimeError("copy.txt still listed in ls after rm")
-        if "mydir" not in after_rm_copy:
-            raise RuntimeError("ls after cd/cp missing mydir")
-        if "hello.txt" not in after_rm_copy:
-            raise RuntimeError("ls after cd/cp missing hello.txt")
+        after_rm_notes = log_text()[mark:]
+        if "notes.txt" in after_rm_notes:
+            raise RuntimeError("notes.txt still listed in ls after rm")
+        if "mydir" not in after_rm_notes:
+            raise RuntimeError("ls after nested/mv missing mydir")
+        if "hello.txt" not in after_rm_notes:
+            raise RuntimeError("ls after nested/mv missing hello.txt")
 
         say("typing rmdir mydir ...")
         mark = len(log_text())
@@ -288,9 +344,14 @@ def main():
             ("mkdir overlay", "mkdir ok mydir"),
             ("cd overlay", "cd ok mydir"),
             ("pwd overlay", "/mydir"),
-            ("cd parent", "cd ok .."),
+            ("mkdir nested", "mkdir ok sub"),
+            ("cd nested", "cd ok sub"),
+            ("pwd nested", "/mydir/sub"),
+            ("rmdir notempty", "repertoire non vide"),
+            ("rmdir nested", "rmdir ok sub"),
             ("cp overlay", "cp ok copy.txt"),
-            ("rm overlay", "rm ok copy.txt"),
+            ("mv overlay", "mv ok notes.txt"),
+            ("rm overlay", "rm ok notes.txt"),
             ("rmdir overlay", "rmdir ok mydir"),
         ]
         fail = 0

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -790,6 +790,73 @@ void test_sys_overlay_copy_from_initrd(void) {
     TEST_ASSERT_EQUAL(0, (int)cpu.eax);
 }
 
+void test_sys_overlay_nested_mkdir_notempty(void) {
+    char payload[] = "nested\n";
+    os_dirent_t ents[16];
+    cpu_state_t cpu = {0};
+    int n;
+    int found;
+    int i;
+
+    overlay_init();
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"mydir";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"mydir/sub";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_WRITEFILE;
+    cpu.ebx = (uint32_t)"mydir/sub/a.txt";
+    cpu.ecx = (uint32_t)payload;
+    cpu.edx = 7;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(7, (int)cpu.eax);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"mydir";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 16;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    found = 0;
+    for (i = 0; i < n; i++) {
+        if (strcmp(ents[i].name, "sub") == 0 && ents[i].flags == OS_DIRENT_DIR) {
+            found = 1;
+        }
+    }
+    TEST_ASSERT(found);
+
+    cpu.eax = SYS_UNLINK;
+    cpu.ebx = (uint32_t)"mydir";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_NOTEMPTY, (int)cpu.eax);
+
+    cpu.eax = SYS_UNLINK;
+    cpu.ebx = (uint32_t)"mydir/sub";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_NOTEMPTY, (int)cpu.eax);
+
+    cpu.eax = SYS_UNLINK;
+    cpu.ebx = (uint32_t)"mydir/sub/a.txt";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_UNLINK;
+    cpu.ebx = (uint32_t)"mydir/sub";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_UNLINK;
+    cpu.ebx = (uint32_t)"mydir";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+}
+
 // === RUNNER PRINCIPAL ===
 
 int main(void) {
@@ -849,6 +916,7 @@ int main(void) {
     RUN_TEST(test_sys_overlay_write_read);
     RUN_TEST(test_sys_overlay_protects_initrd);
     RUN_TEST(test_sys_overlay_copy_from_initrd);
+    RUN_TEST(test_sys_overlay_nested_mkdir_notempty);
     
     unity_print_results();
     unity_cleanup();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objectif

L’overlay savait déjà `mkdir` à la racine, `cd` et `cp`. Il manquait un parcours **imbriqué** sous QEMU, le refus `rmdir` d’un dossier non vide, et un `mv` réellement tapé au clavier.

## Comportement (déjà dans le noyau, maintenant exercé)

- `cd mydir` puis `mkdir sub` → `mkdir ok sub`
- `cd sub` / `pwd` → `/mydir/sub`
- `rmdir mydir` tant que `sub` existe → `rmdir: repertoire non vide`
- `rmdir sub` puis `rmdir mydir` → OK
- `cp hello.txt copy.txt` puis `mv copy.txt notes.txt` → `mv ok notes.txt` ; `copy.txt` disparaît, `cat notes.txt` lit l’initrd copié

Pas de nouveau syscall. Pas de `/` ni `>` au sendkey (`dot` pour `..`).

## Tests

- `test_syscall` 42/42 : mkdir `mydir/sub`, fichier `mydir/sub/a.txt`, unlink parent → `NOTEMPTY`
- Smoke QEMU : nested cd/pwd + rmdir non vide + mv
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

