### PR TITLE
Persist overlay on QEMU IDE disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run unit tests (make test-all)
         run: make test-all
 
-      - name: QEMU smoke (sendkey shell extras + overlay on serial)
+      - name: QEMU smoke (overlay + extras + persist disque)
         run: make qemu-smoke
 
       - name: Upload logs

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ ASFLAGS = -f elf32
 OS_IMAGE = build/ai_os.bin
 ISO_IMAGE = build/ai_os.iso
 INITRD_IMAGE = my_initrd.tar
+DISK_IMAGE ?= build/overlay.img
+DISK_SECTORS ?= 64
+QEMU_DISK_OPTS = -drive file=$(DISK_IMAGE),format=raw,if=ide,cache=writethrough
 MODEL_DIR ?= models
 GPT2_MODEL ?= $(MODEL_DIR)/gpt2_124M.bin
 # GPT-2 124M charge ses 475 Mio de poids depuis l'initrd; 1 Gio est le minimum valide.
@@ -28,11 +31,11 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 # Liste des fichiers objets - MISE À JOUR avec tous les nouveaux fichiers
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
-          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/gpt2_model.o build/gpt2_tokenizer.o build/gpt2_infer.o build/interrupts.o \
+          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/gpt2_model.o build/gpt2_tokenizer.o build/gpt2_infer.o build/interrupts.o \
           build/keyboard.o build/timer.o build/multiboot.o build/kernel.o build/kbd_buffer.o
 
-# Cible par défaut : construire le système complet (noyau + initrd)
-all: $(OS_IMAGE) pack-initrd
+# Cible par défaut : construire le système complet (noyau + initrd + disque overlay)
+all: $(OS_IMAGE) pack-initrd disk
 	@echo "=== AI-OS v7 - Système avec GPT-2 local construit ==="
 	@echo "Noyau: $(OS_IMAGE) ($(shell ls -lh $(OS_IMAGE) | awk '{print $$5}'))"
 	@echo "Initrd: $(INITRD_IMAGE) ($(shell ls -lh $(INITRD_IMAGE) | awk '{print $$5}'))"
@@ -143,7 +146,11 @@ build/initrd.o: fs/initrd.c fs/initrd.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-build/overlay.o: fs/overlay.c fs/overlay.h fs/initrd.h
+build/overlay.o: fs/overlay.c fs/overlay.h fs/initrd.h kernel/ata.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/ata.o: kernel/ata.c kernel/ata.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
@@ -261,8 +268,8 @@ iso: check-iso-deps $(OS_IMAGE) pack-initrd
 	@echo "ISO générée: $(ISO_IMAGE)"
 
 # Lancer l'ISO avec QEMU (boot CD)
-run-iso: iso
-	qemu-system-i386 -cdrom $(ISO_IMAGE) -boot d -m $(GPT2_RAM) -cpu pentium3 -no-reboot -no-shutdown
+run-iso: iso disk
+	qemu-system-i386 -cdrom $(ISO_IMAGE) -boot d -m $(GPT2_RAM) -cpu pentium3 -no-reboot -no-shutdown $(QEMU_DISK_OPTS)
 
 iso-clean:
 	@rm -rf build/isodir $(ISO_IMAGE)
@@ -271,28 +278,28 @@ iso-clean:
 user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle: userspace-all
 
 # Cible pour exécuter l'OS dans QEMU avec initrd (mode console corrigé)
-run: $(OS_IMAGE) pack-initrd
+run: $(OS_IMAGE) pack-initrd disk
 	qemu-system-i386 -kernel $(OS_IMAGE) -initrd $(INITRD_IMAGE) \
 		-display curses \
 		-m $(GPT2_RAM) -cpu pentium3 \
-		-no-reboot -no-shutdown
+		-no-reboot -no-shutdown $(QEMU_DISK_OPTS)
 
 # Cible pour exécuter l'OS dans QEMU avec interface graphique améliorée
-run-gui: $(OS_IMAGE) pack-initrd
+run-gui: $(OS_IMAGE) pack-initrd disk
 	qemu-system-i386 -kernel $(OS_IMAGE) -initrd $(INITRD_IMAGE) \
 		-m $(GPT2_RAM) -cpu pentium3 -vga std \
 		-display gtk \
-		-no-reboot -no-shutdown
+		-no-reboot -no-shutdown $(QEMU_DISK_OPTS)
 
 # Alternative nographic (si curses ne fonctionne pas)
-run-nographic: $(OS_IMAGE) pack-initrd
+run-nographic: $(OS_IMAGE) pack-initrd disk
 	@echo "=== Mode NOGRAPHIC - Clavier peut être limité ==="
 	@echo "Utilisez 'make run' pour le mode console optimal"
 	qemu-system-i386 -kernel $(OS_IMAGE) -initrd $(INITRD_IMAGE) \
 		-nographic \
 		-chardev stdio,id=serial0 \
 		-m $(GPT2_RAM) -cpu pentium3 \
-		-no-reboot -no-shutdown
+		-no-reboot -no-shutdown $(QEMU_DISK_OPTS)
 
 # Cible pour tester le clavier avec GUI et capture des logs série
 run-kbd-gui-test: $(OS_IMAGE) pack-initrd
@@ -409,8 +416,16 @@ ci-tests: $(OS_IMAGE) pack-initrd
 	@echo "=== Tests d'intégration continue ==="
 	@$(MAKE) -C tests ci-test
 
+# Image disque IDE brute (snapshot overlay). Recréee seulement si absente.
+$(DISK_IMAGE):
+	@mkdir -p $(dir $@)
+	dd if=/dev/zero of=$@ bs=512 count=$(DISK_SECTORS) status=none
+
+.PHONY: disk
+disk: $(DISK_IMAGE)
+
 # Boot QEMU headless, tape ls/cat/ps/uptime (sendkey), exige l'initrd et le noyau.
-qemu-smoke: $(OS_IMAGE) pack-initrd
+qemu-smoke: $(OS_IMAGE) pack-initrd disk
 	@chmod +x tests/scripts/ci_qemu_smoke.sh
 	@tests/scripts/ci_qemu_smoke.sh
 
@@ -435,7 +450,7 @@ help:
 	@echo ""
 	@echo "Cibles principales:"
 	@echo "  deps         - Installe les paquets hôte (scripts/bootstrap-dev.sh)"
-	@echo "  all          - Compile le système complet (noyau + initrd + programmes)"
+	@echo "  all          - Compile le système complet (noyau + initrd + disque overlay)"
 	@echo "  kernel-only  - Compile seulement le noyau"
 	@echo "  run          - Compile et exécute avec QEMU (mode texte)"
 	@echo "  run-gui      - Compile et exécute avec QEMU (mode graphique)"
@@ -453,7 +468,8 @@ help:
 	@echo "  test-kernel     - Tests des modules kernel uniquement"
 	@echo "  test-userspace  - Tests des modules userspace uniquement"  
 	@echo "  test-all        - Suite complète de tests (< 5 min)"
