### PR TITLE
Overlay : SYS_RENAME pour mv de dossiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make run-gui
 - **🤖 Simulateur d'IA Intégré** - Réponses préprogrammées par mots-clés (`fake_ai.c`), pas un modèle ML
 - **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
 - **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
-- **💾 Système de Fichiers** - Initrd TAR en lecture seule + overlay RAM (`mkdir`/`rm`). Pas de disque persistant. `ls` fusionne les deux via `SYS_LISTDIR`.
+- **💾 Système de Fichiers** - Initrd TAR en lecture seule + overlay RAM (`mkdir`/`rm`/`mv` fichier et dossier). Pas de disque persistant. `ls` fusionne les deux via `SYS_LISTDIR`.
 - **🧠 Gestion Mémoire** - VMM/PMM avec paging (cible ~128 MB RAM sous QEMU)
 - **🔌 Gestion Interruptions** - PIC, clavier PS/2, timer PIT
 
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **106 tests** répartis dans `test_pmm` (17), `test_syscall` (43), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **107 tests** répartis dans `test_pmm` (17), `test_syscall` (44), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash
@@ -177,7 +177,7 @@ ai-os/
 - ✅ **Interruptions clavier (IRQ1) générées par QEMU**
 - ✅ **Fin des boucles infinies** sur appels système
 - ✅ **IA accessible** via interface clavier
-- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `cp`, `grep`, `kill`, `top`, `ai`, etc. — `ls`/`mkdir`/`rm`/`cp`/`mv`/`ps`/`kill`/`mem` via syscalls noyau, voir `docs/ETAT_REEL.md`)
+- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `cp`, `grep`, `kill`, `top`, `ai`, etc. — `ls`/`mkdir`/`rm`/`cp`/`mv` (dont dossiers overlay)/`ps`/`kill`/`mem` via syscalls noyau, voir `docs/ETAT_REEL.md`)
 
 ### ✅ Corrections Antérieures
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **105 tests** répartis dans `test_pmm` (17), `test_syscall` (42), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **106 tests** répartis dans `test_pmm` (17), `test_syscall` (43), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (overlay write/cp-into-dir + nested mkdir/mv ; CI sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/write/rmdir/uptime)  
+**Code de référence :** `master` (stat/grep/wc overlay + write/cp-into-dir ; CI sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -57,7 +57,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 42/42 |
+| `test_syscall` | 43/43 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
@@ -68,7 +68,7 @@ Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `cp`/`mv` de répertoires restent un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `grep` / `wc` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `cp`/`mv` de répertoires restent un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
@@ -76,7 +76,8 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `ls` / `dir` | Listing **initrd + overlay** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
 | `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l’initrd ne peut pas être modifié (`PROTECTED`) ; `rmdir` d’un dossier non vide échoue (`NOTEMPTY`) |
 | `cp` / `mv` | Copie overlay (`SYS_READFILE` + `SYS_WRITEFILE`) ; `cp fichier dossier/` joint le nom ; `mv` refuse l’initrd (rollback) ; répertoires : VFS RAM local |
-| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM |
+| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM. `grep` affiche `grep hits N` ; `wc` affiche `wc ok L W C fichier` |
+| `stat` | Type et taille (`SYS_STAT`) : `stat file hello.txt 35` / `stat dir mydir 0` |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau (le `>` n’est pas tapable en CI sendkey) |
 | `write` | `write <fichier> <texte>` → overlay (`SYS_WRITEFILE`), sans redirection. Succès : `write ok <fichier>` |
 | `cd` / `pwd` | Chemin shell ; `cd` accepte overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`). Succès : `cd ok <arg>` |
