### PR TITLE
Overlay : SYS_APPEND pour concaténer sans écraser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run unit tests (make test-all)
         run: make test-all
 
-      - name: QEMU smoke (sendkey ls/cat/ps/uptime/mem/getpid on serial)
+      - name: QEMU smoke (sendkey ls/cat/ps/uptime/mem/getpid/append on serial)
         run: make qemu-smoke
 
       - name: Upload logs

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make run-gui
 
 ## ⭐ Fonctionnalités Principales
 
-- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd + overlay noyau ; `mkdir`/`rm`/`cp`/`mv`/`touch`/`write` mutent l’overlay (pas de disque persistant). `ps`/`kill`/`getpid`/`mem`/`uptime` interrogent le noyau.
+- **🖥️ Shell Interactif** - Prompt `/ (-.-) :` en Ring 3. `ls`/`cat` lisent l’initrd + overlay noyau ; `mkdir`/`rm`/`cp`/`mv`/`touch`/`write`/`append` mutent l’overlay (pas de disque persistant). `ps`/`kill`/`getpid`/`mem`/`uptime` interrogent le noyau.
 - **🤖 Simulateur d'IA Intégré** - `ai hello` lance `bin/ai_assistant` (`SYS_EXEC`) ; réponses préprogrammées, pas un modèle ML
 - **🛡️ Espace Utilisateur Sécurisé** - Isolation Ring 0/3, chargeur ELF, syscalls
 - **⚡ Tâches et changement de contexte** - Passage kernel → shell via `jump_to_task()` ; le round-robin à chaque tick n’est pas le mode actuel (stabilité)
@@ -80,7 +80,7 @@ Le fichier `grub.cfg` est généré automatiquement (entrée AI-OS multiboot + m
 
 ## 🧪 Tests de Non-Régression (NOUVEAU)
 
-AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **119 tests** répartis dans `test_pmm` (17), `test_syscall` (46), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
+AI-OS inclut une suite Unity de tests unitaires (kernel + userspace). En août 2026 : **120 tests** répartis dans `test_pmm` (17), `test_syscall` (47), `test_task` (21), `test_shell` (25), `test_ramfs` (10). Les dossiers integration / system / performance / robustness n’ont pas encore de fichiers. `make test-all` est la commande de référence.
 
 ### Configuration Initiale
 ```bash

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (CI `getpid` / `touch` ; `mem` / `SYS_MEMINFO` ; `ai hello` via SYS_EXEC ; head/tail/sort ; overlay SYS_COPY/RENAME)  
+**Code de référence :** `master` (CI `append` / `SYS_APPEND` ; `getpid` / `touch` ; `mem` / `SYS_MEMINFO` ; `ai hello` via SYS_EXEC ; overlay SYS_COPY/RENAME)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -30,8 +30,8 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - Initrd format TAR POSIX (`fs/initrd.c`)
 - Chargeur ELF 32-bit
 - Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
-- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME`, `SYS_COPY` (ABI : `include/os_syscalls.h`)
-- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `touch` (fichier vide) / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
+- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME`, `SYS_COPY`, `SYS_APPEND` (ABI : `include/os_syscalls.h`)
+- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`, concatène sans écraser) / `touch` (fichier vide) / `echo >` visibles par `ls`/`cat` ; l’initrd reste en lecture seule ; `rmdir` d’un dossier non vide échoue
 
 ### Espace utilisateur
 
@@ -57,18 +57,18 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | Binaire | Tests unitaires |
 |---|---|
 | `test_pmm` | 17/17 |
-| `test_syscall` | 46/46 |
+| `test_syscall` | 47/47 |
 | `test_task` | 21/21 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
 
-Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé « Total Tests » de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des cinq binaires (**119** = 17+46+21+25+10).
+Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé « Total Tests » de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des cinq binaires (**120** = 17+47+21+25+10).
 
 Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en plus de `nasm` et `qemu-system-i386`).
 
 ## Shell : commandes réelles vs affichées
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `touch` / `grep` / `wc` / `ps` / `kill` / `getpid` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write`/`touch` écrivent dans l’overlay noyau. `procsim.c` n’est plus utilisé par `ps`/`kill`.
+Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `append` / `touch` / `grep` / `wc` / `ps` / `kill` / `getpid` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write`/`append`/`touch` écrivent dans l’overlay noyau. `procsim.c` n’est plus utilisé par `ps`/`kill`.
 
 | Commande | Comportement réel |
 |---|---|
@@ -80,6 +80,7 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `stat` | Type et taille (`SYS_STAT`) : `stat file hello.txt 35` / `stat dir mydir 0` |
 | `echo` | Affichage ; `echo texte > fichier` écrit dans l’overlay noyau (le `>` n’est pas tapable en CI sendkey) |
 | `write` | `write <fichier> <texte>` → overlay (`SYS_WRITEFILE`), sans redirection. Succès : `write ok <fichier>` |
+| `append` | `append <fichier> <texte>` → concatène (`SYS_APPEND`) ; crée le fichier s’il n’existe pas ; un fichier initrd est recopié dans l’overlay (copie sur écriture). Succès : `append ok <fichier>` |
 | `touch` | `touch <fichier>` → fichier overlay vide (`SYS_WRITEFILE` taille 0). Succès : `touch ok <fichier>` ; un fichier existant n’est pas tronqué |
 | `cd` / `pwd` | Chemin shell ; `cd` accepte overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`). Succès : `cd ok <arg>` |
 | `ps` / `jobs` / `top` / `kill` / `spawn` / `getpid` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY (pas de changement de contexte). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`). `getpid` affiche `getpid ok <pid>` (`SYS_GETPID`) |
