### PR TITLE
Overlay : write sans > et cp vers un dossier

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (overlay nested mkdir/mv + syscalls initrd/spawn/kill ; CI sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/rmdir/uptime)  
+**Code de référence :** `master` (overlay write/cp-into-dir + nested mkdir/mv ; CI sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/write/rmdir/uptime)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -31,7 +31,7 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - Chargeur ELF 32-bit
 - Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
 - Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT` (ABI : `include/os_syscalls.h`)
-- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` / `mv` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
+- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (y compris vers un dossier) / `mv` / `write` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
 
 ### Espace utilisateur
 
@@ -68,16 +68,17 @@ Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` écrit dans l’overlay noyau. `cp`/`mv` de répertoires restent un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `cp`/`mv` de répertoires restent un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
 | `help` | Aide |
 | `ls` / `dir` | Listing **initrd + overlay** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
 | `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l’initrd ne peut pas être modifié (`PROTECTED`) ; `rmdir` d’un dossier non vide échoue (`NOTEMPTY`) |
-| `cp` / `mv` | Copie overlay (`SYS_READFILE` + `SYS_WRITEFILE`) ; `mv` refuse l’initrd (rollback) ; répertoires : VFS RAM local |
+| `cp` / `mv` | Copie overlay (`SYS_READFILE` + `SYS_WRITEFILE`) ; `cp fichier dossier/` joint le nom ; `mv` refuse l’initrd (rollback) ; répertoires : VFS RAM local |
 | `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM |
-| `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau |
+| `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau (le `>` n’est pas tapable en CI sendkey) |
+| `write` | `write <fichier> <texte>` → overlay (`SYS_WRITEFILE`), sans redirection. Succès : `write ok <fichier>` |
 | `cd` / `pwd` | Chemin shell ; `cd` accepte overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`). Succès : `cd ok <arg>` |
 | `ps` / `jobs` / `top` / `kill` / `spawn` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY (pas de changement de contexte). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`) |
 | `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT |
@@ -126,13 +127,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/rmdir/uptime
+make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/write/rmdir/uptime
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2`, `uptime`, `mkdir mydir`, `cd mydir`, `mkdir sub`, `mv copy.txt notes.txt` et `rmdir mydir` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2`, `uptime`, `mkdir mydir`, `cd mydir`, `mkdir sub`, `mv copy.txt notes.txt`, `cp hello.txt mydir` et `write hi.txt ping` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,7 +51,7 @@
 ### Reste ouvert (hors périmètre « shell qui démarre »)
 - [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
 - [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
-- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` / `mv` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
+- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` / `mv` / `write` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
 - [ ] FS persistant sur disque (l’overlay RAM n’est pas persisté)
 - [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
 - [ ] Réseau, vrai moteur IA — voir roadmap README / dossier `US/`

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -10,7 +10,7 @@ cd "$ROOT"
 
 KERNEL="${KERNEL:-build/ai_os.bin}"
 INITRD="${INITRD:-my_initrd.tar}"
-SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-100}"
+SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-120}"
 
 if [ ! -f "$KERNEL" ] || [ ! -f "$INITRD" ]; then
     echo "ERROR: missing $KERNEL or $INITRD — run 'make all' first"

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -142,7 +142,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/uptime) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/write/uptime) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -313,6 +313,43 @@ def main():
         if "hello.txt" not in after_rm_notes:
             raise RuntimeError("ls after nested/mv missing hello.txt")
 