@@ -133,7 +134,7 @@ make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape `ls`, `cat hello.txt`, `ls bin`, `ps`, `spawn idle`, `kill 2`, `uptime`, `mkdir mydir`, `cd mydir`, `mkdir sub`, `mv copy.txt notes.txt`, `cp hello.txt mydir` et `write hi.txt ping` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat hello.txt`, `stat mydir`, `grep ping hi.txt` et `wc hi.txt` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (stat/grep/wc overlay + write/cp-into-dir ; CI sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc)  
+**Code de référence :** `master` (overlay SYS_RENAME : mv fichier et dossier ; CI sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -30,8 +30,8 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - Initrd format TAR POSIX (`fs/initrd.c`)
 - Chargeur ELF 32-bit
 - Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
-- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT` (ABI : `include/os_syscalls.h`)
-- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (y compris vers un dossier) / `mv` / `write` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
+- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME` (ABI : `include/os_syscalls.h`)
+- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (y compris vers un dossier) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
 
 ### Espace utilisateur
 
@@ -57,7 +57,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 43/43 |
+| `test_syscall` | 44/44 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
@@ -68,14 +68,14 @@ Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `grep` / `wc` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `cp`/`mv` de répertoires restent un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `grep` / `wc` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `cp` de répertoires reste un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
 | `help` | Aide |
 | `ls` / `dir` | Listing **initrd + overlay** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
 | `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l’initrd ne peut pas être modifié (`PROTECTED`) ; `rmdir` d’un dossier non vide échoue (`NOTEMPTY`) |
