### PR TITLE
Overlay : SYS_COPY pour cp de dossiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make run-gui
 - **🤖 Simulateur d'IA Intégré** - Réponses préprogrammées par mots-clés (`fake_ai.c`), pas un modèle ML
 - **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
 - **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
-- **💾 Système de Fichiers** - Initrd TAR en lecture seule + overlay RAM (`mkdir`/`rm`/`mv` fichier et dossier). Pas de disque persistant. `ls` fusionne les deux via `SYS_LISTDIR`.
+- **💾 Système de Fichiers** - Initrd TAR en lecture seule + overlay RAM (`mkdir`/`rm`/`cp`/`mv` fichier et dossier). Pas de disque persistant. `ls` fusionne les deux via `SYS_LISTDIR`.
 - **🧠 Gestion Mémoire** - VMM/PMM avec paging (cible ~128 MB RAM sous QEMU)
 - **🔌 Gestion Interruptions** - PIC, clavier PS/2, timer PIT
 
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **107 tests** répartis dans `test_pmm` (17), `test_syscall` (44), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **108 tests** répartis dans `test_pmm` (17), `test_syscall` (45), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash
@@ -177,7 +177,7 @@ ai-os/
 - ✅ **Interruptions clavier (IRQ1) générées par QEMU**
 - ✅ **Fin des boucles infinies** sur appels système
 - ✅ **IA accessible** via interface clavier
-- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `cp`, `grep`, `kill`, `top`, `ai`, etc. — `ls`/`mkdir`/`rm`/`cp`/`mv` (dont dossiers overlay)/`ps`/`kill`/`mem` via syscalls noyau, voir `docs/ETAT_REEL.md`)
+- ✅ **Commandes de `help` branchées** (`mkdir`, `ls`, `cp`, `grep`, `kill`, `top`, `ai`, etc. — `ls`/`mkdir`/`rm`/`cp`/`mv` (fichiers et dossiers overlay)/`ps`/`kill`/`mem` via syscalls noyau, voir `docs/ETAT_REEL.md`)
 
 ### ✅ Corrections Antérieures
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (overlay SYS_RENAME : mv fichier et dossier ; CI sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc)  
+**Code de référence :** `master` (overlay SYS_COPY : cp de dossiers ; CI sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/cp/mv/write/grep/wc)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -30,8 +30,8 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - Initrd format TAR POSIX (`fs/initrd.c`)
 - Chargeur ELF 32-bit
 - Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
-- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME` (ABI : `include/os_syscalls.h`)
-- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (y compris vers un dossier) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
+- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME`, `SYS_COPY` (ABI : `include/os_syscalls.h`)
+- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
 
 ### Espace utilisateur
 
@@ -57,7 +57,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 44/44 |
+| `test_syscall` | 45/45 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
@@ -68,14 +68,14 @@ Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `grep` / `wc` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `cp` de répertoires reste un VFS RAM local. `procsim.c` n’est plus utilisé par `ps`/`kill`.
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `grep` / `wc` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
 | `help` | Aide |
 | `ls` / `dir` | Listing **initrd + overlay** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
 | `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l’initrd ne peut pas être modifié (`PROTECTED`) ; `rmdir` d’un dossier non vide échoue (`NOTEMPTY`) |
-| `cp` / `mv` | `cp` copie overlay (`SYS_READFILE` + `SYS_WRITEFILE`) ; `cp fichier dossier/` joint le nom. `mv` appelle `SYS_RENAME` (fichier ou dossier, enfants réécrits) ; l’initrd reste `PROTECTED` ; dossiers absents du noyau : VFS RAM local |
+| `cp` / `mv` | `cp` fichier : `SYS_READFILE` + `SYS_WRITEFILE` (y compris initrd → overlay, et `cp fichier dossier/` joint le nom). `cp` dossier overlay : `SYS_COPY` (enfants dupliqués, source conservée). `mv` : `SYS_RENAME`. L’initrd reste `PROTECTED`. |
 | `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM. `grep` affiche `grep hits N` ; `wc` affiche `wc ok L W C fichier` |
 | `stat` | Type et taille (`SYS_STAT`) : `stat file hello.txt 35` / `stat dir mydir 0` |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau (le `>` n’est pas tapable en CI sendkey) |
