### PR TITLE
CI : unalias ok après expansion d’alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run unit tests (make test-all)
         run: make test-all
 
-      - name: QEMU smoke (sendkey ls/cat/ps/uptime/mem/getpid/whoami/alias on serial)
+      - name: QEMU smoke (sendkey ls/cat/ps/uptime/mem/getpid/whoami/alias/unalias on serial)
         run: make qemu-smoke
 
       - name: Upload logs

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d’AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** `master` (CI `alias ok` / expansion ; `whoami` / `which` ; `test f`/`d` ; overlay SYS_COPY/RENAME)  
+**Code de référence :** `master` (CI `unalias ok` ; `alias` / expansion ; `whoami` / `which` ; overlay SYS_COPY/RENAME)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -88,7 +88,7 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT. `mem` affiche `mem ok <total> <used> <free>` |
 | `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) |
 | `whoami` / `env` / `export` | Variables d’environnement du shell (`USER=root` par défaut). `whoami` affiche `whoami ok root` |
-| `alias` / `unalias` | Table d’alias, expansion avant exécution. Succès : `alias ok <name>` |
+| `alias` / `unalias` | Table d’alias, expansion avant exécution. Succès : `alias ok <name>` / `unalias ok <name>` |
 | `history` | Historique en mémoire |
 | `which` | `which ok builtin <cmd>` ou `which ok bin/<cmd>` |
 | `clear`/`cls` | Séquence ANSI + bannière |
@@ -131,13 +131,13 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke   # QEMU headless + sendkey ls/cat/stat/test/head/alias/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/touch/append/rmdir/uptime/mem/getpid/whoami/which
+make qemu-smoke   # QEMU headless + sendkey ls/cat/stat/test/alias/unalias/ai/ps/spawn/kill/mkdir/cd/cp/mv/write/touch/append/rmdir/uptime/mem/getpid/whoami/which
 make ci           # all + test-all + qemu-smoke (même gate que GitHub Actions)
 make run          # console curses (recommandé en local)
 make run-gui      # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `test f`/`test d`, `head`, `alias ll=whoami` puis `ll` (`alias ok ll` / `whoami ok root`), `ai hello` (`SYS_EXEC`), `mem` (`SYS_MEMINFO`), `getpid` (`SYS_GETPID`), `which ls`, `touch`, `append` (`SYS_APPEND`), `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`. `tail` et `sort` restent des commandes shell, hors smoke (budget sendkey).
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU tape aussi `stat`, `test f`/`test d`, `alias ll=whoami` puis `ll` puis `unalias ll` (`alias ok ll` / `whoami ok root` / `unalias ok ll`), `ai hello` (`SYS_EXEC`), `mem` (`SYS_MEMINFO`), `getpid` (`SYS_GETPID`), `which ls`, `touch`, `append` (`SYS_APPEND`), `grep`, `wc`, `cp mydir cpd` et `mv mydir newd` via `sendkey`. `head`, `tail` et `sort` restent des commandes shell, hors smoke (budget sendkey ; `cat` couvre encore `SYS_READFILE` sur l’initrd).
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n’atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -171,7 +171,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/stat/test/head/alias/ai/ps/spawn/kill/uptime/mem/getpid/whoami/which/mkdir/cd/cp/mv/write/touch/append/grep/wc) ===")
+    say("=== QEMU syscall smoke (sendkey ls/cat/stat/test/alias/unalias/ai/ps/spawn/kill/uptime/mem/getpid/whoami/which/mkdir/cd/cp/mv/write/touch/append/grep/wc) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -194,14 +194,14 @@ def main():
             ("stat hello.txt",
              ["s", "t", "a", "t", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret"],
              "stat file hello.txt"),
-            ("head hello.txt",
-             ["h", "e", "a", "d", "spc", "h", "e", "l", "l", "o", "dot", "t", "x", "t", "ret"],
-             "head ok 1 hello.txt"),
             ("ls bin", ["l", "s", "spc", "b", "i", "n", "ret"], "fake_ai"),
             ("alias ll=whoami",
              ["a", "l", "i", "a", "s", "spc", "l", "l", "equal", "w", "h", "o", "a", "m", "i", "ret"],
              "alias ok ll"),
             ("ll", ["l", "l", "ret"], "whoami ok root"),
+            ("unalias ll",
+             ["u", "n", "a", "l", "i", "a", "s", "spc", "l", "l", "ret"],
+             "unalias ok ll"),
             ("which ls",
              ["w", "h", "i", "c", "h", "spc", "l", "s", "ret"],
              "which ok builtin ls"),
@@ -596,6 +596,7 @@ def main():
             ("getpid", "getpid ok"),
             ("whoami", "whoami ok root"),
             ("alias", "alias ok ll"),
+            ("unalias", "unalias ok ll"),
             ("which builtin", "which ok builtin ls"),
             ("mkdir overlay", "mkdir ok mydir"),
             ("cd overlay", "cd ok mydir"),
@@ -623,7 +624,6 @@ def main():
             ("rm write", "rm ok hi.txt"),
             ("stat file", "stat file hello.txt"),
             ("test file", "test ok file hello.txt"),
-            ("head initrd", "head ok 1 hello.txt"),
             ("stat dir", "stat dir mydir"),
             ("test dir", "test ok dir mydir"),
         ]

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -1506,6 +1506,9 @@ static void cmd_unalias(shell_context_t* ctx, char args[][128], int arg_count) {
                 ctx->aliases[j] = ctx->aliases[j + 1];
             }
             ctx->alias_count--;
+            print_string("unalias ok ");
+            print_string(args[0]);
+            print_string("\n");
             return;
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`unalias` était listé par `help` mais sans aiguille CI. Suite naturelle de #71 (`alias ok` + expansion).

Le smoke est long : les sendkey en trop (surtout `e`) doublent parfois une touche.

## Changements

- `unalias <nom>` affiche `unalias ok <nom>`
- Smoke : après `ll`, `unalias ll` → `unalias ok ll` (aucune lettre `e`)
- `head` reste une commande shell ; retiré du smoke (`cat` couvre encore `SYS_READFILE` sur l’initrd)
- Budget sendkey : overlay inchangé vs #71 (`head` avait deux `e`)

## Vérifications locales

- [x] `make test-all` : `Total Tests: 121`
- [x] `make qemu-smoke` : `OK: unalias`, `OK: alias`, `mv ok notes.txt` (~135 s)

## Hors périmètre

- `export` / `env` en smoke
- Codes de retour `$?`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

