### PR TITLE
CI : getpid (SYS_GETPID) et touch overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run unit tests (make test-all)
         run: make test-all
 
-      - name: QEMU smoke (sendkey ls/cat/ps/uptime/mem on serial)
+      - name: QEMU smoke (sendkey ls/cat/ps/uptime/mem/getpid on serial)
         run: make qemu-smoke
 
       - name: Upload logs

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make run-gui
 
 ## ⭐ Fonctionnalités Principales
 
-- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd + overlay noyau ; `mkdir`/`rm`/`cp`/`mv` mutent l’overlay (pas de disque persistant). `ps`/`kill`/`mem`/`uptime` interrogent le noyau.
+- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd + overlay noyau ; `mkdir`/`rm`/`cp`/`mv`/`touch`/`write` mutent l’overlay (pas de disque persistant). `ps`/`kill`/`getpid`/`mem`/`uptime` interrogent le noyau.
 - **🤖 Simulateur d'IA Intégré** - `ai hello` lance `bin/ai_assistant` (`SYS_EXEC`) ; réponses préprogrammées, pas un modèle ML
 - **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
 - **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **118 tests** répartis dans `test_pmm` (17), `test_syscall` (45), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **119 tests** répartis dans `test_pmm` (17), `test_syscall` (46), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (CI `mem` / `SYS_MEMINFO` ; `ai hello` via SYS_EXEC ; head/tail/sort ; overlay SYS_COPY/RENAME)  
+**Code de référence :** `master` (CI `getpid` / `touch` ; `mem` / `SYS_MEMINFO` ; `ai hello` via SYS_EXEC ; head/tail/sort ; overlay SYS_COPY/RENAME)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -31,7 +31,7 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - Chargeur ELF 32-bit
 - Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
 - Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME`, `SYS_COPY` (ABI : `include/os_syscalls.h`)
-- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
+- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `touch` (fichier vide) / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
 
 ### Espace utilisateur
 
@@ -57,18 +57,18 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 45/45 |
+| `test_syscall` | 46/46 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
 
-Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé « Total Tests » de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des cinq binaires (**118** = 17+45+21+25+10).
+Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé « Total Tests » de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des cinq binaires (**119** = 17+46+21+25+10).
 
 Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en plus de `nasm` et `qemu-system-i386`).
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `grep` / `wc` / `ps` / `kill` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write` écrivent dans l’overlay noyau. `procsim.c` n’est plus utilisé par `ps`/`kill`.
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `touch` / `grep` / `wc` / `ps` / `kill` / `getpid` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write`/`touch` écrivent dans l’overlay noyau. `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
@@ -80,8 +80,9 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `stat` | Type et taille (`SYS_STAT`) : `stat file hello.txt 35` / `stat dir mydir 0` |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau (le `>` n’est pas tapable en CI sendkey) |
 | `write` | `write <fichier> <texte>` → overlay (`SYS_WRITEFILE`), sans redirection. Succès : `write ok <fichier>` |