@@ -128,13 +128,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/cd/mv (fichier et dossier)/write/rmdir/uptime
+make qemu-smoke   # QEMU headless + sendkey ls/cat/ps/spawn/kill/mkdir/cd/cp/mv/write/rmdir/uptime
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `grep`, `wc` et `mv mydir newd` (rename overlay avec enfant) via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `grep`, `wc`, `cp mydir cpd` (copie d’arborescence) et `mv mydir newd` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,7 +51,7 @@
 ### Reste ouvert (hors périmètre « shell qui démarre »)
 - [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
 - [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
-- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
+- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` (fichier et dossier via `SYS_COPY`) / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
 - [ ] FS persistant sur disque (l’overlay RAM n’est pas persisté)
 - [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
 - [ ] Réseau, vrai moteur IA — voir roadmap README / dossier `US/`

--- a/fs/overlay.c
+++ b/fs/overlay.c
@@ -326,6 +326,85 @@ int overlay_rename(const char* oldpath, const char* newpath) {
     return OV_OK;
 }
 
+static int ov_used_count(void) {
+    int n = 0;
+    int i;
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        if (g_ov[i].used) n++;
+    }
+    return n;
+}
+
+int overlay_copy(const char* src, const char* dst) {
+    ov_node_t* srcnode;
+    char oldp[OV_PATH_MAX];
+    char newp[OV_PATH_MAX];
+    int oldn;
+    int newn;
+    int i;
+    int need = 0;
+    int free_n;
+
+    ov_normalize(src, oldp, OV_PATH_MAX);
+    ov_normalize(dst, newp, OV_PATH_MAX);
+    if (!oldp[0] || !newp[0]) return OV_ERR_INVAL;
+    if (ov_eq(oldp, newp)) return OV_ERR_EXISTS;
+
+    srcnode = ov_find(oldp);
+    if (!srcnode) {
+        if (initrd_is_file(oldp) || initrd_is_dir(oldp)) return OV_ERR_PROTECTED;
+        return OV_ERR_NOTFOUND;
+    }
+    if (ov_find(newp)) return OV_ERR_EXISTS;
+    if (initrd_is_file(newp) || initrd_is_dir(newp)) return OV_ERR_EXISTS;
+    if (!ov_parent_is_dir(newp)) return OV_ERR_NOTDIR;
+
+    oldn = ov_len(oldp);
+    newn = ov_len(newp);
+    if (ov_under(newp, oldp, oldn) && newp[oldn] == '/') return OV_ERR_INVAL;
+
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        int rest;
+        if (!g_ov[i].used) continue;
+        if (!ov_under(g_ov[i].path, oldp, oldn)) continue;
+        rest = ov_len(g_ov[i].path) - oldn;
+        if (newn + rest >= OV_PATH_MAX) return OV_ERR_INVAL;
+        need++;
+    }
+    free_n = OV_MAX_NODES - ov_used_count();
+    if (need > free_n) return OV_ERR_NOSPACE;
+
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        ov_node_t* n;
+        char rest[OV_PATH_MAX];
+        int r = 0;
+        int k;
+        uint32_t b;
+        if (!g_ov[i].used) continue;
+        if (!ov_under(g_ov[i].path, oldp, oldn)) continue;
+        n = ov_alloc();
+        if (!n) return OV_ERR_NOSPACE;
+        n->used = 1;
+        while (g_ov[i].path[oldn + r]) {
+            rest[r] = g_ov[i].path[oldn + r];
+            r++;
+        }
+        rest[r] = '\0';
+        ov_copy(n->path, newp, OV_PATH_MAX);
+        for (k = 0; rest[k] && newn + k < OV_PATH_MAX - 1; k++) {
+            n->path[newn + k] = rest[k];
+        }
+        n->path[newn + k] = '\0';
+        n->used = 1;
+        n->is_dir = g_ov[i].is_dir;
+        n->size = g_ov[i].size;
+        for (b = 0; b < n->size && b < OV_DATA_MAX; b++) {
+            n->data[b] = g_ov[i].data[b];
+        }
+    }
+    return OV_OK;
+}
+
 int overlay_listdir(const char* path, os_dirent_t* out, int start, int max_n) {
     char prefix[OV_PATH_MAX];
     int count = start;

--- a/fs/overlay.h
+++ b/fs/overlay.h
@@ -19,6 +19,7 @@ int overlay_mkdir(const char* path);
 int overlay_write(const char* path, const char* data, uint32_t n);
 int overlay_unlink(const char* path);
 int overlay_rename(const char* oldpath, const char* newpath);
+int overlay_copy(const char* src, const char* dst);
 int overlay_read(const char* path, char* buf, uint32_t max);
 int overlay_stat(const char* path, os_dirent_t* out);
 int overlay_listdir(const char* path, os_dirent_t* out, int start, int max_n);

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -25,8 +25,9 @@
 #define SYS_WRITEFILE 17
 #define SYS_STAT     18
 #define SYS_RENAME   19
+#define SYS_COPY     20
 
-#define MAX_SYSCALLS 20
+#define MAX_SYSCALLS 21
 
 #define OS_NAME_MAX 64
 #define OS_PROC_NAME_MAX 32

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -137,6 +137,9 @@ void syscall_handler(cpu_state_t* cpu) {
         case SYS_RENAME:
             cpu->eax = (uint32_t)sys_rename((const char*)cpu->ebx, (const char*)cpu->ecx);
             break;
+        case SYS_COPY:
+            cpu->eax = (uint32_t)sys_copy((const char*)cpu->ebx, (const char*)cpu->ecx);
+            break;
             
         default:
             // Syscall inconnu
@@ -320,6 +323,11 @@ int sys_stat(const char* path, os_dirent_t* out) {
 int sys_rename(const char* oldpath, const char* newpath) {
     if (!oldpath || !newpath) return -1;
     return overlay_rename(oldpath, newpath);
+}
+
+int sys_copy(const char* src, const char* dst) {
+    if (!src || !dst) return -1;
+    return overlay_copy(src, dst);
 }
 
 int sys_getpid(void) {

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -34,6 +34,7 @@ int sys_unlink(const char* path);
 int sys_writefile(const char* path, const char* buf, uint32_t n);
 int sys_stat(const char* path, os_dirent_t* out);
 int sys_rename(const char* oldpath, const char* newpath);
+int sys_copy(const char* src, const char* dst);
 
 void keyboard_add_char_to_buffer(char c);
 

--- a/tests/framework/kernel_mocks.c
+++ b/tests/framework/kernel_mocks.c
@@ -448,6 +448,11 @@ int sys_rename(const char* oldpath, const char* newpath) {
     return overlay_rename(oldpath, newpath);
 }
 
+int sys_copy(const char* src, const char* dst) {
+    if (!src || !dst) return -1;
+    return overlay_copy(src, dst);
+}
+
 int sys_getpid(void) {
     return current_task ? current_task->id : 0;
 }
@@ -550,6 +555,9 @@ void syscall_handler(cpu_state_t* state) {
             break;
         case SYS_RENAME:
             state->eax = (uint32_t)sys_rename((const char*)state->ebx, (const char*)state->ecx);
+            break;
+        case SYS_COPY:
+            state->eax = (uint32_t)sys_copy((const char*)state->ebx, (const char*)state->ecx);
             break;
         default:
             break;

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -155,7 +155,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/mv/write/grep/wc/rename-dir) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/ps/spawn/kill/mkdir/cd/cp/mv/write/grep/wc) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -348,6 +348,13 @@ def main():
         sendkeys(mon, ["l", "s", "spc", "m", "y", "d", "i", "r", "ret"])
         wait_needle_from("hello.txt", CMD_TIMEOUT, proc, mark)
 
+        say("typing cp mydir cpd ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "c", "p", "spc", "m", "y", "d", "i", "r", "spc", "c", "p", "d", "ret",
+        ])
+        wait_needle_from("cp ok cpd", CMD_TIMEOUT, proc, mark)
+
         say("typing mv mydir newd ...")
         mark = len(log_text())
         sendkeys(mon, [
@@ -365,6 +372,8 @@ def main():
             raise RuntimeError("mydir still listed after mv mydir newd")
         if "newd" not in after_mv_dir:
             raise RuntimeError("ls after mv dir missing newd")
+        if "cpd" not in after_mv_dir:
+            raise RuntimeError("ls after mv dir missing cpd copy")
 
         say("typing ls newd ...")
         mark = len(log_text())
@@ -410,6 +419,46 @@ def main():
             raise RuntimeError("mydir still listed in ls after rmdir")
         if "newd" in after_rmdir_ls:
             raise RuntimeError("newd still listed in ls after rmdir")
+        if "cpd" not in after_rmdir_ls:
+            raise RuntimeError("cpd missing after rmdir newd")
+
+        say("typing cd cpd ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "c", "p", "d", "ret"])
+        wait_needle_from("cd ok cpd", CMD_TIMEOUT, proc, mark)
+
+        say("typing cat hello.txt (in cpd) ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "c", "a", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("demonstration", CMD_TIMEOUT, proc, mark)
+
+        say("typing rm hello.txt (in cpd) ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "r", "m", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("rm ok hello.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing cd .. (after cp dir) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["c", "d", "spc", "dot", "dot", "ret"])
+        wait_needle_from("cd ok ..", CMD_TIMEOUT, proc, mark)
+
+        say("typing rmdir cpd ...")
+        mark = len(log_text())
+        sendkeys(mon, ["r", "m", "d", "i", "r", "spc", "c", "p", "d", "ret"])
+        wait_needle_from("rmdir ok cpd", CMD_TIMEOUT, proc, mark)
+
+        say("typing ls (after rmdir cpd) ...")
+        mark = len(log_text())
+        sendkeys(mon, ["l", "s", "ret"])
+        wait_needle_from("Initrd / VFS", CMD_TIMEOUT, proc, mark)
+        wait_needle_from("Total:", CMD_TIMEOUT, proc, mark)
+        after_rmdir_cpd = log_text()[mark:]
+        if "cpd" in after_rmdir_cpd:
+            raise RuntimeError("cpd still listed in ls after rmdir")
 
         say("typing write hi.txt ping ...")
         mark = len(log_text())
@@ -477,9 +526,12 @@ def main():
             ("mv overlay", "mv ok notes.txt"),
             ("rm overlay", "rm ok notes.txt"),
             ("cp into dir", "cp ok hello.txt"),
+            ("cp overlay dir", "cp ok cpd"),
             ("mv overlay dir", "mv ok newd"),
             ("cd renamed dir", "cd ok newd"),
             ("rmdir overlay", "rmdir ok newd"),
+            ("cd copied dir", "cd ok cpd"),
+            ("rmdir copied dir", "rmdir ok cpd"),
             ("write overlay", "write ok hi.txt"),
             ("grep overlay", "grep hits 1"),
             ("wc overlay", "wc ok 1 1 5 hi.txt"),

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -1013,6 +1013,121 @@ void test_sys_overlay_rename_file_and_dir(void) {
     TEST_ASSERT_EQUAL(OV_ERR_INVAL, (int)cpu.eax);
 }
 
+void test_sys_overlay_copy_dir_tree(void) {
+    char payload[] = "copied\n";
+    char buf[32];
+    os_dirent_t ents[16];
+    os_dirent_t st;
+    cpu_state_t cpu = {0};
+    int n;
+    int found_old;
+    int found_new;
+    int found_child;
+    int i;
+
+    overlay_init();
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"oldd";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"oldd/sub";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_WRITEFILE;
+    cpu.ebx = (uint32_t)"oldd/sub/f.txt";
+    cpu.ecx = (uint32_t)payload;
+    cpu.edx = 7;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(7, (int)cpu.eax);
+
+    cpu.eax = SYS_COPY;
+    cpu.ebx = (uint32_t)"oldd";
+    cpu.ecx = (uint32_t)"newd";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"oldd";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_DIR, (int)st.flags);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"newd";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_DIR, (int)st.flags);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"/";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 16;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    found_old = 0;
+    found_new = 0;
+    for (i = 0; i < n; i++) {
+        if (strcmp(ents[i].name, "oldd") == 0) found_old = 1;
+        if (strcmp(ents[i].name, "newd") == 0) found_new = 1;
+    }
+    TEST_ASSERT(found_old);
+    TEST_ASSERT(found_new);
+
+    cpu.eax = SYS_LISTDIR;
+    cpu.ebx = (uint32_t)"newd";
+    cpu.ecx = (uint32_t)ents;
+    cpu.edx = 16;
+    syscall_handler(&cpu);
+    n = (int)cpu.eax;
+    found_child = 0;
+    for (i = 0; i < n; i++) {
+        if (strcmp(ents[i].name, "sub") == 0 && ents[i].flags == OS_DIRENT_DIR) {
+            found_child = 1;
+        }
+    }
+    TEST_ASSERT(found_child);
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"newd/sub/f.txt";
+    cpu.ecx = (uint32_t)buf;
+    cpu.edx = sizeof(buf);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(7, (int)cpu.eax);
+    buf[7] = '\0';
+    TEST_ASSERT_EQUAL_STRING("copied\n", buf);
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"oldd/sub/f.txt";
+    cpu.ecx = (uint32_t)buf;
+    cpu.edx = sizeof(buf);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(7, (int)cpu.eax);
+
+    cpu.eax = SYS_COPY;
+    cpu.ebx = (uint32_t)"hello.txt";
+    cpu.ecx = (uint32_t)"from-initrd.txt";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_PROTECTED, (int)cpu.eax);
+
+    cpu.eax = SYS_COPY;
+    cpu.ebx = (uint32_t)"oldd";
+    cpu.ecx = (uint32_t)"oldd/nested";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_INVAL, (int)cpu.eax);
+
+    cpu.eax = SYS_COPY;
+    cpu.ebx = (uint32_t)"oldd";
+    cpu.ecx = (uint32_t)"newd";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_EXISTS, (int)cpu.eax);
+}
+
 // === RUNNER PRINCIPAL ===
 
 int main(void) {
@@ -1075,6 +1190,7 @@ int main(void) {
     RUN_TEST(test_sys_overlay_copy_from_initrd);
     RUN_TEST(test_sys_overlay_nested_mkdir_notempty);
     RUN_TEST(test_sys_overlay_rename_file_and_dir);
+    RUN_TEST(test_sys_overlay_copy_dir_tree);
     
     unity_print_results();
     unity_cleanup();

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -174,6 +174,12 @@ int sys_rename(const char* oldpath, const char* newpath) {
     return result;
 }
 
+int sys_copy(const char* src, const char* dst) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_COPY), "b"(src), "c"(dst));
+    return result;
+}
+
 static void print_fs_err(const char* cmd, int rc);
 
 // ==============================================================================
@@ -469,7 +475,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  pwd                - Afficher le répertoire courant\n");
     print_string("  mkdir <dir>        - Créer un répertoire (overlay noyau)\n");
     print_string("  rmdir <dir>        - Supprimer un répertoire vide\n");
-    print_string("  cp <src> <dest>    - Copier un fichier (overlay noyau)\n");
+    print_string("  cp <src> <dest>    - Copier fichier ou dossier overlay\n");
     print_string("  mv <src> <dest>    - Deplacer fichier ou dossier overlay\n");
     print_string("  rm <file>          - Supprimer un fichier\n");
     
@@ -1058,21 +1064,16 @@ static void fs_join(char* out, int max, const char* dir, const char* name) {
     out[i] = '\0';
 }
 
-static int kernel_copy_file(const char* src, char* dest, int dest_max) {
+static int kernel_copy_file_to(const char* src, const char* dest) {
     os_dirent_t st;
     char buf[256];
     int n;
     int w;
-    (void)dest_max;
     if (sys_stat(src, &st) != 0) return -1;
     if (st.flags == OS_DIRENT_DIR) return -4;
     n = sys_readfile(src, buf, (int)sizeof(buf));
     if (n < 0) return n;
-    if (sys_stat(dest, &st) == 0 && st.flags == OS_DIRENT_DIR) {
-        char joined[RAMFS_PATH_MAX];
-        fs_join(joined, RAMFS_PATH_MAX, dest, fs_basename(src));
-        strcpy(dest, joined);
-    }
+    if (sys_stat(dest, &st) == 0 && st.flags == OS_DIRENT_DIR) return -4;
     w = sys_writefile(dest, buf, n);
     if (w < 0) return w;
     return 0;
@@ -1081,6 +1082,8 @@ static int kernel_copy_file(const char* src, char* dest, int dest_max) {
 static void cmd_cp(shell_context_t* ctx, char args[][128], int arg_count) {
     char src[RAMFS_PATH_MAX];
     char dst[RAMFS_PATH_MAX];
+    os_dirent_t st;
+    int src_dir;
     int rc;
     if (arg_count < 2) {
         print_error("cp: usage cp <src> <dest>");
@@ -1088,8 +1091,19 @@ static void cmd_cp(shell_context_t* ctx, char args[][128], int arg_count) {
     }
     resolve_arg(ctx, args[0], src);
     resolve_arg(ctx, args[1], dst);
-    rc = kernel_copy_file(src, dst, RAMFS_PATH_MAX);
-    if (rc == 0) {
+    if (sys_stat(src, &st) == 0) {
+        src_dir = (st.flags == OS_DIRENT_DIR);
+        if (sys_stat(dst, &st) == 0 && st.flags == OS_DIRENT_DIR) {
+            char joined[RAMFS_PATH_MAX];
+            fs_join(joined, RAMFS_PATH_MAX, dst, fs_basename(src));
+            strcpy(dst, joined);
+        }
+        if (src_dir) rc = sys_copy(src, dst);
+        else rc = kernel_copy_file_to(src, dst);
+        if (rc != 0) {
+            print_fs_err("cp", rc);
+            return;
+        }
         print_string("cp ok ");
         print_string(fs_basename(dst));
         print_string("\n");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`cp` overlay ne copiait que des fichiers (`SYS_READFILE` + `SYS_WRITEFILE`). Un dossier retournait une erreur ; le VFS RAM refusait aussi les répertoires (`ramfs_cp` → `ISDIR`).

Cette PR ajoute `SYS_COPY` : le noyau duplique un préfixe de chemin et ses enfants. La source reste en place (contrairement à `SYS_RENAME`).

## Changements

- ABI : `SYS_COPY` (20), `MAX_SYSCALLS` 21
- `overlay_copy()` : fichier ou dossier overlay ; enfants sous `src/` clonés vers `dst/` ; initrd `PROTECTED` ; refuse de copier dans son propre sous-arbre ; `NOSPACE` si plus de 32 nœuds
- Shell `cp` : dossiers → `SYS_COPY` ; fichiers → lecture/écriture (initrd → overlay toujours possible) ; joint le basename si la destination est un dossier
- Test unitaire `test_sys_overlay_copy_dir_tree` (`test_syscall` 45/45, suite **108**)
- Smoke QEMU : `cp hello.txt mydir` puis `cp mydir cpd` (l’arbre survit à `mv mydir newd`)

## Vérifications locales

- `make test-all` : OK (`test_syscall` 45/45)
- `make qemu-smoke` : OK (`cp ok cpd`, `cd ok cpd`, `rmdir ok cpd`, ~107 s / timeout 180 s)

## Hors périmètre

- Copie d’un dossier initrd (`bin/` : ELF trop gros pour l’overlay 256 octets)
- Disque persistant
- Préemption round-robin
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