-	@echo "  qemu-smoke      - Boot QEMU headless, vérifie le shell (log série)"
+	@echo "  qemu-smoke      - Boots QEMU : overlay, extras shell, persist disque"
+	@echo "  disk            - Cree build/overlay.img (IDE, 32 Kio) si absent"
 	@echo "  gpt2-recovery   - Modèle requis : réponse GPT-2 puis reprise shell (rc)"
 	@echo "  gpt2-benchmark  - Modèle requis : mesure de latence QEMU SSE2"
 	@echo "  gpt2-tests      - Modèle requis : recovery + benchmark GPT-2"
@@ -479,7 +495,7 @@ help:
 	@echo "Tests de non-régression:"
 	@echo "  make test-setup           # Configuration initiale (une fois)"
 	@echo "  make test-quick           # Tests pendant développement"
-	@echo "  make test-all             # 134 tests Unity avant push"
+	@echo "  make test-all             # 140 tests Unity avant push"
 
-.PHONY: all kernel-only run run-gui test-build info-initrd info-user user-program userspace-all clean distclean help pack-initrd test-setup test-quick test-kernel test-userspace test-all test-performance test-valgrind test-clean pre-commit-tests ci-tests qemu-smoke gpt2-recovery gpt2-benchmark gpt2-tests ci deps
+.PHONY: all kernel-only run run-gui test-build info-initrd info-user user-program userspace-all clean distclean help pack-initrd test-setup test-quick test-kernel test-userspace test-all test-performance test-valgrind test-clean pre-commit-tests ci-tests qemu-smoke gpt2-recovery gpt2-benchmark gpt2-tests ci deps disk
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/kamgueblondin/ai-os/actions/workflows/ci.yml/badge.svg)](https://github.com/kamgueblondin/ai-os/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-AI-OS est un **prototype de hobby OS i386 32-bit** (Multiboot). Il boote sous QEMU, isole Ring 0/3 et lance un shell ELF. Le noyau charge un initrd TAR, fournit un overlay RAM non persistant et expose une ABI de syscalls (`include/os_syscalls.h`).
+AI-OS est un **prototype de hobby OS i386 32-bit** (Multiboot). Il boote sous QEMU, isole Ring 0/3 et lance un shell ELF. Le noyau charge un initrd TAR, fournit un overlay RAM persisté sur un disque IDE QEMU et expose une ABI de syscalls (`include/os_syscalls.h`).
 
 Un moteur **GPT-2 124M freestanding** est optionnel : si les poids sont présents dans `models/` au moment du `make all` / `make iso`, ils sont empaquetés dans l'initrd et `ai <texte>` appelle `SYS_GPT2_GENERATE`. Sans ces fichiers, le shell et les tests unitaires restent utilisables.
 
@@ -15,12 +15,12 @@ La branche par défaut est **`master`**.
 
 ## Fonctionnalités
 
-- **Shell Ring 3** - prompt `/ (-.-) :`. `ls`/`cat` lisent initrd + overlay ; `mkdir`/`rm`/`cp`/`mv`/`touch`/`write`/`append` mutent l'overlay (pas de disque persistant). `ps`/`kill`/`getpid`/`mem`/`uptime` interrogent le noyau.
+- **Shell Ring 3** - prompt `/ (-.-) :`. `ls`/`cat` lisent initrd + overlay ; `mkdir`/`rm`/`cp`/`mv`/`touch`/`write`/`append` mutent l'overlay (snapshot ATA PIO si un disque IDE est présent). `ps`/`kill`/`getpid`/`mem`/`uptime` interrogent le noyau.
 - **GPT-2 local optionnel** - `ai <texte>` -> `[GPT-2 local]` si le checkpoint est dans l'initrd ; sinon message d'indisponibilité. Le binaire historique `bin/ai_assistant` reste empaqueté.
 - **Isolation** - GDT/IDT, Ring 0/3, chargeur ELF, syscalls (0-22, `MAX_SYSCALLS` = 23).
 - **Tâches** - passage kernel -> shell via `jump_to_task()` ; le round-robin à chaque tick PIT n'est pas le mode actuel.
-- **Fichiers** - initrd TAR en lecture seule + overlay RAM 32 nœuds. Pas de FS persistant.
-- **Matériel QEMU** - PIC, clavier PS/2, PIT 100 Hz. Historique clavier (EOI IRQ0) : [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
+- **Fichiers** - initrd TAR en lecture seule + overlay RAM 32 nœuds (fichiers <= 256 octets). Snapshot persisté sur le disque IDE QEMU (`build/overlay.img`) en ATA PIO LBA28, sans IRQ14.
+- **Matériel QEMU** - PIC, clavier PS/2, PIT 100 Hz, IDE primaire (maître). Historique clavier (EOI IRQ0) : [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
 
 Ce n'est **pas** un OS du quotidien : pas de réseau, pas de TLS/OpenAI effectif, pas d'interface graphique native.
 
@@ -33,7 +33,7 @@ git clone https://github.com/kamgueblondin/ai-os.git
 cd ai-os
 make deps          # ou : bash scripts/bootstrap-dev.sh
 make all
-make test-all      # 134 tests Unity, sans poids GPT-2
+make test-all      # 140 tests Unity, sans poids GPT-2
 make run           # QEMU curses ; le shell lit le clavier PS/2, pas le port série
 ```
 
@@ -41,9 +41,9 @@ make run           # QEMU curses ; le shell lit le clavier PS/2, pas le port sé
 
 | Cible | Rôle |
 |---|---|
-| `make all` | Noyau + initrd |
-| `make test-all` | Unity 32-bit (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_shell` 25, `test_ramfs` 10) |
-| `make qemu-smoke` | Deux boots QEMU (overlay + extras shell), sans modèle |
+| `make all` | Noyau + initrd + `build/overlay.img` (disque IDE 32 Kio) |
+| `make test-all` | Unity 32-bit (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_shell` 25, `test_ramfs` 10) |
+| `make qemu-smoke` | Trois boots QEMU (overlay + extras shell + persist disque), sans modèle |
 | `make ci` | `all` + `test-all` + `qemu-smoke` (gate PR) |
 | `make run` / `make run-gui` | Session interactive (voir [docs/GUIDE_EXECUTION.md](docs/GUIDE_EXECUTION.md)) |
 
@@ -94,7 +94,7 @@ make qemu-smoke    # smoke QEMU (CI)
 make ci            # même gate que GitHub Actions
 ```
 
-Unity 32-bit : **134** tests (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_tokenizer` 13, `test_shell` 25, `test_ramfs` 10). Les dossiers `tests/integration`, `tests/system`, `tests/performance` et `tests/robustness` sont vides. Les pourcentages de "couverture" affiches par d'anciens scripts ne sont pas mesures par gcov.
+Unity 32-bit : **140** tests (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_shell` 25, `test_ramfs` 10). Les dossiers `tests/integration`, `tests/system`, `tests/performance` et `tests/robustness` sont vides. Les pourcentages de "couverture" affiches par d'anciens scripts ne sont pas mesures par gcov.
 
 GitHub Actions (`.github/workflows/ci.yml`) : à chaque push/PR vers `master` (et `main` si la branche est renommée) - `make all`, `make test-all`, `make qemu-smoke`.
 
@@ -111,7 +111,7 @@ ai-os/
 │   ├── syscall/
 │   ├── input/            # buffer clavier
 │   └── llm/              # GPT-2 freestanding
-├── fs/                   # initrd TAR + overlay RAM
+├── fs/                   # initrd TAR + overlay RAM (snapshot IDE)
 ├── userspace/            # shell, idle, fake_ai, ai_assistant
 ├── include/              # ABI syscalls
 ├── initrd_content/       # contenu empaqueté dans my_initrd.tar
@@ -129,9 +129,10 @@ Le dossier [`US/`](US/README.md) décrit la vision MOHHOS (spécifications, pas 
 
 - [x] Inférence GPT-2 locale + cache KV / SSE2
 - [x] Tokenizer BPE GPT-2 (entree et sortie)
+- [x] Overlay persisté (snapshot ATA PIO sur disque IDE QEMU)
 - [ ] Quantification, chargeur GGUF, latence &lt; 1 s
 - [ ] Réseau, DNS, TLS, fournisseur OpenAI effectif
-- [ ] Système de fichiers persistant
+- [ ] Système de fichiers disque général (ext2/FAT)
 
 ## Documentation
 
@@ -152,4 +153,4 @@ Code commenté en français. Une PR = une tranche visible par la CI (`make ci`),
 
 **Dépôt :** [github.com/kamgueblondin/ai-os](https://github.com/kamgueblondin/ai-os)
 
-*Prototype i386 + shell userspace + GPT-2 local optionnel sous QEMU. Dernière mise à jour documentation : 2026-08-13, alignée sur `master` (`8006019`).*
+*Prototype i386 + shell userspace + GPT-2 local optionnel sous QEMU. Dernière mise à jour documentation : 2026-08-13, overlay persisté sur IDE.*

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,7 +1,7 @@
 # État réel d'AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** branche `master` (`origin/master`, commit `8006019` - fusion PR #76, documentation release GPT-2)
+**Code de référence :** branche de travail overlay persisté sur IDE (snapshot ATA PIO)
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
 Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
@@ -16,7 +16,7 @@ AI-OS est un **prototype de noyau pédagogique i386 32-bit**. Il boote sous QEMU
 | Inference GPT-2 locale de démonstration | Fonctionnelle avec checkpoint externe, contexte et sortie bornés |
 | Vision MOHHOS (120 US, 8 phases) | ~1-2 % (spécifications ; ne décrit pas le moteur GPT-2 actuel) |
 
-Ce n'est **pas** un système d'exploitation utilisable au quotidien (pas de FS persistant, pas de réseau, pas d'interface graphique native, pas de vrais pilotes hors QEMU/i8042).
+Ce n'est **pas** un système d'exploitation utilisable au quotidien (pas de FS disque général, pas de réseau, pas d'interface graphique native, pas de vrais pilotes hors QEMU/i8042/ATA PIO).
 
 ## Ce qui fonctionne (vérifié)
 
@@ -31,7 +31,7 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - Chargeur ELF 32-bit
 - Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
 - Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME`, `SYS_COPY`, `SYS_APPEND` et `SYS_GPT2_GENERATE` (ABI : `include/os_syscalls.h`)
-- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`, concatène sans écraser) / `touch` (fichier vide) / `echo >` visibles par `ls`/`cat` ; l'initrd reste en lecture seule ; `rmdir` d'un dossier non vide échoue
+- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`, concatène sans écraser) / `touch` (fichier vide) / `echo >` visibles par `ls`/`cat` ; l'initrd reste en lecture seule ; `rmdir` d'un dossier non vide échoue. Après chaque mutation réussie, un snapshot binaire (magic `AIOV`, 32 nœuds, 24 secteurs) est écrit en ATA PIO LBA28 sur le maître IDE primaire (`kernel/ata.c`, ports `0x1F0`, sans IRQ14). Au boot, si IDENTIFY réussit, l'overlay est restauré. Sans disque QEMU, IDENTIFY échoue tout de suite et l'overlay reste volatile.
 
 ### Espace utilisateur
 
@@ -59,11 +59,12 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | `test_pmm` | 17/17 |
 | `test_syscall` | 48/48 |
 | `test_task` | 21/21 |
+| `test_overlay` | 6/6 |
 | `test_tokenizer` | 13/13 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
 
-Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé "Total Tests" de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des six binaires (**134** = 17+48+21+13+25+10).
+Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé "Total Tests" de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des sept binaires (**140** = 17+48+21+6+13+25+10).
 
 Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en plus de `nasm` et `qemu-system-i386`).
 
@@ -111,7 +112,7 @@ La configuration mesurée avec QEMU sans KVM est de 7,693 s pour `ai hello` et q
 Malgré la roadmap README v7/v8 et le dossier `US/` :
 
 - Apprentissage fédéré, cloud-edge et les autres services IA décrits par les anciennes spécifications MOHHOS
-- Système de fichiers persistant (disque)
+- Système de fichiers disque général (ext2/FAT) ; seul un snapshot overlay ATA PIO (32 nœuds, 256 octets par fichier) survit au reboot QEMU
 - Pile TCP/IP, services réseau
 - Interface graphique du OS (seul QEMU affiche du VGA texte)
 - Architecture microkernel, IPC, plugins
@@ -135,7 +136,7 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke       # deux boots QEMU : overlay (#73) + extras env/history/jobs/top/rc/which
+make qemu-smoke       # trois boots QEMU : overlay (#73) + extras + persist write/reboot/cat
 make gpt2-recovery    # modèle requis : réponse GPT-2, puis validation de `rc`
 make gpt2-benchmark   # modèle requis : mesure avec CPU QEMU Pentium III SSE2
 make gpt2-tests       # modèle requis : reprise shell + benchmark
@@ -144,7 +145,7 @@ make run              # console curses (recommandé en local)
 make run-gui          # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU fait **deux boots** : un scénario cœur (`ls`, `ai-runtime`, création et copie récursive d'un répertoire overlay, `append`, `cat`, `rc`) puis les extras (`which idle`, `history`, `jobs`, `top`, `env`, `date`, `echo hi`, `rc`, `test no zz`, `aistats`/`aimode`/`aihelp`). Le scénario cœur attend le retour du shell après chaque commande afin d'éviter les touches fantômes. Timeouts : 120 s cœur + 90 s extras.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU fait **trois boots** : un scénario cœur (`ls`, `ai-runtime`, création et copie récursive d'un répertoire overlay, `append`, `cat`, `rc`) puis les extras (`which idle`, `history`, `jobs`, `top`, `env`, `date`, `echo hi`, `rc`, `test no zz`, `aistats`/`aimode`/`aihelp`), puis une persistance disque (`write k.txt v7ok`, kill QEMU, reboot, `cat k.txt` voit `v7ok`). Le disque cœur/extras est remis à zéro entre ces deux premiers boots. Le scénario cœur attend le retour du shell après chaque commande afin d'éviter les touches fantômes. Timeouts : 120 s cœur + 90 s extras + 180 s persist.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n'atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -52,7 +52,7 @@
 - [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
 - [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
 - [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` (fichier et dossier via `SYS_COPY`) / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`) / `touch` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
-- [ ] FS persistant sur disque (l'overlay RAM n'est pas persisté)
+- [x] Overlay persisté : snapshot ATA PIO LBA28 sur disque IDE QEMU (`write` survit à un reboot) ; pas un FS général
 - [ ] Préemption round-robin continue (aujourd'hui limitée pour la stabilité)
 - [ ] Réseau, vrai moteur IA - voir roadmap README / dossier `US/`
 

--- a/fs/overlay.c
+++ b/fs/overlay.c
@@ -1,5 +1,6 @@
 #include "overlay.h"
 #include "initrd.h"
+#include "kernel/ata.h"
 
 #define OV_MAX_NODES 32
 #define OV_PATH_MAX  64
@@ -208,6 +209,7 @@ int overlay_mkdir(const char* path) {
     n->size = 0;
     n->data[0] = '\0';
     ov_copy(n->path, want, OV_PATH_MAX);
+    overlay_save_disk();
     return OV_OK;
 }
 
@@ -231,6 +233,7 @@ int overlay_write(const char* path, const char* data, uint32_t n) {
     if (n > OV_DATA_MAX) n = OV_DATA_MAX;
     for (i = 0; i < n; i++) node->data[i] = data[i];
     node->size = n;
+    overlay_save_disk();
     return (int)n;
 }
 
@@ -265,6 +268,7 @@ int overlay_append(const char* path, const char* data, uint32_t n) {
     if (node->size + n > OV_DATA_MAX) return OV_ERR_NOSPACE;
     for (i = 0; i < n; i++) node->data[node->size + i] = data[i];
     node->size += n;
+    overlay_save_disk();
     return (int)n;
 }
 
@@ -296,6 +300,7 @@ int overlay_unlink(const char* path) {
     n->used = 0;
     n->path[0] = '\0';
     n->size = 0;
+    overlay_save_disk();
     return OV_OK;
 }
 
@@ -357,6 +362,7 @@ int overlay_rename(const char* oldpath, const char* newpath) {
             g_ov[i].path[newn + k] = '\0';
         }
     }
+    overlay_save_disk();
     return OV_OK;
 }
 
@@ -436,6 +442,7 @@ int overlay_copy(const char* src, const char* dst) {
             n->data[b] = g_ov[i].data[b];
         }
     }
+    overlay_save_disk();
     return OV_OK;
 }
 
@@ -468,4 +475,126 @@ int overlay_listdir(const char* path, os_dirent_t* out, int start, int max_n) {
         count++;
     }
     return count;
+}
+
+#define OV_DISK_SECTORS 24
+#define OV_DISK_BYTES   (OV_DISK_SECTORS * 512)
+
+static uint8_t g_ov_disk_buf[OV_DISK_BYTES];
+
+static void ov_put_u32(uint8_t* p, uint32_t v) {
+    p[0] = (uint8_t)v;
+    p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16);
+    p[3] = (uint8_t)(v >> 24);
+}
+
+static uint32_t ov_get_u32(const uint8_t* p) {
+    return (uint32_t)p[0]
+        | ((uint32_t)p[1] << 8)
+        | ((uint32_t)p[2] << 16)
+        | ((uint32_t)p[3] << 24);
+}
+
+int overlay_snapshot(uint8_t* buf, uint32_t max, uint32_t* out_size) {
+    uint32_t off;
+    int i;
+    int used = 0;
+
+    if (!buf || max < OV_SNAP_SIZE) return -1;
+
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        if (g_ov[i].used) used++;
+    }
+
+    ov_put_u32(buf + 0, OV_SNAP_MAGIC);
+    ov_put_u32(buf + 4, OV_SNAP_VERSION);
+    ov_put_u32(buf + 8, OV_SNAP_NODES);
+    ov_put_u32(buf + 12, (uint32_t)used);
+
+    off = 16;
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        uint32_t b;
+        buf[off + 0] = g_ov[i].used ? 1 : 0;
+        buf[off + 1] = g_ov[i].is_dir ? 1 : 0;
+        buf[off + 2] = 0;
+        buf[off + 3] = 0;
+        ov_put_u32(buf + off + 4, g_ov[i].used ? g_ov[i].size : 0);
+        for (b = 0; b < OV_PATH_MAX; b++) {
+            buf[off + 8 + b] = (uint8_t)g_ov[i].path[b];
+        }
+        for (b = 0; b < OV_DATA_MAX; b++) {
+            buf[off + 8 + OV_PATH_MAX + b] = (uint8_t)g_ov[i].data[b];
+        }
+        off += OV_SNAP_NODE;
+    }
+
+    if (out_size) *out_size = OV_SNAP_SIZE;
+    return 0;
+}
+
+int overlay_restore(const uint8_t* buf, uint32_t n) {
+    uint32_t off;
+    uint32_t used_count;
+    uint32_t seen;
+    int i;
+
+    if (!buf || n < OV_SNAP_SIZE) return -1;
+    if (ov_get_u32(buf + 0) != OV_SNAP_MAGIC) return -1;
+    if (ov_get_u32(buf + 4) != OV_SNAP_VERSION) return -1;
+    if (ov_get_u32(buf + 8) != OV_SNAP_NODES) return -1;
+
+    used_count = ov_get_u32(buf + 12);
+    if (used_count > OV_SNAP_NODES) return -1;
+
+    seen = 0;
+    off = 16;
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        uint8_t used = buf[off];
+        uint8_t is_dir = buf[off + 1];
+        uint32_t size = ov_get_u32(buf + off + 4);
+        if (used > 1 || is_dir > 1) return -1;
+        if (used) {
+            if (size > OV_DATA_MAX) return -1;
+            seen++;
+        }
+        off += OV_SNAP_NODE;
+    }
+    if (seen != used_count) return -1;
+
+    overlay_init();
+    off = 16;
+    for (i = 0; i < OV_MAX_NODES; i++) {
+        uint32_t b;
+        if (buf[off]) {
+            g_ov[i].used = 1;
+            g_ov[i].is_dir = buf[off + 1] ? 1 : 0;
+            g_ov[i].size = ov_get_u32(buf + off + 4);
+            for (b = 0; b < OV_PATH_MAX; b++) {
+                g_ov[i].path[b] = (char)buf[off + 8 + b];
+            }
+            g_ov[i].path[OV_PATH_MAX - 1] = '\0';
+            for (b = 0; b < OV_DATA_MAX; b++) {
+                g_ov[i].data[b] = (char)buf[off + 8 + OV_PATH_MAX + b];
+            }
+        }
+        off += OV_SNAP_NODE;
+    }
+    return 0;
+}
+
+int overlay_save_disk(void) {
+    uint32_t sz = 0;
+    uint32_t i;
+
+    if (!ata_present()) return 0;
+    if (overlay_snapshot(g_ov_disk_buf, sizeof(g_ov_disk_buf), &sz) != 0) return -1;
+    for (i = sz; i < sizeof(g_ov_disk_buf); i++) g_ov_disk_buf[i] = 0;
+    return ata_write_sectors(0, OV_DISK_SECTORS, g_ov_disk_buf);
+}
+
+int overlay_load_disk(void) {
+    if (!ata_present()) return -1;
+    if (ata_read_sectors(0, OV_DISK_SECTORS, g_ov_disk_buf) != 0) return -1;
+    return overlay_restore(g_ov_disk_buf, sizeof(g_ov_disk_buf));
 }

--- a/fs/overlay.h
+++ b/fs/overlay.h
@@ -14,6 +14,14 @@
 #define OV_ERR_INVAL    -7
 #define OV_ERR_PROTECTED -8
 
+#define OV_SNAP_MAGIC   0x564F4941u /* 'AIOV' little-endian */
+#define OV_SNAP_VERSION 1
+#define OV_SNAP_NODES   32
+#define OV_SNAP_PATH    64
+#define OV_SNAP_DATA    256
+#define OV_SNAP_NODE    (1 + 1 + 2 + 4 + OV_SNAP_PATH + OV_SNAP_DATA)
+#define OV_SNAP_SIZE    (16 + OV_SNAP_NODES * OV_SNAP_NODE)
+
 void overlay_init(void);
 int overlay_mkdir(const char* path);
 int overlay_write(const char* path, const char* data, uint32_t n);
@@ -25,5 +33,10 @@ int overlay_read(const char* path, char* buf, uint32_t max);
 int overlay_stat(const char* path, os_dirent_t* out);
 int overlay_listdir(const char* path, os_dirent_t* out, int start, int max_n);
 int overlay_is_dir(const char* path);
+
+int overlay_snapshot(uint8_t* buf, uint32_t max, uint32_t* out_size);
+int overlay_restore(const uint8_t* buf, uint32_t n);
+int overlay_load_disk(void);
+int overlay_save_disk(void);
 
 #endif

--- a/kernel/ata.c
+++ b/kernel/ata.c
@@ -1,0 +1,158 @@
+#include "ata.h"
+
+extern unsigned char inb(unsigned short port);
+extern void outb(unsigned short port, unsigned char data);
+
+#define ATA_DATA     0x1F0
+#define ATA_ERROR    0x1F1
+#define ATA_SECCOUNT 0x1F2
+#define ATA_LBA0     0x1F3
+#define ATA_LBA1     0x1F4
+#define ATA_LBA2     0x1F5
+#define ATA_DRIVE    0x1F6
+#define ATA_CMD      0x1F7
+#define ATA_STATUS   0x1F7
+#define ATA_ALTSTAT  0x3F6
+
+#define ATA_SR_ERR  0x01
+#define ATA_SR_DRQ  0x08
+#define ATA_SR_DF   0x20
+#define ATA_SR_BSY  0x80
+
+#define ATA_CMD_READ_PIO  0x20
+#define ATA_CMD_WRITE_PIO 0x30
+#define ATA_CMD_IDENTIFY  0xEC
+
+#define ATA_TIMEOUT 500000u
+
+static int g_ata_present;
+
+static unsigned short ata_inw(unsigned short port) {
+    unsigned short ret;
+    asm volatile ("inw %1, %0" : "=a"(ret) : "dN"(port));
+    return ret;
+}
+
+static void ata_outw(unsigned short port, unsigned short data) {
+    asm volatile ("outw %0, %1" : : "a"(data), "dN"(port));
+}
+
+static void ata_io_delay(void) {
+    (void)inb(ATA_ALTSTAT);
+    (void)inb(ATA_ALTSTAT);
+    (void)inb(ATA_ALTSTAT);
+    (void)inb(ATA_ALTSTAT);
+}
+
+static int ata_wait_not_busy(void) {
+    uint32_t i;
+    for (i = 0; i < ATA_TIMEOUT; i++) {
+        uint8_t st = inb(ATA_STATUS);
+        if (st == 0xFF) return -1;
+        if ((st & ATA_SR_BSY) == 0) return (int)st;
+    }
+    return -1;
+}
+
+static int ata_wait_drq(void) {
+    uint32_t i;
+    for (i = 0; i < ATA_TIMEOUT; i++) {
+        uint8_t st = inb(ATA_STATUS);
+        if (st == 0xFF) return -1;
+        if (st & (ATA_SR_ERR | ATA_SR_DF)) return -1;
+        if ((st & ATA_SR_BSY) == 0 && (st & ATA_SR_DRQ)) return 0;
+    }
+    return -1;
+}
+
+static void ata_select_lba(uint32_t lba, uint8_t count) {
+    outb(ATA_DRIVE, (uint8_t)(0xE0 | ((lba >> 24) & 0x0F)));
+    ata_io_delay();
+    outb(ATA_SECCOUNT, count);
+    outb(ATA_LBA0, (uint8_t)lba);
+    outb(ATA_LBA1, (uint8_t)(lba >> 8));
+    outb(ATA_LBA2, (uint8_t)(lba >> 16));
+}
+
+int ata_present(void) {
+    return g_ata_present;
+}
+
+int ata_init(void) {
+    int st;
+    uint32_t i;
+
+    g_ata_present = 0;
+
+    outb(ATA_DRIVE, 0xA0);
+    ata_io_delay();
+    st = inb(ATA_STATUS);
+    /* No controller / no drive: fail immediately so QEMU without -hda does not hang. */
+    if (st == 0x00 || st == 0xFF) return -1;
+
+    outb(ATA_SECCOUNT, 0);
+    outb(ATA_LBA0, 0);
+    outb(ATA_LBA1, 0);
+    outb(ATA_LBA2, 0);
+    outb(ATA_CMD, ATA_CMD_IDENTIFY);
+    ata_io_delay();
+
+    st = inb(ATA_STATUS);
+    if (st == 0x00 || st == 0xFF) return -1;
+    if (ata_wait_not_busy() < 0) return -1;
+    if (ata_wait_drq() < 0) return -1;
+
+    for (i = 0; i < 256; i++) {
+        (void)ata_inw(ATA_DATA);
+    }
+
+    g_ata_present = 1;
+    return 0;
+}
+
+int ata_read_sectors(uint32_t lba, uint32_t count, void* buf) {
+    uint8_t* out = (uint8_t*)buf;
+    uint32_t s;
+    uint32_t w;
+
+    if (!g_ata_present || !buf || count == 0 || count > 256) return -1;
+    if (lba + count < lba) return -1;
+
+    ata_select_lba(lba, (uint8_t)count);
+    outb(ATA_CMD, ATA_CMD_READ_PIO);
+
+    for (s = 0; s < count; s++) {
+        if (ata_wait_drq() < 0) return -1;
+        for (w = 0; w < 256; w++) {
+            uint16_t word = ata_inw(ATA_DATA);
+            out[0] = (uint8_t)word;
+            out[1] = (uint8_t)(word >> 8);
+            out += 2;
+        }
+        if (ata_wait_not_busy() < 0) return -1;
+    }
+    return 0;
+}
+
+int ata_write_sectors(uint32_t lba, uint32_t count, const void* buf) {
+    const uint8_t* in = (const uint8_t*)buf;
+    uint32_t s;
+    uint32_t w;
+
+    if (!g_ata_present || !buf || count == 0 || count > 256) return -1;
+    if (lba + count < lba) return -1;
+
+    ata_select_lba(lba, (uint8_t)count);
+    outb(ATA_CMD, ATA_CMD_WRITE_PIO);
+
+    for (s = 0; s < count; s++) {
+        if (ata_wait_drq() < 0) return -1;
+        for (w = 0; w < 256; w++) {
+            uint16_t word = (uint16_t)in[0] | ((uint16_t)in[1] << 8);
+            ata_outw(ATA_DATA, word);
+            in += 2;
+        }
+        if (ata_wait_not_busy() < 0) return -1;
+    }
+    return 0;
+}

--- a/kernel/ata.h
+++ b/kernel/ata.h
@@ -1,0 +1,13 @@
+#ifndef ATA_H
+#define ATA_H
+
+#include <stdint.h>
+
+/* ATA PIO LBA28 on the primary master (0x1F0). No IRQ14. */
+
+int ata_init(void);
+int ata_present(void);
+int ata_read_sectors(uint32_t lba, uint32_t count, void* buf);
+int ata_write_sectors(uint32_t lba, uint32_t count, const void* buf);
+
+#endif

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -10,6 +10,7 @@
 #include "elf.h"
 #include "../fs/initrd.h"
 #include "../fs/overlay.h"
+#include "ata.h"
 #include "llm/gpt2_model.h"
 #include "llm/gpt2_infer.h"
 #include "llm/gpt2_tokenizer.h"
@@ -539,7 +540,15 @@ void kmain(uint32_t multiboot_magic, uint32_t multiboot_addr) {
     }
 
     overlay_init();
-    print_string("Overlay FS initialise (mkdir/rm en RAM).\n");
+    if (ata_init() == 0) {
+        if (overlay_load_disk() == 0) {
+            print_string("Overlay FS charge depuis le disque IDE.\n");
+        } else {
+            print_string("Overlay FS initialise (disque IDE vide).\n");
+        }
+    } else {
+        print_string("Overlay FS initialise (mkdir/rm en RAM).\n");
+    }
 
     // NOUVEAU: Initialisation du système de tâches
     print_string("Initialisation du systeme de taches...\n");

--- a/tests/framework/kernel_mocks.c
+++ b/tests/framework/kernel_mocks.c
@@ -6,6 +6,7 @@
 #include "kernel/mem/vmm.h"
 #include "kernel/task/task.h"
 #include "kernel/syscall/syscall.h"
+#include "kernel/ata.h"
 #include "fs/overlay.h"
 
 // === GESTION MÉMOIRE MOCKS ===
@@ -586,4 +587,26 @@ void syscall_handler(cpu_state_t* state) {
         default:
             break;
     }
+}
+
+int ata_init(void) {
+    return -1;
+}
+
+int ata_present(void) {
+    return 0;
+}
+
+int ata_read_sectors(uint32_t lba, uint32_t count, void* buf) {
+    (void)lba;
+    (void)count;
+    (void)buf;
+    return -1;
+}
+
+int ata_write_sectors(uint32_t lba, uint32_t count, const void* buf) {
+    (void)lba;
+    (void)count;
+    (void)buf;
+    return -1;
 }

--- a/tests/scripts/ci_qemu_persist.py
+++ b/tests/scripts/ci_qemu_persist.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Short deterministic QEMU smoke test for boot, shell, GPT-2 runtime and RAM overlay."""
+"""Two QEMU boots: write overlay file, kill, reboot, cat the same file from disk."""
 from __future__ import print_function
 
 import os
@@ -12,10 +12,11 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 KERNEL = os.environ.get("KERNEL", os.path.join(ROOT, "build", "ai_os.bin"))
 INITRD = os.environ.get("INITRD", os.path.join(ROOT, "my_initrd.tar"))
 LOG_DIR = os.path.join(ROOT, "test_logs")
-LOG = os.environ.get("LOG", os.path.join(LOG_DIR, "ci-qemu-serial.log"))
-QEMU_ERR = os.environ.get("QEMU_ERR", os.path.join(LOG_DIR, "ci-qemu-stderr.log"))
-MON_SOCK = os.environ.get("QEMU_MON_SOCK", os.path.join(LOG_DIR, "qemu-core-monitor.sock"))
-BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "75"))
+LOG = os.environ.get("PERSIST_LOG", os.path.join(LOG_DIR, "ci-qemu-persist-serial.log"))
+QEMU_ERR = os.environ.get("PERSIST_ERR", os.path.join(LOG_DIR, "ci-qemu-persist-stderr.log"))
+MON_SOCK = os.environ.get("PERSIST_MON_SOCK", os.path.join(LOG_DIR, "qemu-persist-monitor.sock"))
+DISK = os.environ.get("PERSIST_DISK", os.path.join(ROOT, "build", "overlay-persist.img"))
+BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "40"))
 CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "20"))
 
 
@@ -38,7 +39,6 @@ def wait_for(proc, needle, timeout, start=0):
         if proc.poll() is not None:
             raise RuntimeError("QEMU stopped unexpectedly; log tail:\n%s" % log_text()[-2000:])
         if needle in log_text()[start:]:
-            # Let the shell reach the next SYS_GETS before the next command.
             time.sleep(0.35)
             return
         time.sleep(0.15)
@@ -64,19 +64,25 @@ def monitor_connect():
     raise RuntimeError("QEMU monitor unavailable")
 
 
-def qemu_disk_args():
-    disk = os.environ.get("OVERLAY_DISK", os.path.join(ROOT, "build", "overlay.img"))
-    if os.path.isfile(disk):
-        return ["-drive", "file=%s,format=raw,if=ide,cache=writethrough" % disk]
-    return []
+def drain_monitor(client):
+    client.settimeout(0.05)
+    while True:
+        try:
+            data = client.recv(8192)
+            if not data:
+                break
+        except socket.timeout:
+            break
 
 
 def send_command(client, command):
     aliases = {" ": "spc", "-": "minus", ".": "dot"}
     for char in command:
         client.sendall(("sendkey %s\n" % aliases.get(char, char.lower())).encode("ascii"))
-        time.sleep(0.25)
+        drain_monitor(client)
+        time.sleep(0.20)
     client.sendall(b"sendkey ret\n")
+    drain_monitor(client)
 
 
 def terminate(proc):
@@ -89,48 +95,33 @@ def terminate(proc):
         proc.kill()
 
 
-def main():
-    if not os.path.isfile(KERNEL) or not os.path.isfile(INITRD):
-        raise RuntimeError("missing build artefacts; run make all first")
-    os.makedirs(LOG_DIR, exist_ok=True)
-    for path in (LOG, QEMU_ERR, MON_SOCK):
-        try:
-            os.remove(path)
-        except OSError:
-            pass
+def qemu_cmd():
+    return [
+        "qemu-system-i386", "-cpu", "pentium3", "-kernel", KERNEL,
+        "-initrd", INITRD, "-m", "1024M", "-display", "none", "-vga", "none",
+        "-serial", "file:" + LOG, "-monitor", "unix:%s,server,nowait" % MON_SOCK,
+        "-machine", "type=pc,accel=tcg", "-no-reboot", "-no-shutdown",
+        "-drive", "file=%s,format=raw,if=ide,cache=writethrough" % DISK,
+    ]
 
+
+def boot_and_type(command, marker):
     proc = None
     monitor = None
     try:
-        with open(QEMU_ERR, "wb") as err:
-            proc = subprocess.Popen([
-                "qemu-system-i386", "-cpu", "pentium3", "-kernel", KERNEL,
-                "-initrd", INITRD, "-m", "1024M", "-display", "none", "-vga", "none",
-                "-serial", "file:" + LOG, "-monitor", "unix:%s,server,nowait" % MON_SOCK,
-                "-machine", "type=pc,accel=tcg", "-no-reboot", "-no-shutdown",
-            ] + qemu_disk_args(), cwd=ROOT, stdout=err, stderr=err)
+        os.remove(MON_SOCK)
+    except OSError:
+        pass
+    try:
+        with open(QEMU_ERR, "ab") as err:
+            proc = subprocess.Popen(qemu_cmd(), cwd=ROOT, stdout=err, stderr=err)
             wait_for(proc, "(-.-)", BOOT_TIMEOUT)
             wait_for(proc, "SYS_GETS: Debut", BOOT_TIMEOUT)
             monitor = monitor_connect()
-
-            commands = (
-                ("ls", "Initrd / VFS"),
-                ("ai-runtime", "cache KV actif"),
-                ("mkdir qd", "mkdir ok qd"),
-                ("cp hello.txt qd", "cp ok hello.txt"),
-                ("cp qd qc", "cp ok qc"),
-                ("ls qc", "hello.txt"),
-                ("append q.txt ok", "append ok q.txt"),
-                ("cat q.txt", "ok"),
-                ("rc", "rc ok 0"),
-            )
-            for command, marker in commands:
-                say("typing %s ..." % command)
-                start = len(log_text())
-                send_command(monitor, command)
-                wait_for(proc, marker, CMD_TIMEOUT, start)
-        say("QEMU core smoke passed.")
-        return 0
+            say("typing %s ..." % command)
+            start = len(log_text())
+            send_command(monitor, command)
+            wait_for(proc, marker, CMD_TIMEOUT, start)
     finally:
         if monitor is not None:
             monitor.close()
@@ -141,9 +132,34 @@ def main():
             pass
 
 
+def prepare_disk():
+    os.makedirs(os.path.dirname(DISK), exist_ok=True)
+    with open(DISK, "wb") as handle:
+        handle.write(b"\x00" * (512 * 64))
+
+
+def main():
+    if not os.path.isfile(KERNEL) or not os.path.isfile(INITRD):
+        raise RuntimeError("missing build artefacts; run make all first")
+    os.makedirs(LOG_DIR, exist_ok=True)
+    prepare_disk()
+    for path in (LOG, QEMU_ERR, MON_SOCK):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+    say("=== QEMU overlay persist boot 1 (write) ===")
+    boot_and_type("write k.txt v7ok", "write ok k.txt")
+    say("=== QEMU overlay persist boot 2 (cat after reboot) ===")
+    boot_and_type("cat k.txt", "v7ok")
+    say("QEMU overlay persist smoke passed.")
+    return 0
+
+
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except Exception as error:
-        print("QEMU core smoke failed: %s" % error, file=sys.stderr)
+        print("QEMU persist smoke failed: %s" % error, file=sys.stderr)
         raise SystemExit(1)

--- a/tests/scripts/ci_qemu_shell_extras.py
+++ b/tests/scripts/ci_qemu_shell_extras.py
@@ -115,6 +115,13 @@ def dump_logs():
         say(err[-2000:])
 
 
+def qemu_disk_args():
+    disk = os.environ.get("OVERLAY_DISK", os.path.join(ROOT, "build", "overlay.img"))
+    if os.path.isfile(disk):
+        return ["-drive", "file=%s,format=raw,if=ide,cache=writethrough" % disk]
+    return []
+
+
 def kill_qemu(proc):
     if proc.poll() is not None:
         return
@@ -154,7 +161,7 @@ def main():
         "-machine", "type=pc,accel=tcg",
         "-no-reboot",
         "-no-shutdown",
-    ]
+    ] + qemu_disk_args()
     say("=== QEMU shell extras (history/jobs/top/env/date/echo/rc/which idle/aistats) ===")
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -3,6 +3,7 @@
 # Keyboard is PS/2: HMP sendkey injects scancodes (host TTY would not reach SYS_GETS).
 # Hard timeout: QEMU stderr must not be a PIPE (deadlock on GitHub Actions).
 # Core smoke and shell extras are separate boots so extra sendkeys do not ghost the shell.
+# Overlay disk is zeroed before core and extras; persist uses its own image across two boots.
 
 set -euo pipefail
 
@@ -13,6 +14,16 @@ KERNEL="${KERNEL:-build/ai_os.bin}"
 INITRD="${INITRD:-my_initrd.tar}"
 CORE_TIMEOUT="${CORE_TIMEOUT:-120}"
 EXTRAS_TIMEOUT="${EXTRAS_TIMEOUT:-90}"
+PERSIST_TIMEOUT="${PERSIST_TIMEOUT:-180}"
+OVERLAY_DISK="${OVERLAY_DISK:-$ROOT/build/overlay.img}"
+PERSIST_DISK="${PERSIST_DISK:-$ROOT/build/overlay-persist.img}"
+export OVERLAY_DISK PERSIST_DISK
+
+reset_overlay_disk() {
+    local img="$1"
+    mkdir -p "$(dirname "$img")"
+    dd if=/dev/zero of="$img" bs=512 count=64 status=none
+}
 
 if [ ! -f "$KERNEL" ] || [ ! -f "$INITRD" ]; then
     echo "ERROR: missing $KERNEL or $INITRD - run 'make all' first"
@@ -49,5 +60,8 @@ run_python() {
     return "$rc"
 }
 
+reset_overlay_disk "$OVERLAY_DISK"
 run_python core "$CORE_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_core_smoke.py"
+reset_overlay_disk "$OVERLAY_DISK"
 run_python extras "$EXTRAS_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_shell_extras.py"
+run_python persist "$PERSIST_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_persist.py"

--- a/tests/unit/kernel/test_overlay.c
+++ b/tests/unit/kernel/test_overlay.c
@@ -1,0 +1,122 @@
+/* test_overlay.c - snapshot / restore of the RAM overlay (no ATA ports) */
+
+#include <string.h>
+#include "../../framework/unity.h"
+#include "../../../fs/overlay.h"
+
+static uint8_t g_snap[OV_SNAP_SIZE + 64];
+
+void setUp(void) {
+    overlay_init();
+}
+
+void tearDown(void) {
+}
+
+static void test_snapshot_empty_roundtrip(void) {
+    uint32_t sz = 0;
+    char buf[16];
+
+    setUp();
+    TEST_ASSERT_EQUAL(0, overlay_snapshot(g_snap, sizeof(g_snap), &sz));
+    TEST_ASSERT_EQUAL(OV_SNAP_SIZE, sz);
+    TEST_ASSERT_EQUAL(1, overlay_write("keep.txt", "x", 1));
+    TEST_ASSERT_EQUAL(0, overlay_restore(g_snap, sz));
+    TEST_ASSERT_TRUE(overlay_read("keep.txt", buf, sizeof(buf)) < 0);
+}
+
+static void test_snapshot_write_roundtrip(void) {
+    uint32_t sz = 0;
+    char buf[16];
+    int n;
+
+    setUp();
+    TEST_ASSERT_EQUAL(4, overlay_write("k.txt", "v7ok", 4));
+    TEST_ASSERT_EQUAL(0, overlay_snapshot(g_snap, sizeof(g_snap), &sz));
+    overlay_init();
+    TEST_ASSERT_TRUE(overlay_read("k.txt", buf, sizeof(buf)) < 0);
+    TEST_ASSERT_EQUAL(0, overlay_restore(g_snap, sz));
+    n = overlay_read("k.txt", buf, sizeof(buf));
+    TEST_ASSERT_EQUAL(4, n);
+    buf[n] = '\0';
+    TEST_ASSERT_EQUAL_STRING("v7ok", buf);
+}
+
+static void test_snapshot_mkdir_roundtrip(void) {
+    uint32_t sz = 0;
+    os_dirent_t st;
+    char buf[16];
+    int n;
+
+    setUp();
+    TEST_ASSERT_EQUAL(OV_OK, overlay_mkdir("qd"));
+    TEST_ASSERT_EQUAL(5, overlay_write("qd/k.txt", "hello", 5));
+    TEST_ASSERT_EQUAL(0, overlay_snapshot(g_snap, sizeof(g_snap), &sz));
+    overlay_init();
+    TEST_ASSERT_EQUAL(0, overlay_restore(g_snap, sz));
+    TEST_ASSERT_TRUE(overlay_is_dir("qd"));
+    TEST_ASSERT_EQUAL(OV_OK, overlay_stat("qd", &st));
+    TEST_ASSERT_EQUAL(OS_DIRENT_DIR, st.flags);
+    n = overlay_read("qd/k.txt", buf, sizeof(buf));
+    TEST_ASSERT_EQUAL(5, n);
+    buf[n] = '\0';
+    TEST_ASSERT_EQUAL_STRING("hello", buf);
+}
+
+static void test_snapshot_unlink_roundtrip(void) {
+    uint32_t sz_before = 0;
+    uint32_t sz_after = 0;
+    uint8_t snap_after[OV_SNAP_SIZE];
+    char buf[16];
+
+    setUp();
+    TEST_ASSERT_EQUAL(3, overlay_write("gone.txt", "bye", 3));
+    TEST_ASSERT_EQUAL(0, overlay_snapshot(g_snap, sizeof(g_snap), &sz_before));
+    TEST_ASSERT_EQUAL(OV_OK, overlay_unlink("gone.txt"));
+    TEST_ASSERT_EQUAL(0, overlay_snapshot(snap_after, sizeof(snap_after), &sz_after));
+
+    TEST_ASSERT_EQUAL(0, overlay_restore(g_snap, sz_before));
+    TEST_ASSERT_EQUAL(3, overlay_read("gone.txt", buf, sizeof(buf)));
+
+    TEST_ASSERT_EQUAL(0, overlay_restore(snap_after, sz_after));
+    TEST_ASSERT_TRUE(overlay_read("gone.txt", buf, sizeof(buf)) < 0);
+}
+
+static void test_restore_rejects_bad_magic(void) {
+    uint32_t sz = 0;
+    char buf[16];
+    int n;
+
+    setUp();
+    TEST_ASSERT_EQUAL(4, overlay_write("stay.txt", "keep", 4));
+    TEST_ASSERT_EQUAL(0, overlay_snapshot(g_snap, sizeof(g_snap), &sz));
+    g_snap[0] ^= 0xFF;
+    TEST_ASSERT_TRUE(overlay_restore(g_snap, sz) < 0);
+    n = overlay_read("stay.txt", buf, sizeof(buf));
+    TEST_ASSERT_EQUAL(4, n);
+    buf[n] = '\0';
+    TEST_ASSERT_EQUAL_STRING("keep", buf);
+}
+
+static void test_snapshot_rejects_small_buffer(void) {
+    uint8_t tiny[16];
+    uint32_t sz = 99;
+
+    setUp();
+    TEST_ASSERT_TRUE(overlay_snapshot(tiny, sizeof(tiny), &sz) < 0);
+    TEST_ASSERT_TRUE(overlay_restore(tiny, sizeof(tiny)) < 0);
+    TEST_ASSERT_EQUAL(99, sz);
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_snapshot_empty_roundtrip);
+    RUN_TEST(test_snapshot_write_roundtrip);
+    RUN_TEST(test_snapshot_mkdir_roundtrip);
+    RUN_TEST(test_snapshot_unlink_roundtrip);
+    RUN_TEST(test_restore_rejects_bad_magic);
+    RUN_TEST(test_snapshot_rejects_small_buffer);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Persist the RAM overlay across QEMU reboots with a small ATA PIO snapshot.

`write k.txt v7ok`, kill QEMU, reboot, `cat k.txt` shows `v7ok`.

## What changed
- ATA PIO LBA28 on the primary master (`0x1F0`), no IRQ14. IDENTIFY uses a finite timeout so QEMU without `-hda` does not hang (GPT-2 scripts stay optional-disk).
- Overlay snapshot format `AIOV` v1 (32 nodes, path 64, data 256), serialized byte-by-byte. Saved after successful `mkdir` / `write` / `append` / `unlink` / `rename` / `copy`. Load at boot when a disk is present; RAM remains the session truth if the save fails.
- `make all` / `make run*` attach `build/overlay.img` (32 KiB raw IDE). Unit tests stub ATA so host `inb` never hits ports.
- `make qemu-smoke` still runs the #73 overlay sequence and extras, resetting the disk between those boots, then a two-boot persist smoke on its own image.

## Tests
- Unity **140** = 134 + 6 snapshot/restore tests (`test_overlay`).
- `make ci` = `all` + `test-all` + qemu-smoke (core 120s + extras 90s + persist 180s).

Initrd stays read-only. This is not a general disk filesystem.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