-| `cp` / `mv` | Copie overlay (`SYS_READFILE` + `SYS_WRITEFILE`) ; `cp fichier dossier/` joint le nom ; `mv` refuse l’initrd (rollback) ; répertoires : VFS RAM local |
+| `cp` / `mv` | `cp` copie overlay (`SYS_READFILE` + `SYS_WRITEFILE`) ; `cp fichier dossier/` joint le nom. `mv` appelle `SYS_RENAME` (fichier ou dossier, enfants réécrits) ; l’initrd reste `PROTECTED` ; dossiers absents du noyau : VFS RAM local |
 | `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM. `grep` affiche `grep hits N` ; `wc` affiche `wc ok L W C fichier` |
 | `stat` | Type et taille (`SYS_STAT`) : `stat file hello.txt 35` / `stat dir mydir 0` |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau (le `>` n’est pas tapable en CI sendkey) |
@@ -128,13 +128,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/write/rmdir/uptime
+make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv (fichier et dossier)/write/rmdir/uptime
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat hello.txt`, `stat mydir`, `grep ping hi.txt` et `wc hi.txt` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `grep`, `wc` et `mv mydir newd` (rename overlay avec enfant) via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,7 +51,7 @@
 ### Reste ouvert (hors périmètre « shell qui démarre »)
 - [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
 - [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
-- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` / `mv` / `write` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
+- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
 - [ ] FS persistant sur disque (l’overlay RAM n’est pas persisté)
 - [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
 - [ ] Réseau, vrai moteur IA — voir roadmap README / dossier `US/`

--- a/fs/overlay.c
+++ b/fs/overlay.c
@@ -265,6 +265,67 @@ int overlay_unlink(const char* path) {
     return OV_OK;
 }
 
+static int ov_under(const char* path, const char* prefix, int plen) {
+    int i = 0;
+    while (i < plen && path[i] == prefix[i]) i++;
+    if (i != plen) return 0;
+    return path[plen] == '\0' || path[plen] == '/';
+}
+
+int overlay_rename(const char* oldpath, const char* newpath) {
+    char oldp[OV_PATH_MAX];
+    char newp[OV_PATH_MAX];
+    int oldn;
+    int newn;
+    int i;
+
+    ov_normalize(oldpath, oldp, OV_PATH_MAX);
+    ov_normalize(newpath, newp, OV_PATH_MAX);
+    if (!oldp[0] || !newp[0]) return OV_ERR_INVAL;
+    if (ov_eq(oldp, newp)) return OV_OK;
+
+    if (!ov_find(oldp)) {
+        if (initrd_is_file(oldp) || initrd_is_dir(oldp)) return OV_ERR_PROTECTED;
+        return OV_ERR_NOTFOUND;
+    }
+    if (ov_find(newp)) return OV_ERR_EXISTS;
+    if (initrd_is_file(newp) || initrd_is_dir(newp)) return OV_ERR_EXISTS;
+    if (!ov_parent_is_dir(newp)) return OV_ERR_NOTDIR;
+
+    oldn = ov_len(oldp);
+    newn = ov_len(newp);
+    if (ov_under(newp, oldp, oldn) && newp[oldn] == '/') return OV_ERR_INVAL;
+
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        int rest;
+        if (!g_ov[i].used) continue;
+        if (!ov_under(g_ov[i].path, oldp, oldn)) continue;
+        rest = ov_len(g_ov[i].path) - oldn;
+        if (newn + rest >= OV_PATH_MAX) return OV_ERR_INVAL;
+    }
+
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        char rest[OV_PATH_MAX];
+        int r = 0;
+        if (!g_ov[i].used) continue;
+        if (!ov_under(g_ov[i].path, oldp, oldn)) continue;
+        while (g_ov[i].path[oldn + r]) {
+            rest[r] = g_ov[i].path[oldn + r];
+            r++;
+        }
+        rest[r] = '\0';
+        ov_copy(g_ov[i].path, newp, OV_PATH_MAX);
+        {
+            int k;
+            for (k = 0; rest[k] && newn + k < OV_PATH_MAX - 1; k++) {
+                g_ov[i].path[newn + k] = rest[k];
+            }
+            g_ov[i].path[newn + k] = '\0';
+        }
+    }
+    return OV_OK;
+}
+
 int overlay_listdir(const char* path, os_dirent_t* out, int start, int max_n) {
     char prefix[OV_PATH_MAX];
     int count = start;

--- a/fs/overlay.h
+++ b/fs/overlay.h
@@ -18,6 +18,7 @@ void overlay_init(void);
 int overlay_mkdir(const char* path);
 int overlay_write(const char* path, const char* data, uint32_t n);
 int overlay_unlink(const char* path);
+int overlay_rename(const char* oldpath, const char* newpath);
 int overlay_read(const char* path, char* buf, uint32_t max);
 int overlay_stat(const char* path, os_dirent_t* out);
 int overlay_listdir(const char* path, os_dirent_t* out, int start, int max_n);

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -24,8 +24,9 @@
 #define SYS_UNLINK   16
 #define SYS_WRITEFILE 17
 #define SYS_STAT     18
+#define SYS_RENAME   19
 
-#define MAX_SYSCALLS 19
+#define MAX_SYSCALLS 20
 
 #define OS_NAME_MAX 64
 #define OS_PROC_NAME_MAX 32

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -134,6 +134,9 @@ void syscall_handler(cpu_state_t* cpu) {
         case SYS_STAT:
             cpu->eax = (uint32_t)sys_stat((const char*)cpu->ebx, (os_dirent_t*)cpu->ecx);
             break;
+        case SYS_RENAME:
+            cpu->eax = (uint32_t)sys_rename((const char*)cpu->ebx, (const char*)cpu->ecx);
+            break;
             
         default:
             // Syscall inconnu
@@ -312,6 +315,11 @@ int sys_stat(const char* path, os_dirent_t* out) {
     if (!path || !out) return -1;
     if (overlay_stat(path, out) == OV_OK) return 0;
     return initrd_stat(path, out);
+}
+
+int sys_rename(const char* oldpath, const char* newpath) {
+    if (!oldpath || !newpath) return -1;
+    return overlay_rename(oldpath, newpath);
 }
 
 int sys_getpid(void) {

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -33,6 +33,7 @@ int sys_mkdir(const char* path);
 int sys_unlink(const char* path);
 int sys_writefile(const char* path, const char* buf, uint32_t n);
 int sys_stat(const char* path, os_dirent_t* out);
+int sys_rename(const char* oldpath, const char* newpath);
 
 void keyboard_add_char_to_buffer(char c);
 

--- a/tests/framework/kernel_mocks.c
+++ b/tests/framework/kernel_mocks.c
@@ -443,6 +443,11 @@ int sys_stat(const char* path, os_dirent_t* out) {
     return initrd_stat(path, out);
 }
 
+int sys_rename(const char* oldpath, const char* newpath) {
+    if (!oldpath || !newpath) return -1;
+    return overlay_rename(oldpath, newpath);
+}
+
 int sys_getpid(void) {
     return current_task ? current_task->id : 0;
 }
@@ -542,6 +547,9 @@ void syscall_handler(cpu_state_t* state) {
             break;
         case SYS_STAT:
             state->eax = (uint32_t)sys_stat((const char*)state->ebx, (os_dirent_t*)state->ecx);
+            break;
+        case SYS_RENAME:
+            state->eax = (uint32_t)sys_rename((const char*)state->ebx, (const char*)state->ecx);
             break;
         default:
             break;

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -10,7 +10,7 @@ cd "$ROOT"
 
 KERNEL="${KERNEL:-build/ai_os.bin}"
 INITRD="${INITRD:-my_initrd.tar}"
-SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-120}"
+SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-180}"
 
 if [ ! -f "$KERNEL" ] || [ ! -f "$INITRD" ]; then
     echo "ERROR: missing $KERNEL or $INITRD — run 'make all' first"

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -142,7 +142,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv/write/uptime) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -162,6 +162,9 @@ def main():
             ("cat hello.txt",
              ["c", "a", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret"],
              "demonstration"),
+            ("stat hello.txt",
+             ["s", "t", "a", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret"],
+             "stat file hello.txt"),
             ("ls bin", ["l", "s", "spc", "b", "i", "n", "ret"], "fake_ai"),
             ("ps", ["p", "s", "ret"], "Processus (noyau)"),
         ]
@@ -201,6 +204,11 @@ def main():
         mark = len(log_text())
         sendkeys(mon, ["m", "k", "d", "i", "r", "spc", "m", "y", "d", "i", "r", "ret"])
         wait_needle_from("mkdir ok mydir", CMD_TIMEOUT, proc, mark)
+
+        say("typing stat mydir ...")
+        mark = len(log_text())
+        sendkeys(mon, ["s", "t", "a", "t", "spc", "m", "y", "d", "i", "r", "ret"])
+        wait_needle_from("stat dir mydir", CMD_TIMEOUT, proc, mark)
 
         say("typing cd mydir ...")
         mark = len(log_text())
@@ -377,6 +385,19 @@ def main():
         sendkeys(mon, ["c", "a", "t", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
         wait_needle_from("ping", CMD_TIMEOUT, proc, mark)
 
+        say("typing grep ping hi.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "g", "r", "e", "p", "spc", "p", "i", "n", "g", "spc",
+            "h", "i", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("grep hits 1", CMD_TIMEOUT, proc, mark)
+
+        say("typing wc hi.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, ["w", "c", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
+        wait_needle_from("wc ok 1 1 5 hi.txt", CMD_TIMEOUT, proc, mark)
+
         say("typing rm hi.txt ...")
         mark = len(log_text())
         sendkeys(mon, ["r", "m", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
@@ -419,7 +440,11 @@ def main():
             ("cp into dir", "cp ok hello.txt"),
             ("rmdir overlay", "rmdir ok mydir"),
             ("write overlay", "write ok hi.txt"),
+            ("grep overlay", "grep hits 1"),
+            ("wc overlay", "wc ok 1 1 5 hi.txt"),
             ("rm write", "rm ok hi.txt"),
+            ("stat file", "stat file hello.txt"),
+            ("stat dir", "stat dir mydir"),
         ]
         fail = 0
         for label, needle in checks:

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -89,6 +89,10 @@ def monitor_connect(retries=50):
 def sendkeys(mon, keys):
     for k in keys:
         mon.sendall(("sendkey %s\n" % k).encode("ascii"))
+        try:
+            mon.recv(8192)
+        except socket.timeout:
+            pass
         time.sleep(0.12)
 
 
@@ -187,6 +191,7 @@ def main():
         mark = len(log_text())
         sendkeys(mon, ["k", "i", "l", "l", "spc", "2", "ret"])
         wait_needle_from("Processus 2 termine", CMD_TIMEOUT, proc, mark)
+        time.sleep(0.3)
 
         say("typing ps (after kill) ...")
         mark = len(log_text())

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -146,7 +146,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc/rename-dir) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -339,34 +339,49 @@ def main():
         sendkeys(mon, ["l", "s", "spc", "m", "y", "d", "i", "r", "ret"])
         wait_needle_from("hello.txt", CMD_TIMEOUT, proc, mark)
 
-        say("typing cd mydir (copied file) ...")
-        mark = len(log_text())
-        sendkeys(mon, ["c", "d", "spc", "m", "y", "d", "i", "r", "ret"])
-        wait_needle_from("cd ok mydir", CMD_TIMEOUT, proc, mark)
-
-        say("typing cat hello.txt (in mydir) ...")
+        say("typing mv mydir newd ...")
         mark = len(log_text())
         sendkeys(mon, [
-            "c", "a", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
+            "m", "v", "spc", "m", "y", "d", "i", "r", "spc", "n", "e", "w", "d", "ret",
+        ])
+        wait_needle_from("mv ok newd", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls (after mv dir) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "ret"])
+        wait_needle_from("Initrd / VFS", CMD_TIMEOUT, proc, mark)
+        wait_needle_from("Total:", CMD_TIMEOUT, proc, mark)
+        after_mv_dir = log_text()[mark:]
+        if "mydir" in after_mv_dir:
+            raise RuntimeError("mydir still listed after mv mydir newd")
+        if "newd" not in after_mv_dir:
+            raise RuntimeError("ls after mv dir missing newd")
+
+        say("typing ls newd ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "spc", "n", "e", "w", "d", "ret"])
+        wait_needle_from("hello.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing cat newd/hello.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "c", "a", "t", "spc", "n", "e", "w", "d", "slash",
+            "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
         ])
         wait_needle_from("demonstration", CMD_TIMEOUT, proc, mark)
 
-        say("typing rm hello.txt (in mydir) ...")
+        say("typing rm newd/hello.txt ...")
         mark = len(log_text())
         sendkeys(mon, [
-            "r", "m", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
+            "r", "m", "spc", "n", "e", "w", "d", "slash",
+            "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
         ])
         wait_needle_from("rm ok hello.txt", CMD_TIMEOUT, proc, mark)
 
-        say("typing cd .. (after cp into dir) ...")
+        say("typing rmdir newd ...")
         mark = len(log_text())
-        sendkeys(mon, ["c", "d", "spc", "dot", "dot", "ret"])
-        wait_needle_from("cd ok ..", CMD_TIMEOUT, proc, mark)
-
-        say("typing rmdir mydir ...")
-        mark = len(log_text())
-        sendkeys(mon, ["r", "m", "d", "i", "r", "spc", "m", "y", "d", "i", "r", "ret"])
-        wait_needle_from("rmdir ok mydir", CMD_TIMEOUT, proc, mark)
+        sendkeys(mon, ["r", "m", "d", "i", "r", "spc", "n", "e", "w", "d", "ret"])
+        wait_needle_from("rmdir ok newd", CMD_TIMEOUT, proc, mark)
 
         say("typing ls (after rmdir) ...")
         mark = len(log_text())
@@ -376,6 +391,8 @@ def main():
         after_rmdir_ls = log_text()[mark:]
         if "mydir" in after_rmdir_ls:
             raise RuntimeError("mydir still listed in ls after rmdir")
+        if "newd" in after_rmdir_ls:
+            raise RuntimeError("newd still listed in ls after rmdir")
 
         say("typing write hi.txt ping ...")
         mark = len(log_text())
@@ -443,7 +460,8 @@ def main():
             ("mv overlay", "mv ok notes.txt"),
             ("rm overlay", "rm ok notes.txt"),
             ("cp into dir", "cp ok hello.txt"),
-            ("rmdir overlay", "rmdir ok mydir"),
+            ("mv overlay dir", "mv ok newd"),
+            ("rmdir overlay", "rmdir ok newd"),
             ("write overlay", "write ok hi.txt"),
             ("grep overlay", "grep hits 1"),
             ("wc overlay", "wc ok 1 1 5 hi.txt"),

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -86,14 +86,23 @@ def monitor_connect(retries=50):
     raise RuntimeError("cannot connect to QEMU monitor: %s" % last)
 
 
+def drain_monitor(mon):
+    """Read HMP replies until the socket is quiet so sendkey commands do not pile up."""
+    mon.settimeout(0.05)
+    while True:
+        try:
+            data = mon.recv(8192)
+            if not data:
+                break
+        except socket.timeout:
+            break
+
+
 def sendkeys(mon, keys):
     for k in keys:
         mon.sendall(("sendkey %s\n" % k).encode("ascii"))
-        try:
-            mon.recv(8192)
-        except socket.timeout:
-            pass
-        time.sleep(0.12)
+        drain_monitor(mon)
+        time.sleep(0.16)
 
 
 def dump_logs():
@@ -469,6 +478,7 @@ def main():
             ("rm overlay", "rm ok notes.txt"),
             ("cp into dir", "cp ok hello.txt"),
             ("mv overlay dir", "mv ok newd"),
+            ("cd renamed dir", "cd ok newd"),
             ("rmdir overlay", "rmdir ok newd"),
             ("write overlay", "write ok hi.txt"),
             ("grep overlay", "grep hits 1"),

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -362,21 +362,29 @@ def main():
         sendkeys(mon, ["l", "s", "spc", "n", "e", "w", "d", "ret"])
         wait_needle_from("hello.txt", CMD_TIMEOUT, proc, mark)
 
-        say("typing cat newd/hello.txt ...")
+        say("typing cd newd ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "n", "e", "w", "d", "ret"])
+        wait_needle_from("cd ok newd", CMD_TIMEOUT, proc, mark)
+
+        say("typing cat hello.txt (in newd) ...")
         mark = len(log_text())
         sendkeys(mon, [
-            "c", "a", "t", "spc", "n", "e", "w", "d", "slash",
-            "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
+            "c", "a", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
         ])
         wait_needle_from("demonstration", CMD_TIMEOUT, proc, mark)
 
-        say("typing rm newd/hello.txt ...")
+        say("typing rm hello.txt (in newd) ...")
         mark = len(log_text())
         sendkeys(mon, [
-            "r", "m", "spc", "n", "e", "w", "d", "slash",
-            "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
+            "r", "m", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
         ])
         wait_needle_from("rm ok hello.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing cd .. (after mv dir) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "dot", "dot", "ret"])
+        wait_needle_from("cd ok ..", CMD_TIMEOUT, proc, mark)
 
         say("typing rmdir newd ...")
         mark = len(log_text())

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -738,6 +738,33 @@ void test_sys_overlay_protects_initrd(void) {
     TEST_ASSERT_EQUAL(OV_ERR_NOTDIR, (int)cpu.eax);
 }
 
+void test_sys_stat_initrd_file_and_overlay_dir(void) {
+    os_dirent_t st;
+    cpu_state_t cpu = {0};
+
+    overlay_init();
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"hello.txt";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_FILE, (int)st.flags);
+    TEST_ASSERT_EQUAL(18, (int)st.size);
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"mydir";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"mydir";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_DIR, (int)st.flags);
+}
+
 void test_sys_overlay_copy_from_initrd(void) {
     char src[64];
     char dst[64];
@@ -915,6 +942,7 @@ int main(void) {
     RUN_TEST(test_sys_overlay_mkdir_listdir_unlink);
     RUN_TEST(test_sys_overlay_write_read);
     RUN_TEST(test_sys_overlay_protects_initrd);
+    RUN_TEST(test_sys_stat_initrd_file_and_overlay_dir);
     RUN_TEST(test_sys_overlay_copy_from_initrd);
     RUN_TEST(test_sys_overlay_nested_mkdir_notempty);
     

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -884,6 +884,135 @@ void test_sys_overlay_nested_mkdir_notempty(void) {
     TEST_ASSERT_EQUAL(0, (int)cpu.eax);
 }
 
+void test_sys_overlay_rename_file_and_dir(void) {
+    char payload[] = "renamed\n";
+    char buf[32];
+    os_dirent_t ents[16];
+    os_dirent_t st;
+    cpu_state_t cpu = {0};
+    int n;
+    int found_old;
+    int found_new;
+    int found_child;
+    int i;
+
+    overlay_init();
+
+    cpu.eax = SYS_WRITEFILE;
+    cpu.ebx = (uint32_t)"a.txt";
+    cpu.ecx = (uint32_t)payload;
+    cpu.edx = 8;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(8, (int)cpu.eax);
+
+    cpu.eax = SYS_RENAME;
+    cpu.ebx = (uint32_t)"a.txt";
+    cpu.ecx = (uint32_t)"b.txt";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"b.txt";
+    cpu.ecx = (uint32_t)buf;
+    cpu.edx = sizeof(buf);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(8, (int)cpu.eax);
+    buf[8] = '\0';
+    TEST_ASSERT_EQUAL_STRING("renamed\n", buf);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"a.txt";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(-1, (int)cpu.eax);
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"oldd";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"oldd/sub";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_WRITEFILE;
+    cpu.ebx = (uint32_t)"oldd/sub/f.txt";
+    cpu.ecx = (uint32_t)payload;
+    cpu.edx = 8;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(8, (int)cpu.eax);
+
+    cpu.eax = SYS_RENAME;
+    cpu.ebx = (uint32_t)"oldd";
+    cpu.ecx = (uint32_t)"newd";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"newd";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_DIR, (int)st.flags);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"oldd";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(-1, (int)cpu.eax);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"/";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 16;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    found_old = 0;
+    found_new = 0;
+    for (i = 0; i < n; i++) {
+        if (strcmp(ents[i].name, "oldd") == 0) found_old = 1;
+        if (strcmp(ents[i].name, "newd") == 0) found_new = 1;
+    }
+    TEST_ASSERT_EQUAL(0, found_old);
+    TEST_ASSERT(found_new);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"newd";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 16;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    found_child = 0;
+    for (i = 0; i < n; i++) {
+        if (strcmp(ents[i].name, "sub") == 0 && ents[i].flags == OS_DIRENT_DIR) {
+            found_child = 1;
+        }
+    }
+    TEST_ASSERT(found_child);
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"newd/sub/f.txt";
+    cpu.ecx = (uint32_t)buf;
+    cpu.edx = sizeof(buf);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(8, (int)cpu.eax);
+    buf[8] = '\0';
+    TEST_ASSERT_EQUAL_STRING("renamed\n", buf);
+
+    cpu.eax = SYS_RENAME;
+    cpu.ebx = (uint32_t)"hello.txt";
+    cpu.ecx = (uint32_t)"moved.txt";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_PROTECTED, (int)cpu.eax);
+
+    cpu.eax = SYS_RENAME;
+    cpu.ebx = (uint32_t)"newd";
+    cpu.ecx = (uint32_t)"newd/nested";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_INVAL, (int)cpu.eax);
+}
+
 // === RUNNER PRINCIPAL ===
 
 int main(void) {
@@ -945,6 +1074,7 @@ int main(void) {
     RUN_TEST(test_sys_stat_initrd_file_and_overlay_dir);
     RUN_TEST(test_sys_overlay_copy_from_initrd);
     RUN_TEST(test_sys_overlay_nested_mkdir_notempty);
+    RUN_TEST(test_sys_overlay_rename_file_and_dir);
     
     unity_print_results();
     unity_cleanup();

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -168,6 +168,12 @@ int sys_stat(const char* path, os_dirent_t* out) {
     return result;
 }
 
+int sys_rename(const char* oldpath, const char* newpath) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_RENAME), "b"(oldpath), "c"(newpath));
+    return result;
+}
+
 static void print_fs_err(const char* cmd, int rc);
 
 // ==============================================================================
@@ -464,7 +470,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  mkdir <dir>        - Créer un répertoire (overlay noyau)\n");
     print_string("  rmdir <dir>        - Supprimer un répertoire vide\n");
     print_string("  cp <src> <dest>    - Copier un fichier (overlay noyau)\n");
-    print_string("  mv <src> <dest>    - Déplacer un fichier overlay\n");
+    print_string("  mv <src> <dest>    - Deplacer fichier ou dossier overlay\n");
     print_string("  rm <file>          - Supprimer un fichier\n");
     
     print_colored("\nCOMMANDES PROCESSUS :\n", COLOR_YELLOW);
@@ -1105,21 +1111,12 @@ static void cmd_mv(shell_context_t* ctx, char args[][128], int arg_count) {
     resolve_arg(ctx, args[0], src);
     resolve_arg(ctx, args[1], dst);
     if (sys_stat(src, &st) == 0) {
-        if (st.flags == OS_DIRENT_DIR) {
-            print_error("mv: repertoire non supporte");
-            return;
+        if (sys_stat(dst, &st) == 0 && st.flags == OS_DIRENT_DIR) {
+            char joined[RAMFS_PATH_MAX];
+            fs_join(joined, RAMFS_PATH_MAX, dst, fs_basename(src));
+            strcpy(dst, joined);
         }
-        rc = kernel_copy_file(src, dst, RAMFS_PATH_MAX);
-        if (rc != 0) {
-            print_fs_err("mv", rc);
-            return;
-        }
-        rc = sys_unlink(src);
-        if (rc == -8) {
-            sys_unlink(dst);
-            print_fs_err("mv", rc);
-            return;
-        }
+        rc = sys_rename(src, dst);
         if (rc != 0) {
             print_fs_err("mv", rc);
             return;

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -458,6 +458,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_colored("COMMANDES SYSTÈME :\n", COLOR_YELLOW);
     print_string("  ls [path]          - Lister initrd + overlay noyau\n");
     print_string("  cat <file>         - Afficher un fichier (overlay puis initrd)\n");
+    print_string("  stat <path>        - Type et taille (syscall SYS_STAT)\n");
     print_string("  cd <path>          - Changer de répertoire\n");
     print_string("  pwd                - Afficher le répertoire courant\n");
     print_string("  mkdir <dir>        - Créer un répertoire (overlay noyau)\n");
@@ -804,6 +805,36 @@ void cmd_write(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("\n");
 }
 
+static void cmd_stat(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    os_dirent_t st;
+    int size = 0;
+    int is_dir = 0;
+    if (arg_count == 0) {
+        print_error("stat: chemin manquant");
+        return;
+    }
+    resolve_arg(ctx, args[0], path);
+    if (sys_stat(path, &st) == 0) {
+        is_dir = (st.flags == OS_DIRENT_DIR);
+        size = (int)st.size;
+    } else if (ramfs_is_dir(path)) {
+        is_dir = 1;
+        size = 0;
+    } else if (ramfs_is_file(path)) {
+        if (!ramfs_read(path, &size)) size = 0;
+        is_dir = 0;
+    } else {
+        print_error("stat: introuvable");
+        return;
+    }
+    print_string(is_dir ? "stat dir " : "stat file ");
+    print_string(args[0]);
+    print_string(" ");
+    print_int(size);
+    print_string("\n");
+}
+
 void cmd_clear(shell_context_t* ctx, char args[][128], int arg_count) {
     // Séquence ANSI pour effacer l'écran
     print_string("\x1b[2J\x1b[H");
@@ -887,7 +918,7 @@ static int is_builtin(const char* cmd) {
         "help", "ls", "dir", "ps", "sysinfo", "info", "mem", "memory",
         "history", "env", "echo", "write", "clear", "cls", "exit", "quit",
         "ai", "ai-mode", "ai-help", "ai-test", "ai-stats",
-        "cd", "pwd", "cat", "mkdir", "rmdir", "cp", "mv", "rm",
+        "cd", "pwd", "cat", "stat", "mkdir", "rmdir", "cp", "mv", "rm",
         "kill", "spawn", "jobs", "top", "uptime", "date", "whoami",
         "alias", "unalias", "export", "which",
         "grep", "wc", "sort", "head", "tail",
@@ -1407,7 +1438,11 @@ static void cmd_grep(shell_context_t* ctx, char args[][128], int arg_count) {
     }
     if (hits == 0) {
         print_string("(aucune correspondance)\n");
+        return;
     }
+    print_string("grep hits ");
+    print_int(hits);
+    print_string("\n");
 }
 
 static void cmd_wc(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -1444,13 +1479,14 @@ static void cmd_wc(shell_context_t* ctx, char args[][128], int arg_count) {
             words++;
         }
     }
+    print_string("wc ok ");
     print_int(lines);
     print_string(" ");
     print_int(words);
     print_string(" ");
     print_int(chars);
     print_string(" ");
-    print_string(path);
+    print_string(args[0]);
     print_string("\n");
 }
 
@@ -1740,6 +1776,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "cat") == 0) {
         cmd_cat(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "stat") == 0) {
+        cmd_stat(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "which") == 0) {
         if (arg_count == 0) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`mv` overlay ne savait déplacer que des fichiers (copie + unlink) et refusait les répertoires (`mv: repertoire non supporte`). Cette PR ajoute `SYS_RENAME` : le noyau réécrit le préfixe de chemin, y compris les enfants.

## Changements

- ABI : `SYS_RENAME` (19), `MAX_SYSCALLS` 20 (`include/os_syscalls.h`)
- `overlay_rename()` : fichier ou dossier ; enfants sous `old/` → `new/` ; initrd `PROTECTED` ; refuse de se déplacer dans son propre sous-arbre
- Shell `mv` appelle `SYS_RENAME` (joint le basename si la destination est un dossier)
- Test unitaire `test_sys_overlay_rename_file_and_dir` (`test_syscall` 44/44, suite **107**)
- Smoke QEMU : après `cp hello.txt mydir`, `mv mydir newd`, `cd newd`, `cat`/`rm`, `rmdir newd`
- Sendkey : drain HMP jusqu’au silence + 0.16 s/touche ; timeout smoke **180 s** (passage local ~93 s)

S’appuie sur #61 (stat/grep/wc + drain sendkey). Si #61 est fusionné d’abord, ce PR ne garde que les commits rename.

## Vérifications locales

- `make test-all` : OK (`test_syscall` 44/44)
- `make qemu-smoke` : OK (`mv ok newd`, `cd ok newd`, `rmdir ok newd`)

## Hors périmètre

- Disque persistant
- `cp` de répertoires (toujours VFS RAM local)
- Préemption round-robin
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

