### PR TITLE
CI : SYS_EXEC via ai hello

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## 🎯 Description
 
-AI-OS est un **prototype de noyau pédagogique i386 32-bit** (hobby OS) qui boote sous QEMU, isole Ring 0/3 et lance un shell utilisateur ELF. L’orientation « OS pour l’IA » est réelle au niveau architecture (userspace, syscalls, initrd), mais l’IA embarquée est un **simulateur par mots-clés** (`userspace/fake_ai.c`), pas un moteur d’inférence.
+AI-OS est un **prototype de noyau pédagogique i386 32-bit** (hobby OS) qui boote sous QEMU, isole Ring 0/3 et lance un shell utilisateur ELF. L’orientation « OS pour l’IA » est réelle au niveau architecture (userspace, syscalls, initrd), mais l’IA embarquée est un **simulateur par mots-clés** (`ai_assistant.c` via `ai <texte>`), pas un moteur d’inférence.
 
 **État réel du code (août 2026) :** [docs/ETAT_REEL.md](docs/ETAT_REEL.md) — ce qui marche, les stubs du shell, ce qui n’est pas encore codé (FS persistant, réseau, vision MOHHOS). Index de toute la doc : [docs/README.md](docs/README.md).
 
@@ -37,7 +37,7 @@ make run-gui
 ## ⭐ Fonctionnalités Principales
 
 - **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd + overlay noyau ; `mkdir`/`rm`/`cp`/`mv` mutent l’overlay (pas de disque persistant). `ps`/`kill`/`mem`/`uptime` interrogent le noyau.
-- **🤖 Simulateur d'IA Intégré** - Réponses préprogrammées par mots-clés (`fake_ai.c`), pas un modèle ML
+- **🤖 Simulateur d'IA Intégré** - `ai hello` lance `bin/ai_assistant` (`SYS_EXEC`) ; réponses préprogrammées, pas un modèle ML
 - **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
 - **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
 - **💾 Système de Fichiers** - Initrd TAR en lecture seule + overlay RAM (`mkdir`/`rm`/`cp`/`mv` fichier et dossier). Pas de disque persistant. `ls` fusionne les deux via `SYS_LISTDIR`.

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (head/tail/sort ok ; overlay SYS_COPY/RENAME ; CI sendkey ls/cat/stat/head/tail/sort/ps/spawn/kill/mkdir/cd/cp/mv/write/grep/wc)  
+**Code de référence :** `master` (CI `ai hello` via SYS_EXEC ; head/tail/sort ; overlay SYS_COPY/RENAME)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -89,13 +89,13 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `history` | Historique en mémoire |
 | `which` | `builtin` ou `bin/<cmd> (non verifie)` |
 | `clear`/`cls` | Séquence ANSI + bannière |
-| `ai`, `ai-mode`, `ai-help`, `ai-test`, `ai-stats` | Pont vers le simulateur + compteur de requêtes |
+| `ai`, `ai-mode`, `ai-help`, `ai-test`, `ai-stats` | `ai <texte>` lance `bin/ai_assistant` via `SYS_EXEC` (bloquant). `hello`/`bonjour` → `AI: bonjour` puis `ai ok`. Compteur de requêtes dans le shell. |
 | `exit` / `quit` / `logout` | Sortie du programme |
 | `reboot` / `shutdown` | Message simulé (QEMU n’est pas arrêté) |
 
 ## « Intelligence artificielle »
 
-`userspace/fake_ai.c` compare la question (minuscules) à des mots-clés et imprime une réponse préprogrammée (`bonjour` → `AI: bonjour`, `healthcheck` → `AI HEALTH: OK`, …). Il n’y a pas de TensorFlow Lite, pas de NLP, pas de modèle, pas d’apprentissage.
+`userspace/ai_assistant.c` (lancé par `ai <texte>` via `SYS_EXEC`) compare la question à quelques mots-clés ASCII (`hello`/`bonjour` → `AI: bonjour`, `healthcheck` → `AI HEALTH: OK`). `userspace/fake_ai.c` est un second binaire dans l’initrd (réponses plus longues) ; le shell n’appelle pas ce fichier. Il n’y a pas de TensorFlow Lite, pas de NLP, pas de modèle, pas d’apprentissage.
 
 `initrd_content/ai_knowledge.txt` et `ai_data.txt` sont des fichiers texte d’accompagnement, pas une base vectorielle.
 
@@ -128,13 +128,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/head/tail/sort/ps/spawn/kill/mkdir/cd/cp/mv/write/rmdir/uptime
+make qemu-smoke   # QEMU headless + sendkey ls/cat/head/tail/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/rmdir/uptime
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `head`, `tail`, `sort`, `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `head`, `tail`, `sort`, `ai hello` (`SYS_EXEC`), `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -61,6 +61,22 @@ def wait_needle(needle, timeout, proc):
     wait_needle_from(needle, timeout, proc, 0)
 
 
