### PR TITLE
CI : SYS_MEMINFO via mem + compteur Unity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run unit tests (make test-all)
         run: make test-all
 
-      - name: QEMU smoke (sendkey ls/cat/ps/uptime on serial)
+      - name: QEMU smoke (sendkey ls/cat/ps/uptime/mem on serial)
         run: make qemu-smoke
 
       - name: Upload logs

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **108 tests** répartis dans `test_pmm` (17), `test_syscall` (45), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **118 tests** répartis dans `test_pmm` (17), `test_syscall` (45), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -62,7 +62,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
 
-Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé « Total Tests » de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des cinq binaires (**108**).
+Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé « Total Tests » de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des cinq binaires (**118** = 17+45+21+25+10).
 
 Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en plus de `nasm` et `qemu-system-i386`).
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,14 +1,14 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (CI `ai hello` via SYS_EXEC ; head/tail/sort ; overlay SYS_COPY/RENAME)  
+**Code de référence :** `master` (CI `mem` / `SYS_MEMINFO` ; `ai hello` via SYS_EXEC ; head/tail/sort ; overlay SYS_COPY/RENAME)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
 
 ## Synthèse
 
-AI-OS est un **prototype de noyau pédagogique i386 32-bit**. Il boote sous QEMU, charge un initrd TAR, passe en espace utilisateur (Ring 3) et exécute un shell ELF interactif. L’« IA » est un **simulateur par mots-clés** (`userspace/fake_ai.c`), pas un moteur d’inférence.
+AI-OS est un **prototype de noyau pédagogique i386 32-bit**. Il boote sous QEMU, charge un initrd TAR, passe en espace utilisateur (Ring 3) et exécute un shell ELF interactif. L’« IA » est un **simulateur par mots-clés** (`userspace/ai_assistant.c`), pas un moteur d’inférence.
 
 | Périmètre | Avancement réel |
 |---|---|
@@ -37,7 +37,7 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 
 - `userspace/shell.c` s’exécute vraiment en Ring 3 (plus de boucle shell simulée dans le kernel)
 - Programmes empaquetés dans l’initrd : `shell`, `fake_ai`, `ai_assistant`, `user_program`
-- Commande `ai <texte>` lance `fake_ai` via `SYS_EXEC`
+- Commande `ai <texte>` lance `bin/ai_assistant` via `SYS_EXEC`
 
 ### Clavier (août 2026)
 
@@ -62,7 +62,7 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
 
-Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le compteur « Total Tests » du script `run_all_tests.sh` reste à 0 (incrément placé après `return`) : bug d’affichage, pas d’échec des binaires.
+Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé « Total Tests » de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des cinq binaires (**108**).
 
 Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en plus de `nasm` et `qemu-system-i386`).
 
@@ -82,7 +82,7 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `write` | `write <fichier> <texte>` → overlay (`SYS_WRITEFILE`), sans redirection. Succès : `write ok <fichier>` |
 | `cd` / `pwd` | Chemin shell ; `cd` accepte overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`). Succès : `cd ok <arg>` |
 | `ps` / `jobs` / `top` / `kill` / `spawn` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY (pas de changement de contexte). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`) |