+| `touch` | `touch <fichier>` → fichier overlay vide (`SYS_WRITEFILE` taille 0). Succès : `touch ok <fichier>` ; un fichier existant n’est pas tronqué |
 | `cd` / `pwd` | Chemin shell ; `cd` accepte overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`). Succès : `cd ok <arg>` |
-| `ps` / `jobs` / `top` / `kill` / `spawn` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY (pas de changement de contexte). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`) |
+| `ps` / `jobs` / `top` / `kill` / `spawn` / `getpid` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY (pas de changement de contexte). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`). `getpid` affiche `getpid ok <pid>` (`SYS_GETPID`) |
 | `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT. `mem` affiche `mem ok <total> <used> <free>` |
 | `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) |
 | `whoami` / `env` / `export` | Variables d’environnement du shell (`USER=root` par défaut) |
@@ -128,13 +129,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/head/tail/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/rmdir/uptime/mem
+make qemu-smoke   # QEMU headless + sendkey ls/cat/head/tail/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/touch/rmdir/uptime/mem/getpid
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `head`, `tail`, `sort`, `ai hello` (`SYS_EXEC`), `mem` (`SYS_MEMINFO`), `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `head`, `tail`, `sort`, `ai hello` (`SYS_EXEC`), `mem` (`SYS_MEMINFO`), `getpid` (`SYS_GETPID`), `touch`, `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,7 +51,7 @@
 ### Reste ouvert (hors périmètre « shell qui démarre »)
 - [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
 - [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
-- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` (fichier et dossier via `SYS_COPY`) / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
+- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` (fichier et dossier via `SYS_COPY`) / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `touch` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
 - [ ] FS persistant sur disque (l’overlay RAM n’est pas persisté)
 - [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
 - [ ] Réseau, vrai moteur IA — voir roadmap README / dossier `US/`

--- a/fs/overlay.c
+++ b/fs/overlay.c
@@ -216,7 +216,7 @@ int overlay_write(const char* path, const char* data, uint32_t n) {
     char want[OV_PATH_MAX];
     uint32_t i;
     ov_normalize(path, want, OV_PATH_MAX);
-    if (!want[0] || !data) return OV_ERR_INVAL;
+    if (!want[0] || (n > 0 && !data)) return OV_ERR_INVAL;
     node = ov_find(want);
     if (node && node->is_dir) return OV_ERR_ISDIR;
     if (initrd_is_dir(want)) return OV_ERR_ISDIR;

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -310,7 +310,7 @@ int sys_unlink(const char* path) {
 }
 
 int sys_writefile(const char* path, const char* buf, uint32_t n) {
-    if (!path || !buf) return -1;
+    if (!path || (n > 0 && !buf)) return -1;
     return overlay_write(path, buf, n);
 }
 

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Boot QEMU, type ls/cat/ps/uptime/mem via HMP sendkey, assert serial output.
+"""Boot QEMU, type ls/cat/ps/uptime/mem/getpid via HMP sendkey, assert serial output.
 
 Used by ci_qemu_smoke.sh so GitHub Actions actually exercises the initrd and
 kernel syscalls, not only the boot prompt.
@@ -171,7 +171,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/stat/head/tail/sort/ai/ps/spawn/kill/uptime/mem/mkdir/cd/cp/mv/write/grep/wc) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/head/tail/sort/ai/ps/spawn/kill/uptime/mem/getpid/mkdir/cd/cp/mv/write/touch/grep/wc) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -249,6 +249,11 @@ def main():
         mark = len(log_text())
         sendkeys(mon, ["m", "e", "m", "ret"])
         wait_needle_from("mem ok", CMD_TIMEOUT, proc, mark)
+
+        say("typing getpid ...")
+        mark = len(log_text())
+        sendkeys(mon, ["g", "e", "t", "p", "i", "d", "ret"])
+        wait_needle_from("getpid ok", CMD_TIMEOUT, proc, mark)
 
         say("typing mkdir mydir ...")
         mark = len(log_text())
@@ -481,6 +486,25 @@ def main():
         if "cpd" in after_rmdir_cpd:
             raise RuntimeError("cpd still listed in ls after rmdir")
 
+        say("typing touch z.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "t", "o", "u", "c", "h", "spc", "z", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("touch ok z.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing stat z.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "s", "t", "a", "t", "spc", "z", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("stat file z.txt 0", CMD_TIMEOUT, proc, mark)
+
+        say("typing rm z.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, ["r", "m", "spc", "z", "dot", "t", "x", "t", "ret"])
+        wait_needle_from("rm ok z.txt", CMD_TIMEOUT, proc, mark)
+
         say("typing write hi.txt ping ...")
         mark = len(log_text())
         sendkeys(mon, [
@@ -538,6 +562,7 @@ def main():
             ("kill idle", "Processus %s termine" % idle_pid),
             ("uptime", "PIT ticks"),
             ("mem pmm", "mem ok"),
+            ("getpid", "getpid ok"),
             ("mkdir overlay", "mkdir ok mydir"),
             ("cd overlay", "cd ok mydir"),
             ("pwd overlay", "/mydir"),
@@ -555,6 +580,8 @@ def main():
             ("cd copied dir", "cd ok cpd"),
             ("rmdir copied dir", "rmdir ok cpd"),
             ("write overlay", "write ok hi.txt"),
+            ("touch overlay", "touch ok z.txt"),
+            ("stat empty", "stat file z.txt 0"),
             ("grep overlay", "grep hits 1"),
             ("wc overlay", "wc ok 1 1 5 hi.txt"),
             ("rm write", "rm ok hi.txt"),

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -723,6 +723,36 @@ void test_sys_overlay_write_read(void) {
     TEST_ASSERT_EQUAL(0, (int)cpu.eax);
 }
 
+void test_sys_overlay_write_empty(void) {
+    os_dirent_t st;
+    char buf[8];
+    cpu_state_t cpu = {0};
+
+    overlay_init();
+
+    cpu.eax = SYS_WRITEFILE;
+    cpu.ebx = (uint32_t)"empty.txt";
+    cpu.ecx = (uint32_t)"";
+    cpu.edx = 0;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"empty.txt";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_FILE, (int)st.flags);
+    TEST_ASSERT_EQUAL(0, (int)st.size);
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"empty.txt";
+    cpu.ecx = (uint32_t)buf;
+    cpu.edx = sizeof(buf);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+}
+
 void test_sys_overlay_protects_initrd(void) {
     cpu_state_t cpu = {0};
     overlay_init();
@@ -1185,6 +1215,7 @@ int main(void) {
     RUN_TEST(test_sys_kill_removes_ready_task);
     RUN_TEST(test_sys_overlay_mkdir_listdir_unlink);
     RUN_TEST(test_sys_overlay_write_read);
+    RUN_TEST(test_sys_overlay_write_empty);
     RUN_TEST(test_sys_overlay_protects_initrd);
     RUN_TEST(test_sys_stat_initrd_file_and_overlay_dir);
     RUN_TEST(test_sys_overlay_copy_from_initrd);

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -485,6 +485,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  kill <pid>         - Terminer un processus\n");
     print_string("  jobs               - Afficher les tâches\n");
     print_string("  top                - Moniteur système\n");
+    print_string("  getpid             - PID du shell (syscall SYS_GETPID)\n");
     
     print_colored("\nCOMMANDES SYSTÈME :\n", COLOR_YELLOW);
     print_string("  sysinfo            - Informations système\n");
@@ -511,6 +512,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  clear              - Effacer l'écran\n");
     print_string("  echo <text>        - Afficher du texte\n");
     print_string("  write <file> <txt> - Ecrire un fichier overlay (sans >)\n");
+    print_string("  touch <file>       - Creer un fichier overlay vide\n");
     print_string("  grep <pattern>     - Rechercher dans un texte\n");
     print_string("  wc <file>          - Compter lignes/mots/caractères\n");
     print_string("  sort <file>        - Trier les lignes (sort ok N fichier)\n");
@@ -824,6 +826,35 @@ void cmd_write(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("\n");
 }
 
+static void cmd_touch(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    os_dirent_t st;
+    int rc;
+    if (arg_count == 0) {
+        print_error("touch: fichier manquant");
+        return;
+    }
+    resolve_arg(ctx, args[0], path);
+    if (sys_stat(path, &st) == 0) {
+        if (st.flags == OS_DIRENT_DIR) {
+            print_error("touch: est un repertoire");
+            return;
+        }
+        print_string("touch ok ");
+        print_string(args[0]);
+        print_string("\n");
+        return;
+    }
+    rc = sys_writefile(path, "", 0);
+    if (rc < 0) {
+        print_fs_err("touch", rc);
+        return;
+    }
+    print_string("touch ok ");
+    print_string(args[0]);
+    print_string("\n");
+}
+
 static void cmd_stat(shell_context_t* ctx, char args[][128], int arg_count) {
     char path[RAMFS_PATH_MAX];
     os_dirent_t st;
@@ -935,10 +966,10 @@ static void cmd_cat(shell_context_t* ctx, char args[][128], int arg_count) {
 static int is_builtin(const char* cmd) {
     static const char* names[] = {
         "help", "ls", "dir", "ps", "sysinfo", "info", "mem", "memory",
-        "history", "env", "echo", "write", "clear", "cls", "exit", "quit",
+        "history", "env", "echo", "write", "touch", "clear", "cls", "exit", "quit",
         "ai", "ai-mode", "ai-help", "ai-test", "ai-stats",
         "cd", "pwd", "cat", "stat", "mkdir", "rmdir", "cp", "mv", "rm",
-        "kill", "spawn", "jobs", "top", "uptime", "date", "whoami",
+        "kill", "spawn", "jobs", "top", "getpid", "uptime", "date", "whoami",
         "alias", "unalias", "export", "which",
         "grep", "wc", "sort", "head", "tail",
         "logout", "reboot", "shutdown",
@@ -1247,6 +1278,13 @@ static void cmd_top(shell_context_t* ctx, char args[][128], int arg_count) {
         print_string(procs[i].name);
         print_string("\n");
     }
+    print_string("\n");
+}
+
+static void cmd_getpid(shell_context_t* ctx, char args[][128], int arg_count) {
+    (void)ctx; (void)args; (void)arg_count;
+    print_string("getpid ok ");
+    print_int(sys_getpid());
     print_string("\n");
 }
 
@@ -1798,6 +1836,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
     } else if (strcmp(command, "write") == 0) {
         cmd_write(ctx, args, arg_count);
         return 1;
+    } else if (strcmp(command, "touch") == 0) {
+        cmd_touch(ctx, args, arg_count);
+        return 1;
     } else if (strcmp(command, "clear") == 0 || strcmp(command, "cls") == 0) {
         cmd_clear(ctx, args, arg_count);
         return 1;
@@ -1861,6 +1902,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "top") == 0) {
         cmd_top(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "getpid") == 0) {
+        cmd_getpid(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "uptime") == 0) {
         cmd_uptime(ctx, args, arg_count);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Le smoke QEMU n’exerçait pas `SYS_GETPID`, et le shell n’avait pas de `touch` (fichier overlay vide).

## Changements

- `getpid` imprime `getpid ok <pid>` (`SYS_GETPID`)
- `touch <fichier>` crée un fichier overlay de taille 0 (`SYS_WRITEFILE`) ; un fichier existant n’est pas tronqué
- Smoke : `getpid` → `getpid ok` ; `touch z.txt` → `touch ok z.txt` puis `stat file z.txt 0`
- Test unitaire : `SYS_WRITEFILE` avec `n = 0` (suite Unity **119**)

## Vérifications locales

- [x] `make test-all` : `Total Tests: 119`, 0 failed
- [x] `make qemu-smoke` : `OK: getpid`, `OK: touch overlay`, `OK: stat empty` (~124 s)

## Hors périmètre

- Disque persistant / préemption
- Horodatage réel (touch ne met pas à jour un mtime)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

