### PR TITLE
docs: Add GPT-2 model release download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,22 @@ AI-OS dispose maintenant d’un **moteur d’inférence GPT-2 124M freestanding*
 | Ressources | CPU SSE2 et 1 Gio de RAM QEMU requis pour le checkpoint de référence |
 | Réseau | Profil `openai` sélectionnable dans le shell, mais Ethernet, TCP/IP, DNS et TLS restent à implémenter |
 
-Les fichiers de modèle ne sont **pas versionnés** : ils sont volumineux et doivent être fournis par le constructeur de l’image. Pour une image ISO autonome sur une machine vierge, créez le répertoire suivant, puis construisez avec `make iso`.
+Les fichiers de modèle ne sont **pas versionnés** dans l’historique Git : ils sont volumineux. Les assets validés sont publiés séparément dans la [release GPT-2 124M](https://github.com/kamgueblondin/ai-os/releases/tag/gpt2-124m-assets), avec un manifeste SHA-256. Pour une image ISO autonome sur une machine vierge, téléchargez-les dans le répertoire suivant, vérifiez-les, puis construisez avec `make iso`.
 
 ```text
 models/
 ├── gpt2_124M.bin
 └── gpt2_tokenizer.bin
+```
+
+Téléchargez les deux fichiers et leur manifeste depuis la release, puis vérifiez-les avant la compilation :
+
+```bash
+mkdir -p models
+curl -L -o models/gpt2_124M.bin https://github.com/kamgueblondin/ai-os/releases/download/gpt2-124m-assets/gpt2_124M.bin
+curl -L -o models/gpt2_tokenizer.bin https://github.com/kamgueblondin/ai-os/releases/download/gpt2-124m-assets/gpt2_tokenizer.bin
+curl -L -o models/gpt2-124m-assets.sha256 https://github.com/kamgueblondin/ai-os/releases/download/gpt2-124m-assets/gpt2-124m-assets.sha256
+(cd models && sha256sum -c gpt2-124m-assets.sha256)
 ```
 
 Dans le shell, utilisez `ai hello` pour une génération locale, `ai-provider local` pour sélectionner le moteur embarqué, `ai-model list` pour afficher les profils, `ai-runtime` pour les limites d’exécution et `rc` pour confirmer la reprise du shell après une réponse.

--- a/docs/gpt2_baremetal_deployment.md
+++ b/docs/gpt2_baremetal_deployment.md
@@ -21,6 +21,25 @@ Cette version d’AI-OS contient un premier chemin d’inférence **réellement 
 
 GPT-2 est un transformeur causal, c’est-à-dire qu’un jeton ne porte attention qu’aux jetons précédents ; il convient donc à la génération auto-régressive de texte [1]. Le tokenizer de référence GPT-2 emploie un BPE au niveau des octets [1]. La présente implémentation charge bien le vocabulaire d’origine mais utilise, pour le premier chemin bare-metal, un encodage ASCII glouton simplifié : il ne reproduit pas encore toute la segmentation BPE/Unicode de référence.
 
+## Obtenir et vérifier les artefacts GPT-2
+
+Les poids ne sont pas stockés dans l’historique Git. Téléchargez `gpt2_124M.bin`, `gpt2_tokenizer.bin` et `gpt2-124m-assets.sha256` depuis la [release publique GPT-2 124M](https://github.com/kamgueblondin/ai-os/releases/tag/gpt2-124m-assets), puis placez-les dans `models/`.
+
+```bash
+mkdir -p models
+curl -L -o models/gpt2_124M.bin https://github.com/kamgueblondin/ai-os/releases/download/gpt2-124m-assets/gpt2_124M.bin
+curl -L -o models/gpt2_tokenizer.bin https://github.com/kamgueblondin/ai-os/releases/download/gpt2-124m-assets/gpt2_tokenizer.bin
+curl -L -o models/gpt2-124m-assets.sha256 https://github.com/kamgueblondin/ai-os/releases/download/gpt2-124m-assets/gpt2-124m-assets.sha256
+(cd models && sha256sum -c gpt2-124m-assets.sha256)
+```
+
+Les empreintes attendues sont les suivantes :
+
+| Fichier | SHA-256 |
+|---|---|
+| `gpt2_124M.bin` | `3da8b207584030bcdcd207cf7a99952e3421dce92da218b351071857511bf162` |
+| `gpt2_tokenizer.bin` | `6f3abc21e444e4e8300e225f4e03da48ea121cf17e30f67009b8dad7a66c2f13` |
+
 ## Contenu de l’ISO
 
 L’archive `build/ai_os.iso` contient les éléments suivants :


### PR DESCRIPTION
## Résumé

Cette pull request documente la distribution des artefacts GPT-2 requis par AI-OS après la fusion de la PR #75.

Elle ajoute au README principal et au guide de déploiement :

- le lien vers la release publique [`gpt2-124m-assets`](https://github.com/kamgueblondin/ai-os/releases/tag/gpt2-124m-assets) ;
- les commandes de téléchargement du checkpoint, du tokenizer et du manifeste SHA-256 ;
- les empreintes attendues et la vérification `sha256sum -c` avant construction de l’ISO.

Les poids restent des assets de release et ne rejoignent pas l’historique Git du dépôt.