+def parse_spawn_pid(text):
+    key = "spawn ok pid "
+    i = text.find(key)
+    if i < 0:
+        raise RuntimeError("spawn ok pid not in log")
+    digits = []
+    for ch in text[i + len(key):]:
+        if ch.isdigit():
+            digits.append(ch)
+        elif digits:
+            break
+    if not digits:
+        raise RuntimeError("no pid after spawn ok pid")
+    return "".join(digits)
+
+
 def monitor_connect(retries=50):
     last = None
     for _ in range(retries):
@@ -202,16 +218,19 @@ def main():
         mark = len(log_text())
         sendkeys(mon, ["s", "p", "a", "w", "n", "spc", "i", "d", "l", "e", "ret"])
         wait_needle_from("spawn ok pid", CMD_TIMEOUT, proc, mark)
+        idle_pid = parse_spawn_pid(log_text()[mark:])
+        say("spawned idle pid %s" % idle_pid)
 
         say("typing ps (after spawn) ...")
         mark = len(log_text())
         sendkeys(mon, ["p", "s", "ret"])
         wait_needle_from("user  idle", CMD_TIMEOUT, proc, mark)
 
-        say("typing kill 2 ...")
+        say("typing kill %s ..." % idle_pid)
         mark = len(log_text())
-        sendkeys(mon, ["k", "i", "l", "l", "spc", "2", "ret"])
-        wait_needle_from("Processus 2 termine", CMD_TIMEOUT, proc, mark)
+        sendkeys(mon, ["k", "i", "l", "l", "spc"] + list(idle_pid) + ["ret"])
+        kill_needle = "Processus %s termine" % idle_pid
+        wait_needle_from(kill_needle, CMD_TIMEOUT, proc, mark)
         time.sleep(0.3)
 
         say("typing ps (after kill) ...")
@@ -220,7 +239,7 @@ def main():
         wait_needle_from("Processus (noyau)", CMD_TIMEOUT, proc, mark)
         after_kill_ps = log_text()[mark:]
         if "user  idle" in after_kill_ps:
-            raise RuntimeError("idle still listed in ps after kill 2")
+            raise RuntimeError("idle still listed in ps after kill %s" % idle_pid)
 
         say("typing uptime ...")
         sendkeys(mon, ["u", "p", "t", "i", "m", "e", "ret"])
@@ -511,7 +530,7 @@ def main():
             ("ps shell", "shell"),
             ("spawn idle", "spawn ok pid"),
             ("ps shows idle", "user  idle"),
-            ("kill 2", "Processus 2 termine"),
+            ("kill idle", "Processus %s termine" % idle_pid),
             ("uptime", "PIT ticks"),
             ("mkdir overlay", "mkdir ok mydir"),
             ("cd overlay", "cd ok mydir"),

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -155,7 +155,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/stat/head/tail/sort/ps/spawn/kill/mkdir/cd/cp/mv/write/grep/wc) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/head/tail/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/grep/wc) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -188,6 +188,9 @@ def main():
              ["s", "o", "r", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret"],
              "sort ok 1 hello.txt"),
             ("ls bin", ["l", "s", "spc", "b", "i", "n", "ret"], "fake_ai"),
+            ("ai hello",
+             ["a", "i", "spc", "h", "e", "l", "l", "o", "ret"],
+             "ai ok"),
             ("ps", ["p", "s", "ret"], "Processus (noyau)"),
         ]
         for name, keys, needle in commands:
@@ -501,6 +504,8 @@ def main():
             ("initrd ls", "startup.sh"),
             ("cat hello.txt", "Un autre fichier de demonstration"),
             ("ls bin", "fake_ai"),
+            ("ai exec", "AI: bonjour"),
+            ("ai exec returned", "ai ok"),
             ("ps kernel table", "Processus (noyau)"),
             ("ps kernel", "kern"),
             ("ps shell", "shell"),

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -1672,9 +1672,9 @@ void call_ai_assistant(shell_context_t* ctx, const char* query) {
     }
     if (rc != 0) {
         print_colored("\n[IA] indisponible\n", COLOR_YELLOW);
+        return;
     }
-    // Assurer un retour de ligne apres la reponse IA
-    print_string("\n");
+    print_string("ai ok\n");
 }
 
 void cmd_ai(shell_context_t* ctx, char args[][128], int arg_count) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Le smoke QEMU n’exerçait pas `SYS_EXEC` : `spawn idle` crée une tâche READY sans changer de contexte. `ai <texte>` lance vraiment `bin/ai_assistant` (ELF initrd) et attend sa fin.

## Changements

- Après un exec réussi, le shell imprime `ai ok`
- Smoke : `ai hello` → `AI: bonjour` puis `ai ok`
- Smoke : le pid d’idle n’est plus câblé à 2 (l’assistant a déjà pris ce pid) ; lecture de `spawn ok pid N`
- Docs : le shell appelle `ai_assistant`, pas `fake_ai`

## Vérifications locales

- `make test-all` : OK
- `make qemu-smoke` : OK (`AI: bonjour`, `ai ok`, `spawned idle pid 3`, `Processus 3 termine`, ~115 s)

## Hors périmètre

- Vrai moteur IA
- `fake_ai.c` (toujours dans l’initrd, non lancé par `ai`)
- Disque persistant / préemption
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

