### PR TITLE
GPT-2 BPE encode and raw-byte decode for ai input/output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,7 @@ help:
 	@echo "Tests de non-régression:"
 	@echo "  make test-setup           # Configuration initiale (une fois)"
 	@echo "  make test-quick           # Tests pendant développement"
-	@echo "  make test-all             # 121 tests Unity avant push"
+	@echo "  make test-all             # 134 tests Unity avant push"
 
 .PHONY: all kernel-only run run-gui test-build info-initrd info-user user-program userspace-all clean distclean help pack-initrd test-setup test-quick test-kernel test-userspace test-all test-performance test-valgrind test-clean pre-commit-tests ci-tests qemu-smoke gpt2-recovery gpt2-benchmark gpt2-tests ci deps
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ git clone https://github.com/kamgueblondin/ai-os.git
 cd ai-os
 make deps          # ou : bash scripts/bootstrap-dev.sh
 make all
-make test-all      # 121 tests Unity, sans poids GPT-2
+make test-all      # 134 tests Unity, sans poids GPT-2
 make run           # QEMU curses ; le shell lit le clavier PS/2, pas le port série
 ```
 
@@ -94,7 +94,7 @@ make qemu-smoke    # smoke QEMU (CI)
 make ci            # même gate que GitHub Actions
 ```
 
