### PR TITLE
CI : alias ok et expansion ll=whoami

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run unit tests (make test-all)
         run: make test-all
 
-      - name: QEMU smoke (sendkey ls/cat/ps/uptime/mem/getpid/whoami on serial)
+      - name: QEMU smoke (sendkey ls/cat/ps/uptime/mem/getpid/whoami/alias on serial)
         run: make qemu-smoke
 
       - name: Upload logs

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (CI `whoami` / `which` ; `test f`/`d` ; `append` / `SYS_APPEND` ; overlay SYS_COPY/RENAME)  
+**Code de référence :** `master` (CI `alias ok` / expansion ; `whoami` / `which` ; `test f`/`d` ; overlay SYS_COPY/RENAME)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -88,7 +88,7 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT. `mem` affiche `mem ok <total> <used> <free>` |
 | `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) |
 | `whoami` / `env` / `export` | Variables d’environnement du shell (`USER=root` par défaut). `whoami` affiche `whoami ok root` |
-| `alias` / `unalias` | Table d’alias, expansion avant exécution |
+| `alias` / `unalias` | Table d’alias, expansion avant exécution. Succès : `alias ok <name>` |
 | `history` | Historique en mémoire |
 | `which` | `which ok builtin <cmd>` ou `which ok bin/<cmd>` |
 | `clear`/`cls` | Séquence ANSI + bannière |
@@ -131,13 +131,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/stat/test/head/sort/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/touch/append/rmdir/uptime/mem/getpid/whoami/which
+make qemu-smoke   # QEMU headless + sendkey ls/cat/stat/test/head/alias/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/touch/append/rmdir/uptime/mem/getpid/whoami/which
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `test f`/`test d`, `head`, `sort`, `ai hello` (`SYS_EXEC`), `mem` (`SYS_MEMINFO`), `getpid` (`SYS_GETPID`), `whoami`, `which ls`, `touch`, `append` (`SYS_APPEND`), `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`. `tail` reste une commande shell, hors smoke (budget sendkey).
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `test f`/`test d`, `head`, `alias ll=whoami` puis `ll` (`alias ok ll` / `whoami ok root`), `ai hello` (`SYS_EXEC`), `mem` (`SYS_MEMINFO`), `getpid` (`SYS_GETPID`), `which ls`, `touch`, `append` (`SYS_APPEND`), `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`. `tail` et `sort` restent des commandes shell, hors smoke (budget sendkey).
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -171,7 +171,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/stat/test/head/sort/ai/ps/spawn/kill/uptime/mem/getpid/whoami/which/mkdir/cd/cp/mv/write/touch/append/grep/wc) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/test/head/alias/ai/ps/spawn/kill/uptime/mem/getpid/whoami/which/mkdir/cd/cp/mv/write/touch/append/grep/wc) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -197,11 +197,11 @@ def main():
             ("head hello.txt",
              ["h", "e", "a", "d", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret"],
              "head ok 1 hello.txt"),
-            ("sort hello.txt",
-             ["s", "o", "r", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret"],
-             "sort ok 1 hello.txt"),
             ("ls bin", ["l", "s", "spc", "b", "i", "n", "ret"], "fake_ai"),
-            ("whoami", ["w", "h", "o", "a", "m", "i", "ret"], "whoami ok root"),
+            ("alias ll=whoami",
+             ["a", "l", "i", "a", "s", "spc", "l", "l", "equal", "w", "h", "o", "a", "m", "i", "ret"],
+             "alias ok ll"),
+            ("ll", ["l", "l", "ret"], "whoami ok root"),
             ("which ls",
              ["w", "h", "i", "c", "h", "spc", "l", "s", "ret"],
              "which ok builtin ls"),
@@ -595,6 +595,7 @@ def main():
             ("mem pmm", "mem ok"),
             ("getpid", "getpid ok"),
             ("whoami", "whoami ok root"),
+            ("alias", "alias ok ll"),
             ("which builtin", "which ok builtin ls"),
             ("mkdir overlay", "mkdir ok mydir"),
             ("cd overlay", "cd ok mydir"),
@@ -623,7 +624,6 @@ def main():
             ("stat file", "stat file hello.txt"),
             ("test file", "test ok file hello.txt"),
             ("head initrd", "head ok 1 hello.txt"),
-            ("sort initrd", "sort ok 1 hello.txt"),
             ("stat dir", "stat dir mydir"),
             ("test dir", "test ok dir mydir"),
         ]

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -1476,6 +1476,9 @@ static void cmd_alias(shell_context_t* ctx, char args[][128], int arg_count) {
         for (int i = 0; i < ctx->alias_count; i++) {
             if (strcmp(ctx->aliases[i].alias, name) == 0) {
                 strcpy(ctx->aliases[i].command, value);
+                print_string("alias ok ");
+                print_string(name);
+                print_string("\n");
                 return;
             }
         }
@@ -1486,6 +1489,9 @@ static void cmd_alias(shell_context_t* ctx, char args[][128], int arg_count) {
         strcpy(ctx->aliases[ctx->alias_count].alias, name);
         strcpy(ctx->aliases[ctx->alias_count].command, value);
         ctx->alias_count++;
+        print_string("alias ok ");
+        print_string(name);
+        print_string("\n");
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`alias` était listé par `help` et expandait déjà, mais sans aiguille CI. Le smoke est long : les sendkey en trop doublent parfois la touche `e`.

## Changements

- `alias nom=cmd` affiche `alias ok <nom>`
- Smoke : `alias ll=whoami` puis `ll` (expansion → `whoami ok root`)
- `sort` reste une commande shell ; retiré du smoke (head couvre encore `SYS_READFILE` sur l’initrd)
- Budget sendkey : overlay inchangé vs #70 (`equal` à la place de `sort` + `whoami` direct)

## Vérifications locales

- [x] `make test-all` : `Total Tests: 121`
- [x] `make qemu-smoke` : `OK: alias`, `OK: whoami`, `mv ok notes.txt` (~136 s)

## Hors périmètre

- `unalias` / `export` en smoke
- Codes de retour `$?`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

