### PR TITLE
stat, grep hits et wc ok sur l’overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **105 tests** répartis dans `test_pmm` (17), `test_syscall` (42), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **106 tests** répartis dans `test_pmm` (17), `test_syscall` (43), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (overlay write/cp-into-dir + nested mkdir/mv ; CI sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/write/rmdir/uptime)  
+**Code de référence :** `master` (stat/grep/wc overlay + write/cp-into-dir ; CI sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -57,7 +57,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 42/42 |
+| `test_syscall` | 43/43 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
@@ -68,7 +68,7 @@ Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `cp`/`mv` de répertoires restent un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `grep` / `wc` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `cp`/`mv` de répertoires restent un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
@@ -76,7 +76,8 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `ls` / `dir` | Listing **initrd + overlay** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
 | `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l’initrd ne peut pas être modifié (`PROTECTED`) ; `rmdir` d’un dossier non vide échoue (`NOTEMPTY`) |
 | `cp` / `mv` | Copie overlay (`SYS_READFILE` + `SYS_WRITEFILE`) ; `cp fichier dossier/` joint le nom ; `mv` refuse l’initrd (rollback) ; répertoires : VFS RAM local |
-| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM |
+| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM. `grep` affiche `grep hits N` ; `wc` affiche `wc ok L W C fichier` |
+| `stat` | Type et taille (`SYS_STAT`) : `stat file hello.txt 35` / `stat dir mydir 0` |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau (le `>` n’est pas tapable en CI sendkey) |
 | `write` | `write <fichier> <texte>` → overlay (`SYS_WRITEFILE`), sans redirection. Succès : `write ok <fichier>` |
 | `cd` / `pwd` | Chemin shell ; `cd` accepte overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`). Succès : `cd ok <arg>` |