@@ -129,13 +130,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/head/tail/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/touch/rmdir/uptime/mem/getpid
+make qemu-smoke   # QEMU headless + sendkey ls/cat/head/tail/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/touch/append/rmdir/uptime/mem/getpid
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `head`, `tail`, `sort`, `ai hello` (`SYS_EXEC`), `mem` (`SYS_MEMINFO`), `getpid` (`SYS_GETPID`), `touch`, `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `head`, `tail`, `sort`, `ai hello` (`SYS_EXEC`), `mem` (`SYS_MEMINFO`), `getpid` (`SYS_GETPID`), `touch`, `append` (`SYS_APPEND`), `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,7 +51,7 @@
 ### Reste ouvert (hors périmètre « shell qui démarre »)
 - [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
 - [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
-- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` (fichier et dossier via `SYS_COPY`) / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `touch` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
+- [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` (fichier et dossier via `SYS_COPY`) / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`) / `touch` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
 - [ ] FS persistant sur disque (l’overlay RAM n’est pas persisté)
 - [ ] Préemption round-robin continue (aujourd’hui limitée pour la stabilité)
 - [ ] Réseau, vrai moteur IA — voir roadmap README / dossier `US/`

--- a/fs/overlay.c
+++ b/fs/overlay.c
@@ -234,6 +234,40 @@ int overlay_write(const char* path, const char* data, uint32_t n) {
     return (int)n;
 }
 
+int overlay_append(const char* path, const char* data, uint32_t n) {
+    ov_node_t* node;
+    char want[OV_PATH_MAX];
+    uint32_t i;
+    ov_normalize(path, want, OV_PATH_MAX);
+    if (!want[0] || (n > 0 && !data)) return OV_ERR_INVAL;
+    if (initrd_is_dir(want)) return OV_ERR_ISDIR;
+    node = ov_find(want);
+    if (node && node->is_dir) return OV_ERR_ISDIR;
+    if (!node) {
+        uint32_t have = 0;
+        char tmp[OV_DATA_MAX];
+        if (initrd_is_file(want)) {
+            int r = initrd_read_into(want, tmp, OV_DATA_MAX);
+            if (r < 0) return r;
+            have = (uint32_t)r;
+        } else if (!ov_parent_is_dir(want)) {
+            return OV_ERR_NOTDIR;
+        }
+        if (have + n > OV_DATA_MAX) return OV_ERR_NOSPACE;
+        node = ov_alloc();
+        if (!node) return OV_ERR_NOSPACE;
+        node->used = 1;
+        node->is_dir = 0;
+        node->size = have;
+        ov_copy(node->path, want, OV_PATH_MAX);
+        for (i = 0; i < have; i++) node->data[i] = tmp[i];
+    }
+    if (node->size + n > OV_DATA_MAX) return OV_ERR_NOSPACE;
+    for (i = 0; i < n; i++) node->data[node->size + i] = data[i];
+    node->size += n;
+    return (int)n;
+}
+
 int overlay_read(const char* path, char* buf, uint32_t max) {
     ov_node_t* n;
     uint32_t i;

--- a/fs/overlay.h
+++ b/fs/overlay.h
@@ -17,6 +17,7 @@
 void overlay_init(void);
 int overlay_mkdir(const char* path);
 int overlay_write(const char* path, const char* data, uint32_t n);
+int overlay_append(const char* path, const char* data, uint32_t n);
 int overlay_unlink(const char* path);
 int overlay_rename(const char* oldpath, const char* newpath);
 int overlay_copy(const char* src, const char* dst);

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -26,8 +26,9 @@
 #define SYS_STAT     18
 #define SYS_RENAME   19
 #define SYS_COPY     20
+#define SYS_APPEND   21
 
-#define MAX_SYSCALLS 21
+#define MAX_SYSCALLS 22
 
 #define OS_NAME_MAX 64
 #define OS_PROC_NAME_MAX 32

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -140,6 +140,9 @@ void syscall_handler(cpu_state_t* cpu) {
         case SYS_COPY:
             cpu->eax = (uint32_t)sys_copy((const char*)cpu->ebx, (const char*)cpu->ecx);
             break;
+        case SYS_APPEND:
+            cpu->eax = (uint32_t)sys_append((const char*)cpu->ebx, (const char*)cpu->ecx, cpu->edx);
+            break;
             
         default:
             // Syscall inconnu
@@ -328,6 +331,11 @@ int sys_rename(const char* oldpath, const char* newpath) {
 int sys_copy(const char* src, const char* dst) {
     if (!src || !dst) return -1;
     return overlay_copy(src, dst);
+}
+
+int sys_append(const char* path, const char* buf, uint32_t n) {
+    if (!path || (n > 0 && !buf)) return -1;
+    return overlay_append(path, buf, n);
 }
 
 int sys_getpid(void) {

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -35,6 +35,7 @@ int sys_writefile(const char* path, const char* buf, uint32_t n);
 int sys_stat(const char* path, os_dirent_t* out);
 int sys_rename(const char* oldpath, const char* newpath);
 int sys_copy(const char* src, const char* dst);
+int sys_append(const char* path, const char* buf, uint32_t n);
 
 void keyboard_add_char_to_buffer(char c);
 

--- a/tests/framework/kernel_mocks.c
+++ b/tests/framework/kernel_mocks.c
@@ -278,6 +278,22 @@ int initrd_is_file(const char* path) {
     return 0;
 }
 
+int initrd_read_into(const char* path, char* buf, uint32_t max) {
+    char want[64];
+    unsigned i;
+    mock_ird_norm(path, want, 64);
+    if (!want[0] || !buf || max == 0) return -1;
+    for (i = 0; i < sizeof(mock_initrd) / sizeof(mock_initrd[0]); i++) {
+        if (strcmp(want, mock_initrd[i].name) == 0) {
+            uint32_t copy = mock_initrd[i].size;
+            if (copy > max) copy = max;
+            memcpy(buf, mock_initrd[i].data, copy);
+            return (int)copy;
+        }
+    }
+    return -1;
+}
+
 int initrd_is_dir(const char* path) {
     char want[64];
     unsigned i;

--- a/tests/framework/kernel_mocks.c
+++ b/tests/framework/kernel_mocks.c
@@ -433,7 +433,7 @@ int sys_unlink(const char* path) {
 }
 
 int sys_writefile(const char* path, const char* buf, uint32_t n) {
-    if (!path || !buf) return -1;
+    if (!path || (n > 0 && !buf)) return -1;
     return overlay_write(path, buf, n);
 }
 
@@ -451,6 +451,11 @@ int sys_rename(const char* oldpath, const char* newpath) {
 int sys_copy(const char* src, const char* dst) {
     if (!src || !dst) return -1;
     return overlay_copy(src, dst);
+}
+
+int sys_append(const char* path, const char* buf, uint32_t n) {
+    if (!path || (n > 0 && !buf)) return -1;
+    return overlay_append(path, buf, n);
 }
 
 int sys_getpid(void) {
@@ -558,6 +563,9 @@ void syscall_handler(cpu_state_t* state) {
             break;
         case SYS_COPY:
             state->eax = (uint32_t)sys_copy((const char*)state->ebx, (const char*)state->ecx);
+            break;
+        case SYS_APPEND:
+            state->eax = (uint32_t)sys_append((const char*)state->ebx, (const char*)state->ecx, state->edx);
             break;
         default:
             break;

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -171,7 +171,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/stat/head/tail/sort/ai/ps/spawn/kill/uptime/mem/getpid/mkdir/cd/cp/mv/write/touch/grep/wc) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/head/tail/sort/ai/ps/spawn/kill/uptime/mem/getpid/mkdir/cd/cp/mv/write/touch/append/grep/wc) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -500,6 +500,21 @@ def main():
         ])
         wait_needle_from("stat file z.txt 0", CMD_TIMEOUT, proc, mark)
 
+        say("typing append z.txt zap ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "a", "p", "p", "e", "n", "d", "spc", "z", "dot", "t", "x", "t",
+            "spc", "z", "a", "p", "ret",
+        ])
+        wait_needle_from("append ok z.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing stat z.txt (after append) ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "s", "t", "a", "t", "spc", "z", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("stat file z.txt 4", CMD_TIMEOUT, proc, mark)
+
         say("typing rm z.txt ...")
         mark = len(log_text())
         sendkeys(mon, ["r", "m", "spc", "z", "dot", "t", "x", "t", "ret"])
@@ -582,6 +597,8 @@ def main():
             ("write overlay", "write ok hi.txt"),
             ("touch overlay", "touch ok z.txt"),
             ("stat empty", "stat file z.txt 0"),
+            ("append overlay", "append ok z.txt"),
+            ("stat appended", "stat file z.txt 4"),
             ("grep overlay", "grep hits 1"),
             ("wc overlay", "wc ok 1 1 5 hi.txt"),
             ("rm write", "rm ok hi.txt"),

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -753,6 +753,97 @@ void test_sys_overlay_write_empty(void) {
     TEST_ASSERT_EQUAL(0, (int)cpu.eax);
 }
 
+void test_sys_overlay_append(void) {
+    char buf[64];
+    os_dirent_t st;
+    cpu_state_t cpu = {0};
+    char big[256];
+    int i;
+
+    overlay_init();
+
+    cpu.eax = SYS_WRITEFILE;
+    cpu.ebx = (uint32_t)"notes.txt";
+    cpu.ecx = (uint32_t)"hello\n";
+    cpu.edx = 6;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(6, (int)cpu.eax);
+
+    cpu.eax = SYS_APPEND;
+    cpu.ebx = (uint32_t)"notes.txt";
+    cpu.ecx = (uint32_t)"world\n";
+    cpu.edx = 6;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(6, (int)cpu.eax);
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"notes.txt";
+    cpu.ecx = (uint32_t)buf;
+    cpu.edx = sizeof(buf);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(12, (int)cpu.eax);
+    buf[12] = '\0';
+    TEST_ASSERT_EQUAL_STRING("hello\nworld\n", buf);
+
+    cpu.eax = SYS_APPEND;
+    cpu.ebx = (uint32_t)"new.txt";
+    cpu.ecx = (uint32_t)"x\n";
+    cpu.edx = 2;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(2, (int)cpu.eax);
+
+    cpu.eax = SYS_STAT;
+    cpu.ebx = (uint32_t)"new.txt";
+    cpu.ecx = (uint32_t)&st;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+    TEST_ASSERT_EQUAL(OS_DIRENT_FILE, (int)st.flags);
+    TEST_ASSERT_EQUAL(2, (int)st.size);
+
+    cpu.eax = SYS_MKDIR;
+    cpu.ebx = (uint32_t)"mydir";
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(0, (int)cpu.eax);
+
+    cpu.eax = SYS_APPEND;
+    cpu.ebx = (uint32_t)"mydir";
+    cpu.ecx = (uint32_t)"x";
+    cpu.edx = 1;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_ISDIR, (int)cpu.eax);
+
+    cpu.eax = SYS_APPEND;
+    cpu.ebx = (uint32_t)"hello.txt";
+    cpu.ecx = (uint32_t)"Z";
+    cpu.edx = 1;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(1, (int)cpu.eax);
+
+    cpu.eax = SYS_READFILE;
+    cpu.ebx = (uint32_t)"hello.txt";
+    cpu.ecx = (uint32_t)buf;
+    cpu.edx = sizeof(buf);
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(19, (int)cpu.eax);
+    buf[19] = '\0';
+    TEST_ASSERT_EQUAL_STRING("hello from initrd\nZ", buf);
+
+    for (i = 0; i < 256; i++) big[i] = 'a';
+    cpu.eax = SYS_WRITEFILE;
+    cpu.ebx = (uint32_t)"full.txt";
+    cpu.ecx = (uint32_t)big;
+    cpu.edx = 256;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(256, (int)cpu.eax);
+
+    cpu.eax = SYS_APPEND;
+    cpu.ebx = (uint32_t)"full.txt";
+    cpu.ecx = (uint32_t)"b";
+    cpu.edx = 1;
+    syscall_handler(&cpu);
+    TEST_ASSERT_EQUAL(OV_ERR_NOSPACE, (int)cpu.eax);
+}
+
 void test_sys_overlay_protects_initrd(void) {
     cpu_state_t cpu = {0};
     overlay_init();
@@ -1216,6 +1307,7 @@ int main(void) {
     RUN_TEST(test_sys_overlay_mkdir_listdir_unlink);
     RUN_TEST(test_sys_overlay_write_read);
     RUN_TEST(test_sys_overlay_write_empty);
+    RUN_TEST(test_sys_overlay_append);
     RUN_TEST(test_sys_overlay_protects_initrd);
     RUN_TEST(test_sys_stat_initrd_file_and_overlay_dir);
     RUN_TEST(test_sys_overlay_copy_from_initrd);

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -180,6 +180,12 @@ int sys_copy(const char* src, const char* dst) {
     return result;
 }
 
+int sys_append(const char* path, const char* buf, int n) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_APPEND), "b"(path), "c"(buf), "d"(n));
+    return result;
+}
+
 static void print_fs_err(const char* cmd, int rc);
 
 // ==============================================================================
@@ -512,6 +518,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  clear              - Effacer l'écran\n");
     print_string("  echo <text>        - Afficher du texte\n");
     print_string("  write <file> <txt> - Ecrire un fichier overlay (sans >)\n");
+    print_string("  append <file> <txt> - Ajouter du texte (SYS_APPEND)\n");
     print_string("  touch <file>       - Creer un fichier overlay vide\n");
     print_string("  grep <pattern>     - Rechercher dans un texte\n");
     print_string("  wc <file>          - Compter lignes/mots/caractères\n");
@@ -525,7 +532,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  reboot             - Redémarrer le système\n");
     print_string("  shutdown           - Arrêter le système\n");
     
-    print_colored("\nTIP: ls/cat/mkdir/rm/cp/mv/write parlent au noyau (initrd + overlay RAM).\n", COLOR_GREEN);
+    print_colored("\nTIP: ls/cat/mkdir/rm/cp/mv/write/append parlent au noyau (initrd + overlay RAM).\n", COLOR_GREEN);
     print_colored("    Si le mode IA est activé, posez des questions sans 'ai'.\n\n", COLOR_GREEN);
 }
 
@@ -826,6 +833,33 @@ void cmd_write(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("\n");
 }
 
+static void cmd_append(shell_context_t* ctx, char args[][128], int arg_count) {
+    char path[RAMFS_PATH_MAX];
+    char buf[256];
+    int pos = 0;
+    int rc;
+    if (arg_count < 2) {
+        print_error("append: fichier ou texte manquant");
+        return;
+    }
+    resolve_arg(ctx, args[0], path);
+    for (int i = 1; i < arg_count; i++) {
+        int j = 0;
+        if (i > 1 && pos < 254) buf[pos++] = ' ';
+        while (args[i][j] && pos < 254) buf[pos++] = args[i][j++];
+    }
+    buf[pos++] = '\n';
+    buf[pos] = '\0';
+    rc = sys_append(path, buf, pos);
+    if (rc < 0) {
+        print_fs_err("append", rc);
+        return;
+    }
+    print_string("append ok ");
+    print_string(args[0]);
+    print_string("\n");
+}
+
 static void cmd_touch(shell_context_t* ctx, char args[][128], int arg_count) {
     char path[RAMFS_PATH_MAX];
     os_dirent_t st;
@@ -966,7 +1000,7 @@ static void cmd_cat(shell_context_t* ctx, char args[][128], int arg_count) {
 static int is_builtin(const char* cmd) {
     static const char* names[] = {
         "help", "ls", "dir", "ps", "sysinfo", "info", "mem", "memory",
-        "history", "env", "echo", "write", "touch", "clear", "cls", "exit", "quit",
+        "history", "env", "echo", "write", "append", "touch", "clear", "cls", "exit", "quit",
         "ai", "ai-mode", "ai-help", "ai-test", "ai-stats",
         "cd", "pwd", "cat", "stat", "mkdir", "rmdir", "cp", "mv", "rm",
         "kill", "spawn", "jobs", "top", "getpid", "uptime", "date", "whoami",
@@ -1835,6 +1869,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "write") == 0) {
         cmd_write(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "append") == 0) {
+        cmd_append(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "touch") == 0) {
         cmd_touch(ctx, args, arg_count);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`write` écrase toujours le fichier overlay. Il n’y avait pas d’équivalent sendkey de `>>`.

## Changements

- Nouveau syscall `SYS_APPEND` (21) : concatène dans l’overlay (crée le fichier, copie-sur-écriture depuis l’initrd, `NOSPACE` si > 256 octets)
- `append <fichier> <texte>` imprime `append ok <fichier>`
- Smoke : `touch z.txt` → `stat file z.txt 0` → `append z.txt zap` → `stat file z.txt 4`
- Test unitaire : concat, création, dossier, COW initrd, overflow (suite Unity **120**)
- Mock `initrd_read_into` pour lier `overlay_append` dans les tests Unity (sans `fs/initrd.c`)

## Vérifications locales

- [x] `make test-all` : `Total Tests: 120`, 0 failed
- [x] `make qemu-smoke` : `OK: append overlay`, `OK: stat appended` (~130 s)

## Hors périmètre

- Disque persistant
- Taille overlay > 256 octets

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