-Unity 32-bit : **121** tests. Les dossiers `tests/integration`, `tests/system`, `tests/performance` et `tests/robustness` sont vides. Les pourcentages de "couverture" affichés par d'anciens scripts ne sont pas mesurés par gcov.
+Unity 32-bit : **134** tests (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_tokenizer` 13, `test_shell` 25, `test_ramfs` 10). Les dossiers `tests/integration`, `tests/system`, `tests/performance` et `tests/robustness` sont vides. Les pourcentages de "couverture" affiches par d'anciens scripts ne sont pas mesures par gcov.
 
 GitHub Actions (`.github/workflows/ci.yml`) : à chaque push/PR vers `master` (et `main` si la branche est renommée) - `make all`, `make test-all`, `make qemu-smoke`.
 
@@ -128,7 +128,8 @@ ai-os/
 Le dossier [`US/`](US/README.md) décrit la vision MOHHOS (spécifications, pas l'état du dépôt).
 
 - [x] Inférence GPT-2 locale + cache KV / SSE2
-- [ ] Tokenizer BPE complet, quantification, chargeur GGUF, latence &lt; 1 s
+- [x] Tokenizer BPE GPT-2 (entree et sortie)
+- [ ] Quantification, chargeur GGUF, latence &lt; 1 s
 - [ ] Réseau, DNS, TLS, fournisseur OpenAI effectif
 - [ ] Système de fichiers persistant
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -59,10 +59,11 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | `test_pmm` | 17/17 |
 | `test_syscall` | 48/48 |
 | `test_task` | 21/21 |
+| `test_tokenizer` | 13/13 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
 
-Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé "Total Tests" de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des cinq binaires (**121** = 17+48+21+25+10).
+Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé "Total Tests" de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des six binaires (**134** = 17+48+21+13+25+10).
 
 Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en plus de `nasm` et `qemu-system-i386`).
 
@@ -99,9 +100,9 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 
 ## Intelligence artificielle locale
 
-Le chemin local de `ai <texte>` appelle `SYS_GPT2_GENERATE`. Le noyau charge au boot le checkpoint GPT-2 124M en format `llm.c v3` et le tokenizer binaire depuis l'initrd. L'inférence est écrite en C freestanding ; elle utilise un cache clé/valeur par couche et position, un échantillonnage top-k avec pénalité de répétition et un état pseudo-aléatoire. Le noyau est compilé avec `-O3`, SSE2 et `-mstackrealign`, puis active SSE au démarrage.
+Le chemin local de `ai <texte>` appelle `SYS_GPT2_GENERATE`. Le noyau charge au boot le checkpoint GPT-2 124M en format `llm.c v3` et le tokenizer binaire depuis l'initrd. L'inférence est écrite en C freestanding ; elle utilise un cache clé/valeur par couche et position. L'entrée est tokenisée en **BPE GPT-2** (fusions par plus petit identifiant de vocabulaire, découpage type regex). La sortie décode les octets bruts tiktoken (espaces, sauts de ligne, UTF-8) sans les remplacer par des espaces. La génération est **greedy**, jusqu'à 12 jetons ou le premier saut de ligne / EOT.
 
-La démonstration limite le prompt à 64 jetons et génère jusqu'à 4 jetons. L'encodeur de prompt est ASCII glouton : il ne couvre pas encore le BPE complet. Les poids et le tokenizer ne sont pas distribués dans Git ; sans ces deux fichiers, le moteur local est signalé comme indisponible. `userspace/ai_assistant.c` et `userspace/fake_ai.c` sont conservés comme programmes historiques de compatibilité. `initrd_content/ai_knowledge.txt` et `ai_data.txt` restent de simples fichiers texte, sans base vectorielle.
+La démonstration limite le prompt à 64 jetons et génère jusqu'à 12 jetons (arrêt sur newline ou EOT). L'encodeur BPE couvre le vocabulaire llm.c ; le regex unicode `\p{L}` complet n'est pas reproduit (ASCII + séquences UTF-8). Les poids et le tokenizer ne sont pas distribués dans Git ; sans ces deux fichiers, le moteur local est signalé comme indisponible. `userspace/ai_assistant.c` et `userspace/fake_ai.c` sont conservés comme programmes historiques de compatibilité.
 
 La configuration mesurée avec QEMU sans KVM est de 7,693 s pour `ai hello` et quatre jetons, contre 88,835 s avant l'optimisation SSE2. Le réalignement de pile évite également un défaut de protection générale qui pouvait survenir dans la copie récursive de l'overlay lorsque le compilateur produisait des instructions SSE alignées. Le détail figure dans [kv_cache_performance_report.md](kv_cache_performance_report.md).
 

--- a/kernel/llm/gpt2_tokenizer.c
+++ b/kernel/llm/gpt2_tokenizer.c
@@ -3,6 +3,10 @@
 
 #define GPT2_TOKENIZER_MAGIC 20240328U
 #define GPT2_TOKENIZER_MAX_VOCAB 50257U
+#define GPT2_TOKEN_HASH_SIZE 65536U
+#define GPT2_HASH_EMPTY 0xFFFFFFFFU
+#define GPT2_BPE_MAX_PARTS 160U
+#define GPT2_DECODE_MAX 256U
 
 typedef struct {
     const uint8_t* bytes;
@@ -10,22 +14,216 @@ typedef struct {
 } gpt2_token_piece_t;
 
 static gpt2_token_piece_t token_table[GPT2_TOKENIZER_MAX_VOCAB];
+static uint32_t token_hash[GPT2_TOKEN_HASH_SIZE];
 static uint32_t tokenizer_vocab_size;
 static uint32_t tokenizer_eot;
 static int tokenizer_ready;
-static char decoded_piece[256];
+static char decoded_piece[GPT2_DECODE_MAX];
 static const char* tokenizer_status = "GPT-2 tokenizer: aucun vocabulaire charge";
+
+static uint32_t gpt2_hash_bytes(const uint8_t* bytes, uint32_t length) {
+    uint32_t hash = 2166136261U;
+    for (uint32_t i = 0; i < length; i++) {
+        hash ^= bytes[i];
+        hash *= 16777619U;
+    }
+    return hash;
+}
+
+static int gpt2_bytes_equal(const uint8_t* a, const uint8_t* b, uint32_t length) {
+    for (uint32_t i = 0; i < length; i++) {
+        if (a[i] != b[i]) return 0;
+    }
+    return 1;
+}
 
 static void tokenizer_reset(const char* status) {
     tokenizer_vocab_size = 0;
     tokenizer_eot = 0;
     tokenizer_ready = 0;
     tokenizer_status = status;
+    for (uint32_t i = 0; i < GPT2_TOKEN_HASH_SIZE; i++) token_hash[i] = GPT2_HASH_EMPTY;
 }
 
-int gpt2_tokenizer_load_from_initrd(const char* path) {
-    const uint8_t* blob = (const uint8_t*)initrd_read_file(path);
-    uint32_t blob_size = initrd_get_file_size(path);
+static int gpt2_hash_insert(uint32_t token_id) {
+    uint32_t length = token_table[token_id].length;
+    uint32_t hash = gpt2_hash_bytes(token_table[token_id].bytes, length);
+    for (uint32_t probe = 0; probe < GPT2_TOKEN_HASH_SIZE; probe++) {
+        uint32_t slot = (hash + probe) & (GPT2_TOKEN_HASH_SIZE - 1U);
+        if (token_hash[slot] == GPT2_HASH_EMPTY) {
+            token_hash[slot] = token_id;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static uint32_t gpt2_lookup_token(const uint8_t* bytes, uint32_t length) {
+    uint32_t hash;
+    if (!bytes || length == 0) return GPT2_HASH_EMPTY;
+    hash = gpt2_hash_bytes(bytes, length);
+    for (uint32_t probe = 0; probe < GPT2_TOKEN_HASH_SIZE; probe++) {
+        uint32_t slot = (hash + probe) & (GPT2_TOKEN_HASH_SIZE - 1U);
+        uint32_t token_id = token_hash[slot];
+        if (token_id == GPT2_HASH_EMPTY) return GPT2_HASH_EMPTY;
+        if (token_table[token_id].length == length &&
+            gpt2_bytes_equal(token_table[token_id].bytes, bytes, length)) {
+            return token_id;
+        }
+    }
+    return GPT2_HASH_EMPTY;
+}
+
+static int gpt2_is_ascii_letter(uint8_t c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+
+static int gpt2_is_digit(uint8_t c) {
+    return c >= '0' && c <= '9';
+}
+
+static int gpt2_is_space(uint8_t c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
+static int gpt2_is_letter(uint8_t c) {
+    return gpt2_is_ascii_letter(c) || c >= 0xC0U;
+}
+
+static int gpt2_match_ci(const uint8_t* text, uint32_t remaining, const char* lit) {
+    uint32_t i = 0;
+    while (lit[i] != '\0') {
+        uint8_t expected = (uint8_t)lit[i];
+        uint8_t got;
+        if (i >= remaining) return 0;
+        got = text[i];
+        if (expected >= 'a' && expected <= 'z') {
+            if (got != expected && got != (uint8_t)(expected - 32U)) return 0;
+        } else if (got != expected) {
+            return 0;
+        }
+        i++;
+    }
+    return 1;
+}
+
+/* Decoupage proche de la regex GPT-2 (ASCII + sequences UTF-8). */
+static uint32_t gpt2_next_chunk(const uint8_t* text, uint32_t length, uint32_t pos) {
+    uint32_t start;
+    uint32_t i;
+    if (pos >= length) return 0;
+
+    if (text[pos] == '\'' &&
+        (gpt2_match_ci(text + pos, length - pos, "'s") ||
+         gpt2_match_ci(text + pos, length - pos, "'t") ||
+         gpt2_match_ci(text + pos, length - pos, "'m") ||
+         gpt2_match_ci(text + pos, length - pos, "'d"))) {
+        return 2;
+    }
+    if (text[pos] == '\'' &&
+        (gpt2_match_ci(text + pos, length - pos, "'re") ||
+         gpt2_match_ci(text + pos, length - pos, "'ve") ||
+         gpt2_match_ci(text + pos, length - pos, "'ll"))) {
+        return 3;
+    }
+
+    start = pos;
+    if (text[pos] == ' ' && pos + 1U < length &&
+        (gpt2_is_letter(text[pos + 1U]) || gpt2_is_digit(text[pos + 1U]) ||
+         !gpt2_is_space(text[pos + 1U]))) {
+        pos++;
+    }
+    if (pos < length && gpt2_is_letter(text[pos])) {
+        pos++;
+        while (pos < length && (gpt2_is_ascii_letter(text[pos]) ||
+                                (text[pos] >= 0x80U && text[pos] <= 0xBFU) ||
+                                text[pos] >= 0xC0U)) {
+            pos++;
+        }
+        return pos - start;
+    }
+    if (pos < length && gpt2_is_digit(text[pos])) {
+        pos++;
+        while (pos < length && gpt2_is_digit(text[pos])) pos++;
+        return pos - start;
+    }
+    if (pos < length && !gpt2_is_space(text[pos]) && !gpt2_is_letter(text[pos]) &&
+        !gpt2_is_digit(text[pos])) {
+        pos++;
+        while (pos < length && !gpt2_is_space(text[pos]) && !gpt2_is_letter(text[pos]) &&
+               !gpt2_is_digit(text[pos])) {
+            pos++;
+        }
+        return pos - start;
+    }
+
+    if (gpt2_is_space(text[start])) {
+        i = start;
+        while (i < length && gpt2_is_space(text[i])) i++;
+        return i - start;
+    }
+    return 1;
+}
+
+static int gpt2_bpe_chunk(const uint8_t* chunk, uint32_t chunk_len,
+                          uint32_t* out_tokens, uint32_t max_tokens,
+                          uint32_t* inout_count) {
+    uint32_t starts[GPT2_BPE_MAX_PARTS];
+    uint32_t lengths[GPT2_BPE_MAX_PARTS];
+    uint32_t parts;
+    uint32_t count = *inout_count;
+
+    if (chunk_len == 0) return 0;
+    if (chunk_len > GPT2_BPE_MAX_PARTS) {
+        tokenizer_status = "GPT-2 tokenizer: morceau trop long";
+        return -3;
+    }
+
+    parts = chunk_len;
+    for (uint32_t i = 0; i < chunk_len; i++) {
+        starts[i] = i;
+        lengths[i] = 1;
+        if (gpt2_lookup_token(chunk + i, 1) == GPT2_HASH_EMPTY) {
+            tokenizer_status = "GPT-2 tokenizer: octet absent du vocabulaire";
+            return -2;
+        }
+    }
+
+    while (parts > 1U) {
+        uint32_t best_id = GPT2_HASH_EMPTY;
+        uint32_t best_index = 0;
+        for (uint32_t i = 0; i + 1U < parts; i++) {
+            uint32_t merged_len = lengths[i] + lengths[i + 1U];
+            uint32_t token_id = gpt2_lookup_token(chunk + starts[i], merged_len);
+            if (token_id == GPT2_HASH_EMPTY) continue;
+            if (best_id == GPT2_HASH_EMPTY || token_id < best_id) {
+                best_id = token_id;
+                best_index = i;
+            }
+        }
+        if (best_id == GPT2_HASH_EMPTY) break;
+        lengths[best_index] += lengths[best_index + 1U];
+        for (uint32_t i = best_index + 1U; i + 1U < parts; i++) {
+            starts[i] = starts[i + 1U];
+            lengths[i] = lengths[i + 1U];
+        }
+        parts--;
+    }
+
+    if (count + parts > max_tokens) {
+        tokenizer_status = "GPT-2 tokenizer: contexte trop long";
+        return -3;
+    }
+    for (uint32_t i = 0; i < parts; i++) {
+        uint32_t token_id = gpt2_lookup_token(chunk + starts[i], lengths[i]);
+        if (token_id == GPT2_HASH_EMPTY) return -2;
+        out_tokens[count++] = token_id;
+    }
+    *inout_count = count;
+    return 0;
+}
+
+int gpt2_tokenizer_load_from_buffer(const uint8_t* blob, uint32_t blob_size) {
     const uint32_t* header;
     uint32_t offset = 1024;
 
@@ -60,66 +258,68 @@ int gpt2_tokenizer_load_from_initrd(const char* path) {
         token_table[token].bytes = blob + offset;
         token_table[token].length = length;
         offset += length;
+        if (gpt2_hash_insert(token) != 0) {
+            tokenizer_reset("GPT-2 tokenizer: table de hachage pleine");
+            return -6;
+        }
     }
     tokenizer_ready = 1;
     tokenizer_status = "GPT-2 tokenizer: vocabulaire local valide";
     return 0;
 }
 
-int gpt2_tokenizer_encode_ascii(const char* text, uint32_t* out_tokens,
-                                uint32_t max_tokens, uint32_t* out_count) {
-    uint32_t position = 0;
-    uint32_t count = 0;
-    if (!text || !out_tokens || !out_count || !tokenizer_ready) return -1;
+int gpt2_tokenizer_load_from_initrd(const char* path) {
+    const uint8_t* blob = (const uint8_t*)initrd_read_file(path);
+    uint32_t blob_size = initrd_get_file_size(path);
+    return gpt2_tokenizer_load_from_buffer(blob, blob_size);
+}
 
-    while (text[position] != '\0') {
-        uint32_t best_token = tokenizer_eot;
-        uint32_t best_length = 0;
-        for (uint32_t token = 0; token < tokenizer_vocab_size; token++) {
-            uint32_t length = token_table[token].length;
-            if (length <= best_length) continue;
-            uint32_t matched = 1;
-            for (uint32_t i = 0; i < length; i++) {
-                if (text[position + i] == '\0' ||
-                    (uint8_t)text[position + i] != token_table[token].bytes[i]) {
-                    matched = 0;
-                    break;
-                }
-            }
-            if (matched) {
-                best_token = token;
-                best_length = length;
-            }
-        }
-        if (best_length == 0) {
-            tokenizer_status = "GPT-2 tokenizer: octet non representable";
-            return -2;
-        }
-        if (count >= max_tokens) {
-            tokenizer_status = "GPT-2 tokenizer: contexte trop long";
-            return -3;
-        }
-        out_tokens[count++] = best_token;
-        position += best_length;
+int gpt2_tokenizer_encode(const char* text, uint32_t* out_tokens,
+                          uint32_t max_tokens, uint32_t* out_count) {
+    const uint8_t* bytes;
+    uint32_t length = 0;
+    uint32_t pos = 0;
+    uint32_t count = 0;
+    int rc;
+
+    if (!text || !out_tokens || !out_count || !tokenizer_ready) return -1;
+    bytes = (const uint8_t*)text;
+    while (bytes[length] != '\0') length++;
+
+    while (pos < length) {
+        uint32_t chunk_len = gpt2_next_chunk(bytes, length, pos);
+        if (chunk_len == 0) break;
+        rc = gpt2_bpe_chunk(bytes + pos, chunk_len, out_tokens, max_tokens, &count);
+        if (rc != 0) return rc;
+        pos += chunk_len;
     }
     if (count == 0) {
         if (max_tokens == 0) return -3;
         out_tokens[count++] = tokenizer_eot;
     }
     *out_count = count;
-    tokenizer_status = "GPT-2 tokenizer: encodage ASCII termine";
+    tokenizer_status = "GPT-2 tokenizer: encodage BPE termine";
     return 0;
 }
 
+int gpt2_tokenizer_encode_ascii(const char* text, uint32_t* out_tokens,
+                                uint32_t max_tokens, uint32_t* out_count) {
+    return gpt2_tokenizer_encode(text, out_tokens, max_tokens, out_count);
+}
+
 const char* gpt2_tokenizer_decode(uint32_t token_id) {
+    uint32_t length;
+    uint32_t out = 0;
     if (!tokenizer_ready || token_id >= tokenizer_vocab_size) return 0;
-    uint32_t length = token_table[token_id].length;
-    if (length > 255U) length = 255U;
-    for (uint32_t i = 0; i < length; i++) {
+    length = token_table[token_id].length;
+    for (uint32_t i = 0; i < length && out + 1U < GPT2_DECODE_MAX; i++) {
         uint8_t value = token_table[token_id].bytes[i];
-        decoded_piece[i] = (value >= 32U && value <= 126U) ? (char)value : ' ';
+        if (value == 0) continue;
+        if (value < 32U && value != '\t' && value != '\n' && value != '\r') continue;
+        if (value == 127U) continue;
+        decoded_piece[out++] = (char)value;
     }
-    decoded_piece[length] = '\0';
+    decoded_piece[out] = '\0';
     return decoded_piece;
 }
 

--- a/kernel/llm/gpt2_tokenizer.h
+++ b/kernel/llm/gpt2_tokenizer.h
@@ -3,8 +3,12 @@
 
 #include <stdint.h>
 
-/* Tokenizer binary format compatible with the lightweight llm.c decoder. */
+/* Tokenizer llm.c (magic 20240328) : vocabulaire en octets bruts tiktoken. */
+int gpt2_tokenizer_load_from_buffer(const uint8_t* blob, uint32_t blob_size);
 int gpt2_tokenizer_load_from_initrd(const char* path);
+/* BPE GPT-2 (fusions par plus petit id, decoupage type regex). */
+int gpt2_tokenizer_encode(const char* text, uint32_t* out_tokens,
+                          uint32_t max_tokens, uint32_t* out_count);
 int gpt2_tokenizer_encode_ascii(const char* text, uint32_t* out_tokens,
                                 uint32_t max_tokens, uint32_t* out_count);
 const char* gpt2_tokenizer_decode(uint32_t token_id);

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -13,9 +13,8 @@
 #include "../llm/gpt2_infer.h"
 #include "../llm/gpt2_model.h"
 #include "../llm/gpt2_tokenizer.h"
-/* Limite volontaire : le premier moteur CPU ne dispose pas encore de cache KV. */
-#define GPT2_BAREMETAL_GENERATION_STEPS 4U
-static uint32_t gpt2_rng_state = 0x6d2b79f5U;
+/* Completions locales : BPE en entree, greedy, arret newline/EOT, 12 jetons max. */
+#define GPT2_BAREMETAL_GENERATION_STEPS 12U
 
 // Externs VMM
 extern vmm_directory_t* current_directory;
@@ -174,36 +173,28 @@ int sys_gpt2_generate(const char* prompt, char* out, uint32_t max) {
     int rc;
 
     if (!prompt || !out || max < 2) return -1;
-    /* Entree texte stable : ASCII imprimable, espaces normalises et prompt borne. */
+    /* Conserve punctuation, apostrophes, espaces simples et UTF-8. */
     uint32_t input_pos = 0;
     uint32_t output_pos = 0;
-    int pending_space = 0;
     while (input_pos < 255U && prompt[input_pos] != '\0' && output_pos + 1U < sizeof(prompt_copy)) {
         uint8_t ch = (uint8_t)prompt[input_pos++];
-        if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n') {
-            if (output_pos > 0U) pending_space = 1;
-            continue;
-        }
-        if (ch < 32U || ch > 126U) continue;
-        if (pending_space && output_pos + 2U < sizeof(prompt_copy)) prompt_copy[output_pos++] = ' ';
-        pending_space = 0;
+        if (ch == '\t' || ch == '\r' || ch == '\n') ch = ' ';
+        if (ch < 32U || ch == 127U) continue;
+        if (ch == ' ' && (output_pos == 0U || (uint8_t)prompt_copy[output_pos - 1U] == ' ')) continue;
         prompt_copy[output_pos++] = (char)ch;
     }
     prompt_copy[output_pos] = '\0';
 
-    rc = gpt2_tokenizer_encode_ascii(prompt_copy, tokens, 64, &token_count);
+    rc = gpt2_tokenizer_encode(prompt_copy, tokens, 64, &token_count);
     if (rc != 0) return -2;
-    /* Melange le prompt a l'etat de tirage pour eviter une reponse identique a chaque requete. */
-    for (uint32_t i = 0; i < token_count; i++) {
-        gpt2_rng_state ^= tokens[i] + 0x9e3779b9U + (gpt2_rng_state << 6) + (gpt2_rng_state >> 2);
-    }
     model = gpt2_model_current();
     if (!model->ready || token_count > model->config.max_seq_len) return -5;
 
     for (uint32_t step = 0; step < GPT2_BAREMETAL_GENERATION_STEPS && token_count < 64 && token_count < model->config.max_seq_len; step++) {
         uint32_t next_token = 0;
         const char* piece;
-        rc = gpt2_generate_next_sampled(tokens, token_count, &next_token, &gpt2_rng_state);
+        int saw_newline = 0;
+        rc = gpt2_generate_next(tokens, token_count, &next_token);
         if (rc != 0) return -30 + rc;
         if (next_token == gpt2_tokenizer_eot()) break;
         tokens[token_count++] = next_token;
@@ -215,7 +206,9 @@ int sys_gpt2_generate(const char* prompt, char* out, uint32_t max) {
                 return (int)written;
             }
             out[written++] = piece[i];
+            if (piece[i] == '\n') saw_newline = 1;
         }
+        if (saw_newline) break;
     }
     out[written] = '\0';
     return (int)written;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -82,6 +82,11 @@ test-robustness: $(ROBUSTNESS_TEST_BINS)
 	@bash ./scripts/run_all_tests.sh --robustness
 
 # Compilation des tests kernel
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_tokenizer: $(UNIT_DIR)/kernel/test_tokenizer.c ../kernel/llm/gpt2_tokenizer.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_tokenizer.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_%: $(UNIT_DIR)/kernel/test_%.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -99,6 +99,9 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/userspace/ramfs.c $BASE_DIR/userspace/procsim.c"
         cflags="$cflags -I$BASE_DIR/userspace"
     fi
+    if [ "$(basename "$test_file")" = "test_tokenizer.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_tokenizer.c"
+    fi
     
     # Compiler
     echo "gcc $cflags -o \"$test_binary\" \"$test_file\" $extra_src \"$TEST_DIR/framework/unity.c\" \"$TEST_DIR/framework/test_kernel.c\" \"$TEST_DIR/framework/kernel_mocks.c\"" >> "$RESULTS_FILE"

--- a/tests/unit/kernel/test_tokenizer.c
+++ b/tests/unit/kernel/test_tokenizer.c
@@ -1,0 +1,193 @@
+/* test_tokenizer.c - BPE GPT-2 (entree) et decode (sortie) */
+
+#include <string.h>
+#include "../../framework/unity.h"
+#include "../../../kernel/llm/gpt2_tokenizer.h"
+
+char* initrd_read_file(const char* filename) {
+    (void)filename;
+    return 0;
+}
+
+uint32_t initrd_get_file_size(const char* filename) {
+    (void)filename;
+    return 0;
+}
+
+static uint8_t g_blob[4096] __attribute__((aligned(4)));
+
+static void blob_put_piece(uint32_t* offset, const char* bytes, uint8_t length) {
+    g_blob[(*offset)++] = length;
+    for (uint8_t i = 0; i < length; i++) g_blob[(*offset)++] = (uint8_t)bytes[i];
+}
+
+static int load_synthetic_vocab(void) {
+    uint32_t header[256];
+    uint32_t offset;
+    memset(header, 0, sizeof(header));
+    header[0] = 20240328U;
+    header[1] = 2;
+    header[2] = 21;
+    header[3] = 20; /* EOT */
+    memcpy(g_blob, header, sizeof(header));
+    offset = 1024;
+    blob_put_piece(&offset, "a", 1);
+    blob_put_piece(&offset, "b", 1);
+    blob_put_piece(&offset, "c", 1);
+    blob_put_piece(&offset, "h", 1);
+    blob_put_piece(&offset, "e", 1);
+    blob_put_piece(&offset, "l", 1);
+    blob_put_piece(&offset, "o", 1);
+    blob_put_piece(&offset, " ", 1);
+    blob_put_piece(&offset, "he", 2);
+    blob_put_piece(&offset, "hel", 3);
+    blob_put_piece(&offset, "hell", 4);
+    blob_put_piece(&offset, "hello", 5);
+    blob_put_piece(&offset, "ab", 2);
+    blob_put_piece(&offset, "abc", 3);
+    blob_put_piece(&offset, "!", 1);
+    blob_put_piece(&offset, "\n", 1);
+    blob_put_piece(&offset, "\xC3", 1);
+    blob_put_piece(&offset, "\xA9", 1);
+    blob_put_piece(&offset, "\xC3\xA9", 2);
+    blob_put_piece(&offset, "\x01", 1);
+    blob_put_piece(&offset, "E", 1);
+    return gpt2_tokenizer_load_from_buffer(g_blob, offset);
+}
+
+void setUp(void) {
+    TEST_ASSERT_EQUAL(0, load_synthetic_vocab());
+}
+
+void tearDown(void) {
+}
+
+static void test_load_rejects_short_buffer(void) {
+    uint8_t tiny[8];
+    setUp();
+    TEST_ASSERT_TRUE(gpt2_tokenizer_load_from_buffer(tiny, 8) < 0);
+    TEST_ASSERT_EQUAL(0, load_synthetic_vocab());
+}
+
+static void test_encode_empty_yields_eot(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode("", tokens, 8, &count));
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL(20, tokens[0]);
+    TEST_ASSERT_EQUAL(20, gpt2_tokenizer_eot());
+}
+
+static void test_encode_bpe_merges_abc(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode("abc", tokens, 8, &count));
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL(13, tokens[0]);
+}
+
+static void test_encode_bpe_partial_ab(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode("ab", tokens, 8, &count));
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL(12, tokens[0]);
+}
+
+static void test_encode_hello_uses_merge_chain(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode("hello", tokens, 8, &count));
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL(11, tokens[0]);
+}
+
+static void test_encode_splits_punctuation(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode("hello!", tokens, 8, &count));
+    TEST_ASSERT_EQUAL(2, count);
+    TEST_ASSERT_EQUAL(11, tokens[0]);
+    TEST_ASSERT_EQUAL(14, tokens[1]);
+}
+
+static void test_encode_keeps_space_chunk(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode("ab c", tokens, 8, &count));
+    TEST_ASSERT_EQUAL(3, count);
+    TEST_ASSERT_EQUAL(12, tokens[0]);
+    TEST_ASSERT_EQUAL(7, tokens[1]);
+    TEST_ASSERT_EQUAL(2, tokens[2]);
+}
+
+static void test_encode_unknown_byte_fails(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    char text[2];
+    setUp();
+    text[0] = 2;
+    text[1] = 0;
+    TEST_ASSERT_TRUE(gpt2_tokenizer_encode(text, tokens, 8, &count) < 0);
+}
+
+static void test_decode_keeps_ascii_and_space(void) {
+    setUp();
+    TEST_ASSERT_EQUAL_STRING("hello", gpt2_tokenizer_decode(11));
+    TEST_ASSERT_EQUAL_STRING(" ", gpt2_tokenizer_decode(7));
+    TEST_ASSERT_EQUAL_STRING("\n", gpt2_tokenizer_decode(15));
+}
+
+static void test_decode_keeps_utf8(void) {
+    setUp();
+    TEST_ASSERT_EQUAL_STRING("\xC3\xA9", gpt2_tokenizer_decode(18));
+}
+
+static void test_decode_drops_control_bytes(void) {
+    setUp();
+    TEST_ASSERT_EQUAL_STRING("", gpt2_tokenizer_decode(19));
+}
+
+static void test_encode_utf8_letter_chunk(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode("\xC3\xA9", tokens, 8, &count));
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL(18, tokens[0]);
+}
+
+static void test_encode_ascii_wrapper(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode_ascii("a", tokens, 8, &count));
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL(0, tokens[0]);
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_load_rejects_short_buffer);
+    RUN_TEST(test_encode_empty_yields_eot);
+    RUN_TEST(test_encode_bpe_merges_abc);
+    RUN_TEST(test_encode_bpe_partial_ab);
+    RUN_TEST(test_encode_hello_uses_merge_chain);
+    RUN_TEST(test_encode_splits_punctuation);
+    RUN_TEST(test_encode_keeps_space_chunk);
+    RUN_TEST(test_encode_unknown_byte_fails);
+    RUN_TEST(test_decode_keeps_ascii_and_space);
+    RUN_TEST(test_decode_keeps_utf8);
+    RUN_TEST(test_decode_drops_control_bytes);
+    RUN_TEST(test_encode_utf8_letter_chunk);
+    RUN_TEST(test_encode_ascii_wrapper);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -1942,7 +1942,7 @@ void call_ai_assistant(shell_context_t* ctx, const char* query) {
     print_string(ai_model_name(ctx));
     print_string("\n");
     if (strstr(ai_model_name(ctx), "gpt2") != 0) {
-        char generated[256];
+        char generated[384];
         int generated_len = sys_gpt2_generate(query, generated, sizeof(generated));
         if (generated_len >= 0) {
             print_colored("[GPT-2 local] ", COLOR_GREEN);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Le moteur GPT-2 local encodait le prompt en plus long prefixe ASCII et remplaçait tout octet hors 32-126 par un espace a la sortie. `ai hello` voyait donc de mauvais jetons et imprimait une continuation cassee.

## Entree
- BPE GPT-2 : fusions par plus petit id de vocabulaire (format llm.c / tiktoken `decode_bytes`)
- Decoupage type regex (`'s`/`'t`/lettres/chiffres/ponctuation/UTF-8)
- `SYS_GPT2_GENERATE` conserve apostrophes, ponctuation et UTF-8

## Sortie
- Decode des octets bruts (espace, newline, UTF-8) ; controles C0 ignores
- Generation greedy, jusqu'a 12 jetons ou premier saut de ligne / EOT
- Buffer shell 384 octets

## Tests
- `test_tokenizer` : 13 cas (fusions `hello`/`abc`, ponctuation, UTF-8, controles)
- Suite Unity : **134** (17+48+21+13+25+10)
- `make ci` ne telecharge toujours pas `models/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