+        say("typing cp hello.txt mydir ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "c", "p", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t",
+            "spc", "m", "y", "d", "i", "r", "ret",
+        ])
+        wait_needle_from("cp ok hello.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls mydir ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "spc", "m", "y", "d", "i", "r", "ret"])
+        wait_needle_from("hello.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing cd mydir (copied file) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "m", "y", "d", "i", "r", "ret"])
+        wait_needle_from("cd ok mydir", CMD_TIMEOUT, proc, mark)
+
+        say("typing cat hello.txt (in mydir) ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "c", "a", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("demonstration", CMD_TIMEOUT, proc, mark)
+
+        say("typing rm hello.txt (in mydir) ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "r", "m", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("rm ok hello.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing cd .. (after cp into dir) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "dot", "dot", "ret"])
+        wait_needle_from("cd ok ..", CMD_TIMEOUT, proc, mark)
+
         say("typing rmdir mydir ...")
         mark = len(log_text())
         sendkeys(mon, ["r", "m", "d", "i", "r", "spc", "m", "y", "d", "i", "r", "ret"])
@@ -326,6 +363,33 @@ def main():
         after_rmdir_ls = log_text()[mark:]
         if "mydir" in after_rmdir_ls:
             raise RuntimeError("mydir still listed in ls after rmdir")
+
+        say("typing write hi.txt ping ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "w", "r", "i", "t", "e", "spc", "h", "i", "dot", "t", "x", "t",
+            "spc", "p", "i", "n", "g", "ret",
+        ])
+        wait_needle_from("write ok hi.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing cat hi.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "a", "t", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
+        wait_needle_from("ping", CMD_TIMEOUT, proc, mark)
+
+        say("typing rm hi.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, ["r", "m", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
+        wait_needle_from("rm ok hi.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls (after rm hi) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "ret"])
+        wait_needle_from("Initrd / VFS", CMD_TIMEOUT, proc, mark)
+        wait_needle_from("Total:", CMD_TIMEOUT, proc, mark)
+        after_rm_hi = log_text()[mark:]
+        if "hi.txt" in after_rm_hi:
+            raise RuntimeError("hi.txt still listed in ls after rm")
 
         text = log_text()
         checks = [
@@ -352,7 +416,10 @@ def main():
             ("cp overlay", "cp ok copy.txt"),
             ("mv overlay", "mv ok notes.txt"),
             ("rm overlay", "rm ok notes.txt"),
+            ("cp into dir", "cp ok hello.txt"),
             ("rmdir overlay", "rmdir ok mydir"),
+            ("write overlay", "write ok hi.txt"),
+            ("rm write", "rm ok hi.txt"),
         ]
         fail = 0
         for label, needle in checks:

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -497,6 +497,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_colored("\nCOMMANDES UTILITAIRES :\n", COLOR_YELLOW);
     print_string("  clear              - Effacer l'écran\n");
     print_string("  echo <text>        - Afficher du texte\n");
+    print_string("  write <file> <txt> - Ecrire un fichier overlay (sans >)\n");
     print_string("  grep <pattern>     - Rechercher dans un texte\n");
     print_string("  wc <file>          - Compter lignes/mots/caractères\n");
     print_string("  sort <file>        - Trier les lignes\n");
@@ -509,7 +510,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  reboot             - Redémarrer le système\n");
     print_string("  shutdown           - Arrêter le système\n");
     
-    print_colored("\nTIP: ls/cat/mkdir/rm/cp/mv parlent au noyau (initrd + overlay RAM).\n", COLOR_GREEN);
+    print_colored("\nTIP: ls/cat/mkdir/rm/cp/mv/write parlent au noyau (initrd + overlay RAM).\n", COLOR_GREEN);
     print_colored("    Si le mode IA est activé, posez des questions sans 'ai'.\n\n", COLOR_GREEN);
 }
 
@@ -776,6 +777,33 @@ void cmd_echo(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("\n");
 }
 
+void cmd_write(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    char buf[256];
+    int pos = 0;
+    int rc;
+    if (arg_count == 0) {
+        print_error("write: fichier manquant");
+        return;
+    }
+    resolve_arg(ctx, args[0], path);
+    for (int i = 1; i < arg_count; i++) {
+        int j = 0;
+        if (i > 1 && pos < 254) buf[pos++] = ' ';
+        while (args[i][j] && pos < 254) buf[pos++] = args[i][j++];
+    }
+    buf[pos++] = '\n';
+    buf[pos] = '\0';
+    rc = sys_writefile(path, buf, pos);
+    if (rc < 0) {
+        print_fs_err("write", rc);
+        return;
+    }
+    print_string("write ok ");
+    print_string(args[0]);
+    print_string("\n");
+}
+
 void cmd_clear(shell_context_t* ctx, char args[][128], int arg_count) {
     // Séquence ANSI pour effacer l'écran
     print_string("\x1b[2J\x1b[H");
@@ -857,7 +885,7 @@ static void cmd_cat(shell_context_t* ctx, char args[][128], int arg_count) {
 static int is_builtin(const char* cmd) {
     static const char* names[] = {
         "help", "ls", "dir", "ps", "sysinfo", "info", "mem", "memory",
-        "history", "env", "echo", "clear", "cls", "exit", "quit",
+        "history", "env", "echo", "write", "clear", "cls", "exit", "quit",
         "ai", "ai-mode", "ai-help", "ai-test", "ai-stats",
         "cd", "pwd", "cat", "mkdir", "rmdir", "cp", "mv", "rm",
         "kill", "spawn", "jobs", "top", "uptime", "date", "whoami",
@@ -1697,6 +1725,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "echo") == 0) {
         cmd_echo(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "write") == 0) {
+        cmd_write(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "clear") == 0 || strcmp(command, "cls") == 0) {
         cmd_clear(ctx, args, arg_count);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objectif

`echo texte > fichier` écrit déjà dans l’overlay, mais le `>` n’est pas tapable en CI (Shift QEMU). `cp fichier dossier` joignait le nom côté shell sans jamais être exercé sous QEMU.

## Comportement

- Nouveau builtin `write <fichier> <texte>` → `SYS_WRITEFILE`, succès `write ok hi.txt`
- `cp hello.txt mydir` crée `mydir/hello.txt` (overlay)
- `ls mydir` liste le fichier depuis la racine (pas de `/` au clavier)

## CI

Après le parcours nested/mv existant :

1. `cp hello.txt mydir` / `ls mydir` / `cd mydir` / `cat hello.txt` / `rm hello.txt`
2. `rmdir mydir`
3. `write hi.txt ping` / `cat hi.txt` / `rm hi.txt`

Pas de `>` ni `_` au sendkey.

## Tests

Pas de nouveau test unitaire (WRITEFILE déjà couvert). Smoke QEMU = la preuve.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