@@ -133,7 +134,7 @@ make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2`, `uptime`, `mkdir mydir`, `cd mydir`, `mkdir sub`, `mv copy.txt notes.txt`, `cp hello.txt mydir` et `write hi.txt ping` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat hello.txt`, `stat mydir`, `grep ping hi.txt` et `wc hi.txt` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -142,7 +142,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/write/uptime) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -162,6 +162,9 @@ def main():
             ("cat hello.txt",
              ["c", "a", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret"],
              "demonstration"),
+            ("stat hello.txt",
+             ["s", "t", "a", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret"],
+             "stat file hello.txt"),
             ("ls bin", ["l", "s", "spc", "b", "i", "n", "ret"], "fake_ai"),
             ("ps", ["p", "s", "ret"], "Processus (noyau)"),
         ]
@@ -201,6 +204,11 @@ def main():
         mark = len(log_text())
         sendkeys(mon, ["m", "k", "d", "i", "r", "spc", "m", "y", "d", "i", "r", "ret"])
         wait_needle_from("mkdir ok mydir", CMD_TIMEOUT, proc, mark)
+
+        say("typing stat mydir ...")
+        mark = len(log_text())
+        sendkeys(mon, ["s", "t", "a", "t", "spc", "m", "y", "d", "i", "r", "ret"])
+        wait_needle_from("stat dir mydir", CMD_TIMEOUT, proc, mark)
 
         say("typing cd mydir ...")
         mark = len(log_text())
@@ -377,6 +385,19 @@ def main():
         sendkeys(mon, ["c", "a", "t", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
         wait_needle_from("ping", CMD_TIMEOUT, proc, mark)
 
+        say("typing grep ping hi.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "g", "r", "e", "p", "spc", "p", "i", "n", "g", "spc",
+            "h", "i", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("grep hits 1", CMD_TIMEOUT, proc, mark)
+
+        say("typing wc hi.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, ["w", "c", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
+        wait_needle_from("wc ok 1 1 5 hi.txt", CMD_TIMEOUT, proc, mark)
+
         say("typing rm hi.txt ...")
         mark = len(log_text())
         sendkeys(mon, ["r", "m", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
@@ -419,7 +440,11 @@ def main():
             ("cp into dir", "cp ok hello.txt"),
             ("rmdir overlay", "rmdir ok mydir"),
             ("write overlay", "write ok hi.txt"),
+            ("grep overlay", "grep hits 1"),
+            ("wc overlay", "wc ok 1 1 5 hi.txt"),
             ("rm write", "rm ok hi.txt"),
+            ("stat file", "stat file hello.txt"),
+            ("stat dir", "stat dir mydir"),
         ]
         fail = 0
         for label, needle in checks:

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -89,6 +89,10 @@ def monitor_connect(retries=50):
 def sendkeys(mon, keys):
     for k in keys:
         mon.sendall(("sendkey %s\n" % k).encode("ascii"))
+        try:
+            mon.recv(8192)
+        except socket.timeout:
+            pass
         time.sleep(0.12)
 
 
@@ -187,6 +191,7 @@ def main():
         mark = len(log_text())
         sendkeys(mon, ["k", "i", "l", "l", "spc", "2", "ret"])
         wait_needle_from("Processus 2 termine", CMD_TIMEOUT, proc, mark)
+        time.sleep(0.3)
 
         say("typing ps (after kill) ...")
         mark = len(log_text())

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -738,6 +738,33 @@ void test_sys_overlay_protects_initrd(void) {
     TEST_ASSERT_EQUAL(OV_ERR_NOTDIR, (int)cpu.eax);
 }
 
+void test_sys_stat_initrd_file_and_overlay_dir(void) {
+    os_dirent_t st;
+    cpu_state_t cpu = {0};
+
+    overlay_init();
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"hello.txt";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_FILE, (int)st.flags);
+    TEST_ASSERT_EQUAL(18, (int)st.size);
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"mydir";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"mydir";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_DIR, (int)st.flags);
+}
+
 void test_sys_overlay_copy_from_initrd(void) {
     char src[64];
     char dst[64];
@@ -915,6 +942,7 @@ int main(void) {
     RUN_TEST(test_sys_overlay_mkdir_listdir_unlink);
     RUN_TEST(test_sys_overlay_write_read);
     RUN_TEST(test_sys_overlay_protects_initrd);
+    RUN_TEST(test_sys_stat_initrd_file_and_overlay_dir);
     RUN_TEST(test_sys_overlay_copy_from_initrd);
     RUN_TEST(test_sys_overlay_nested_mkdir_notempty);
     

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -458,6 +458,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_colored("COMMANDES SYSTÈME :\n", COLOR_YELLOW);
     print_string("  ls [path]          - Lister initrd + overlay noyau\n");
     print_string("  cat <file>         - Afficher un fichier (overlay puis initrd)\n");
+    print_string("  stat <path>        - Type et taille (syscall SYS_STAT)\n");
     print_string("  cd <path>          - Changer de répertoire\n");
     print_string("  pwd                - Afficher le répertoire courant\n");
     print_string("  mkdir <dir>        - Créer un répertoire (overlay noyau)\n");
@@ -804,6 +805,36 @@ void cmd_write(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("\n");
 }
 
+static void cmd_stat(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    os_dirent_t st;
+    int size = 0;
+    int is_dir = 0;
+    if (arg_count == 0) {
+        print_error("stat: chemin manquant");
+        return;
+    }
+    resolve_arg(ctx, args[0], path);
+    if (sys_stat(path, &st) == 0) {
+        is_dir = (st.flags == OS_DIRENT_DIR);
+        size = (int)st.size;
+    } else if (ramfs_is_dir(path)) {
+        is_dir = 1;
+        size = 0;
+    } else if (ramfs_is_file(path)) {
+        if (!ramfs_read(path, &size)) size = 0;
+        is_dir = 0;
+    } else {
+        print_error("stat: introuvable");
+        return;
+    }
+    print_string(is_dir ? "stat dir " : "stat file ");
+    print_string(args[0]);
+    print_string(" ");
+    print_int(size);
+    print_string("\n");
+}
+
 void cmd_clear(shell_context_t* ctx, char args[][128], int arg_count) {
     // Séquence ANSI pour effacer l'écran
     print_string("\x1b[2J\x1b[H");
@@ -887,7 +918,7 @@ static int is_builtin(const char* cmd) {
         "help", "ls", "dir", "ps", "sysinfo", "info", "mem", "memory",
         "history", "env", "echo", "write", "clear", "cls", "exit", "quit",
         "ai", "ai-mode", "ai-help", "ai-test", "ai-stats",
-        "cd", "pwd", "cat", "mkdir", "rmdir", "cp", "mv", "rm",
+        "cd", "pwd", "cat", "stat", "mkdir", "rmdir", "cp", "mv", "rm",
         "kill", "spawn", "jobs", "top", "uptime", "date", "whoami",
         "alias", "unalias", "export", "which",
         "grep", "wc", "sort", "head", "tail",
@@ -1407,7 +1438,11 @@ static void cmd_grep(shell_context_t* ctx, char args[][128], int arg_count) {
     }
     if (hits == 0) {
         print_string("(aucune correspondance)\n");
+        return;
     }
+    print_string("grep hits ");
+    print_int(hits);
+    print_string("\n");
 }
 
 static void cmd_wc(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -1444,13 +1479,14 @@ static void cmd_wc(shell_context_t* ctx, char args[][128], int arg_count) {
             words++;
         }
     }
+    print_string("wc ok ");
     print_int(lines);
     print_string(" ");
     print_int(words);
     print_string(" ");
     print_int(chars);
     print_string(" ");
-    print_string(path);
+    print_string(args[0]);
     print_string("\n");
 }
 
@@ -1740,6 +1776,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "cat") == 0) {
         cmd_cat(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "stat") == 0) {
+        cmd_stat(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "which") == 0) {
         if (arg_count == 0) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objectif

`SYS_STAT` servait à `cd` mais n’était pas une commande. `grep`/`wc` lisaient déjà l’overlay, sans aiguille CI unique (le motif tapé se retrouve dans `SYS_GETS`).

## Comportement

- `stat hello.txt` → `stat file hello.txt 35`
- `stat mydir` → `stat dir mydir 0`
- `grep ping hi.txt` → ligne + `grep hits 1`
- `wc hi.txt` → `wc ok 1 1 5 hi.txt` (`write hi.txt ping` = `ping\n`)

## CI

Après `cat hello.txt` : `stat hello.txt`. Après `mkdir mydir` : `stat mydir`. Après `write`/`cat` : `grep` + `wc`.

Le smoke vide maintenant le socket moniteur QEMU après chaque `sendkey` (sinon les touches se dupliquent : `pps`, `wrrite`).

## Tests

`test_syscall` 43/43 : STAT sur `hello.txt` (initrd) et `mydir` (overlay). `make qemu-smoke` OK (~50 s).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