-| `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT |
+| `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT. `mem` affiche `mem ok <total> <used> <free>` |
 | `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) |
 | `whoami` / `env` / `export` | Variables d’environnement du shell (`USER=root` par défaut) |
 | `alias` / `unalias` | Table d’alias, expansion avant exécution |
@@ -128,13 +128,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/head/tail/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/rmdir/uptime
+make qemu-smoke   # QEMU headless + sendkey ls/cat/head/tail/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/rmdir/uptime/mem
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `head`, `tail`, `sort`, `ai hello` (`SYS_EXEC`), `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `head`, `tail`, `sort`, `ai hello` (`SYS_EXEC`), `mem` (`SYS_MEMINFO`), `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Boot QEMU, type ls/cat/ps/uptime via HMP sendkey, assert serial output.
+"""Boot QEMU, type ls/cat/ps/uptime/mem via HMP sendkey, assert serial output.
 
 Used by ci_qemu_smoke.sh so GitHub Actions actually exercises the initrd and
 kernel syscalls, not only the boot prompt.
@@ -171,7 +171,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/stat/head/tail/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/grep/wc) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/head/tail/sort/ai/ps/spawn/kill/uptime/mem/mkdir/cd/cp/mv/write/grep/wc) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -244,6 +244,11 @@ def main():
         say("typing uptime ...")
         sendkeys(mon, ["u", "p", "t", "i", "m", "e", "ret"])
         wait_needle("PIT ticks", CMD_TIMEOUT, proc)
+
+        say("typing mem ...")
+        mark = len(log_text())
+        sendkeys(mon, ["m", "e", "m", "ret"])
+        wait_needle_from("mem ok", CMD_TIMEOUT, proc, mark)
 
         say("typing mkdir mydir ...")
         mark = len(log_text())
@@ -532,6 +537,7 @@ def main():
             ("ps shows idle", "user  idle"),
             ("kill idle", "Processus %s termine" % idle_pid),
             ("uptime", "PIT ticks"),
+            ("mem pmm", "mem ok"),
             ("mkdir overlay", "mkdir ok mydir"),
             ("cd overlay", "cd ok mydir"),
             ("pwd overlay", "/mydir"),

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -52,6 +52,27 @@ print_warning() {
     echo -e "${YELLOW}⚠ $1${NC}"
 }
 
+add_unity_counts() {
+    local output=$1
+    local fallback=$2
+    local run_n pass_n fail_n
+    run_n=$(printf '%s\n' "$output" | awk '/^Tests Run:/ {print $3; exit}')
+    pass_n=$(printf '%s\n' "$output" | awk '/^Tests Passed:/ {print $3; exit}')
+    fail_n=$(printf '%s\n' "$output" | awk '/^Tests Failed:/ {print $3; exit}')
+    if [ -n "$run_n" ]; then
+        TOTAL_TESTS=$((TOTAL_TESTS + run_n))
+        PASSED_TESTS=$((PASSED_TESTS + ${pass_n:-0}))
+        FAILED_TESTS=$((FAILED_TESTS + ${fail_n:-0}))
+    else
+        TOTAL_TESTS=$((TOTAL_TESTS + 1))
+        if [ "$fallback" = "pass" ]; then
+            PASSED_TESTS=$((PASSED_TESTS + 1))
+        else
+            FAILED_TESTS=$((FAILED_TESTS + 1))
+        fi
+    fi
+}
+
 # Fonction pour compiler et exécuter un test
 run_test() {
     local test_file=$1
@@ -87,14 +108,14 @@ run_test() {
         if test_output=$("$test_binary" 2>&1); then
             echo -e "${GREEN}PASS${NC}"
             echo "$test_output" >> "$RESULTS_FILE"
-            PASSED_TESTS=$((PASSED_TESTS + 1))
+            add_unity_counts "$test_output" pass
             return 0
         else
             echo -e "${RED}FAIL${NC}"
             echo "Test: $test_name" >> "$RESULTS_FILE"
             echo "$test_output" >> "$RESULTS_FILE"
             echo "---" >> "$RESULTS_FILE"
-            FAILED_TESTS=$((FAILED_TESTS + 1))
+            add_unity_counts "$test_output" fail
             return 1
         fi
     else
@@ -103,8 +124,6 @@ run_test() {
         SKIPPED_TESTS=$((SKIPPED_TESTS + 1))
         return 2
     fi
-    
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
 }
 
 # Fonction pour exécuter une catégorie de tests

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -696,7 +696,14 @@ void cmd_mem(shell_context_t* ctx, char args[][128], int arg_count) {
     print_int((int)mi.used_pages);
     print_string("\n  Libres : ");
     print_int((int)mi.free_pages);
-    print_string("\n  Taille page : 4 KB\n\n");
+    print_string("\n  Taille page : 4 KB\n");
+    print_string("mem ok ");
+    print_int((int)mi.total_pages);
+    print_string(" ");
+    print_int((int)mi.used_pages);
+    print_string(" ");
+    print_int((int)mi.free_pages);
+    print_string("\n");
 }
 
 void cmd_history(shell_context_t* ctx, char args[][128], int arg_count) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Le smoke QEMU n’exerçait pas `SYS_MEMINFO` : `uptime` vérifie le PIT, mais `mem` n’était jamais tapé. Le résumé `make test-all` affichait toujours `Total Tests: 0` (incrément après `return`).

## Changements

- `cmd_mem` imprime `mem ok <total> <used> <free>`
- Smoke : `mem` → aiguille `mem ok`
- `run_all_tests.sh` additionne les lignes Unity `Tests Run:` (**118** = 17+45+21+25+10)
- Docs : `docs/ETAT_REEL.md` / `README.md` (aiguille, `ai` → `bin/ai_assistant`, compteur)

## Vérifications locales

- [x] `make test-all` : `Total Tests: 118`, 0 failed
- [x] `make qemu-smoke` : `OK: mem pmm` (`mem ok 32895 432 32463`, ~116 s)

## Hors périmètre

- Disque persistant / préemption
- Vrai moteur IA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

