### PR TITLE
Spawn and yield actually switch tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run unit tests (make test-all)
         run: make test-all
 
-      - name: QEMU smoke (overlay + extras + persist disque)
+      - name: QEMU smoke (overlay + extras + persist + spawn)
         run: make qemu-smoke
 
       - name: Upload logs

--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ help:
 	@echo "  test-kernel     - Tests des modules kernel uniquement"
 	@echo "  test-userspace  - Tests des modules userspace uniquement"  
 	@echo "  test-all        - Suite complète de tests (< 5 min)"
-	@echo "  qemu-smoke      - Boots QEMU : overlay, extras shell, persist disque"
+	@echo "  qemu-smoke      - Boots QEMU : overlay, extras, persist, spawn/yield"
 	@echo "  disk            - Cree build/overlay.img (IDE, 32 Kio) si absent"
 	@echo "  gpt2-recovery   - Modèle requis : réponse GPT-2 puis reprise shell (rc)"
 	@echo "  gpt2-benchmark  - Modèle requis : mesure de latence QEMU SSE2"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ La branche par défaut est **`master`**.
 - **Shell Ring 3** - prompt `/ (-.-) :`. `ls`/`cat` lisent initrd + overlay ; `mkdir`/`rm`/`cp`/`mv`/`touch`/`write`/`append` mutent l'overlay (snapshot ATA PIO si un disque IDE est présent). `ps`/`kill`/`getpid`/`mem`/`uptime` interrogent le noyau.
 - **GPT-2 local optionnel** - `ai <texte>` -> `[GPT-2 local]` si le checkpoint est dans l'initrd ; sinon message d'indisponibilité. Le binaire historique `bin/ai_assistant` reste empaqueté.
 - **Isolation** - GDT/IDT, Ring 0/3, chargeur ELF, syscalls (0-22, `MAX_SYSCALLS` = 23).
-- **Tâches** - passage kernel -> shell via `jump_to_task()` ; le round-robin à chaque tick PIT n'est pas le mode actuel.
+- **Tâches** - passage kernel -> shell via `jump_to_task()` ; `spawn`/`yield` basculent de façon coopérative (int 0x80). Le round-robin à chaque tick PIT n'est pas le mode actuel.
 - **Fichiers** - initrd TAR en lecture seule + overlay RAM 32 nœuds (fichiers <= 256 octets). Snapshot persisté sur le disque IDE QEMU (`build/overlay.img`) en ATA PIO LBA28, sans IRQ14.
 - **Matériel QEMU** - PIC, clavier PS/2, PIT 100 Hz, IDE primaire (maître). Historique clavier (EOI IRQ0) : [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
 
@@ -43,7 +43,7 @@ make run           # QEMU curses ; le shell lit le clavier PS/2, pas le port sé
 |---|---|
 | `make all` | Noyau + initrd + `build/overlay.img` (disque IDE 32 Kio) |
 | `make test-all` | Unity 32-bit (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_shell` 25, `test_ramfs` 10) |
-| `make qemu-smoke` | Trois boots QEMU (overlay + extras shell + persist disque), sans modèle |
+| `make qemu-smoke` | Quatre boots QEMU (overlay + extras shell + persist disque + spawn/yield), sans modèle |
 | `make ci` | `all` + `test-all` + `qemu-smoke` (gate PR) |
 | `make run` / `make run-gui` | Session interactive (voir [docs/GUIDE_EXECUTION.md](docs/GUIDE_EXECUTION.md)) |
 
@@ -130,6 +130,7 @@ Le dossier [`US/`](US/README.md) décrit la vision MOHHOS (spécifications, pas 
 - [x] Inférence GPT-2 locale + cache KV / SSE2
 - [x] Tokenizer BPE GPT-2 (entree et sortie)
 - [x] Overlay persisté (snapshot ATA PIO sur disque IDE QEMU)
+- [x] `spawn` / `yield` coopératifs (l'enfant tourne vraiment)
 - [ ] Quantification, chargeur GGUF, latence &lt; 1 s
 - [ ] Réseau, DNS, TLS, fournisseur OpenAI effectif
 - [ ] Système de fichiers disque général (ext2/FAT)

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -29,7 +29,7 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - PMM / VMM / heap, paging
 - Initrd format TAR POSIX (`fs/initrd.c`)
 - Chargeur ELF 32-bit
-- Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3)
+- Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3) ; `SYS_SPAWN` / `SYS_YIELD` basculent depuis le cadre user (pas depuis IRQ0)
 - Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME`, `SYS_COPY`, `SYS_APPEND` et `SYS_GPT2_GENERATE` (ABI : `include/os_syscalls.h`)
 - Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`, concatène sans écraser) / `touch` (fichier vide) / `echo >` visibles par `ls`/`cat` ; l'initrd reste en lecture seule ; `rmdir` d'un dossier non vide échoue. Après chaque mutation réussie, un snapshot binaire (magic `AIOV`, 32 nœuds, 24 secteurs) est écrit en ATA PIO LBA28 sur le maître IDE primaire (`kernel/ata.c`, ports `0x1F0`, sans IRQ14). Au boot, si IDENTIFY réussit, l'overlay est restauré. Sans disque QEMU, IDENTIFY échoue tout de suite et l'overlay reste volatile.
 
@@ -46,7 +46,7 @@ Les nombreuses notes "clavier corrigé" des versions 6.0/6.1 étaient **partiell
 Correctif actuel :
 
 1. EOI IRQ0 **avant** `timer_handler` / `schedule()` (`boot/isr_stubs.s`)
-2. Planification seulement si `g_reschedule_needed` (lancement du shell, exec/spawn) - plus à chaque tick, ce qui provoquait un page fault une fois l'EOI rétabli (`kernel/timer.c`)
+2. Planification seulement si `g_reschedule_needed` (lancement du shell, exec bloquant) - plus à chaque tick, ce qui provoquait un page fault une fois l'EOI rétabli (`kernel/timer.c`). `SYS_SPAWN` et `SYS_YIELD` appellent `schedule()` depuis le cadre **user** de `int 0x80`.
 
 Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` reçus par `SYS_GETS`.
 
@@ -86,7 +86,7 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 | `append` | `append <fichier> <texte>` -> concatène (`SYS_APPEND`) ; crée le fichier s'il n'existe pas ; un fichier initrd est recopié dans l'overlay (copie sur écriture). Succès : `append ok <fichier>` |
 | `touch` | `touch <fichier>` -> fichier overlay vide (`SYS_WRITEFILE` taille 0). Succès : `touch ok <fichier>` ; un fichier existant n'est pas tronqué |
 | `cd` / `pwd` | Chemin shell ; `cd` accepte overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`). Succès : `cd ok <arg>` |
-| `ps` / `jobs` / `top` / `kill` / `spawn` / `getpid` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY (pas de changement de contexte). pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`). `getpid` affiche `getpid ok <pid>` (`SYS_GETPID`). `jobs` affiche `jobs ok N` ; `top` affiche `top ok N` |
+| `ps` / `jobs` / `top` / `kill` / `spawn` / `yield` / `getpid` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY puis lui cède le CPU une fois (cadre syscall). `idle` affiche `idle ok` puis boucle sur `SYS_YIELD`. `yield` affiche `yield ok`. pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`). `getpid` affiche `getpid ok <pid>` (`SYS_GETPID`). `jobs` affiche `jobs ok N` ; `top` affiche `top ok N` |
 | `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT. `mem` affiche `mem ok <total> <used> <free>` |
 | `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) et affiche `date ok` |
 | `whoami` / `env` / `export` | Variables d'environnement du shell (`USER=root` par défaut). `whoami` affiche `whoami ok root` ; `export VAR=val` affiche `export ok VAR` ; `env` affiche `env ok N` |
@@ -119,7 +119,7 @@ Malgré la roadmap README v7/v8 et le dossier `US/` :
 - Réseau P2P, multi-plateforme, économie collaborative
 - Les 120 User Stories MOHHOS : **spécifications**, pas d'implémentation (sauf recouvrement accidentel avec le noyau actuel : mémoire, tests unitaires partiels)
 
-Le préemptif "à chaque tick" est volontairement **limité** : après le premier passage au shell, le timer n'appelle plus `schedule()` sauf `g_reschedule_needed`. Le round-robin continu n'est pas le mode de production actuel (stabilité).
+Le préemptif "à chaque tick" est volontairement **limité** : après le premier passage au shell, le timer n'appelle plus `schedule()` sauf `g_reschedule_needed` (exec bloquant). `spawn` et `yield` basculent depuis le syscall, sans round-robin IRQ0 (stabilité clavier).
 
 ## Documents historiques à ne pas prendre pour l'état courant
 
@@ -136,7 +136,7 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke       # trois boots QEMU : overlay (#73) + extras + persist write/reboot/cat
+make qemu-smoke       # quatre boots QEMU : overlay (#73) + extras + persist + spawn/yield
 make gpt2-recovery    # modèle requis : réponse GPT-2, puis validation de `rc`
 make gpt2-benchmark   # modèle requis : mesure avec CPU QEMU Pentium III SSE2
 make gpt2-tests       # modèle requis : reprise shell + benchmark
@@ -145,7 +145,7 @@ make run              # console curses (recommandé en local)
 make run-gui          # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU fait **trois boots** : un scénario cœur (`ls`, `ai-runtime`, création et copie récursive d'un répertoire overlay, `append`, `cat`, `rc`) puis les extras (`which idle`, `history`, `jobs`, `top`, `env`, `date`, `echo hi`, `rc`, `test no zz`, `aistats`/`aimode`/`aihelp`), puis une persistance disque (`write k.txt v7ok`, kill QEMU, reboot, `cat k.txt` voit `v7ok`). Le disque cœur/extras est remis à zéro entre ces deux premiers boots. Le scénario cœur attend le retour du shell après chaque commande afin d'éviter les touches fantômes. Timeouts : 120 s cœur + 90 s extras + 180 s persist.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU fait **quatre boots** : un scénario cœur (`ls`, `ai-runtime`, création et copie récursive d'un répertoire overlay, `append`, `cat`, `rc`) puis les extras (`which idle`, `history`, `jobs`, `top`, `env`, `date`, `echo hi`, `rc`, `test no zz`, `aistats`/`aimode`/`aihelp`), une persistance disque (`write k.txt v7ok`, kill QEMU, reboot, `cat k.txt` voit `v7ok`), puis `spawn idle` (aiguille `idle ok`), `yield`, `kill`. Le disque cœur/extras/spawn est remis à zéro entre ces boots. Le scénario cœur attend le retour du shell après chaque commande afin d'éviter les touches fantômes. Timeouts : 120 s cœur + 90 s extras + 180 s persist + 90 s spawn.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n'atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -53,6 +53,7 @@
 - [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
 - [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` (fichier et dossier via `SYS_COPY`) / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`) / `touch` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
 - [x] Overlay persisté : snapshot ATA PIO LBA28 sur disque IDE QEMU (`write` survit à un reboot) ; pas un FS général
+- [x] `spawn` / `yield` coopératifs (cadre syscall user ; pas de round-robin IRQ0)
 - [ ] Préemption round-robin continue (aujourd'hui limitée pour la stabilité)
 - [ ] Réseau, vrai moteur IA - voir roadmap README / dossier `US/`
 

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -88,8 +88,10 @@ void syscall_handler(cpu_state_t* cpu) {
             break;
             
         case SYS_YIELD:
-            // Cède volontairement le CPU
-            asm volatile("int $0x30");
+            /* Cooperative switch from the int 0x80 user frame (safe).
+             * Nested int 0x30 / IRQ0 is not used: that frame has no SS/ESP. */
+            cpu->eax = 0;
+            schedule(cpu);
             break;
             
         // SYS_GETS - Lire une ligne depuis le clavier
@@ -106,6 +108,9 @@ void syscall_handler(cpu_state_t* cpu) {
             print_string_serial("[SPAWN] starting child\n");
             cpu->eax = sys_spawn((const char*)cpu->ebx, (char**)cpu->ecx);
             print_string_serial("[SPAWN] child created\n");
+            if ((int)cpu->eax >= 0) {
+                schedule(cpu);
+            }
             break;
         case SYS_LISTDIR:
             cpu->eax = (uint32_t)sys_listdir((const char*)cpu->ebx, (os_dirent_t*)cpu->ecx, (int)cpu->edx);
@@ -266,8 +271,8 @@ int sys_exec(const char* path, char* argv[]) {
     return 0; // Succès
 }
 
-// Non-bloquant: cree la tache et retourne son pid, -1 sinon.
-// Pas de reschedule : le shell garde le CPU (tache fille en TASK_READY).
+/* Cree la tache et retourne son pid. Le handler appelle schedule() pour
+ * laisser tourner l'enfant jusqu'au prochain SYS_YIELD (cadre user, pas IRQ0). */
 int sys_spawn(const char* path, char* argv[]) {
     task_t* new_task = create_task_from_initrd_file(path);
     if (!new_task) {

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -101,37 +101,46 @@ void schedule(cpu_state_t* cpu) {
         current_task->state = TASK_READY;
     }
 
-    // Chercher la prochaine tâche prête.
-    // C'est un simple ordonnanceur round-robin qui ignore les tâches en attente.
-    task_t* next_task = current_task ? current_task : task_queue;
-    while (1) {
-        next_task = next_task->next;
+    /* Prefer a user TASK_READY. The kernel task stays READY after the first
+     * jump_to_task() to the shell; picking it on SYS_YIELD would iret into a
+     * stale boot frame. Round-robin on IRQ0 stays off (nested kernel IRQ). */
+    {
+        task_t* start = current_task ? current_task : task_queue;
+        task_t* t = start;
+        task_t* next_task = start;
+        int found_user = 0;
 
-        // Si la tâche est prête à s'exécuter, on la choisit.
-        if (next_task->state == TASK_READY) {
-            break;
-        }
-
-        // Si on a fait un tour complet et que personne n'est prêt,
-        // et que la tâche actuelle ne peut plus tourner, on choisit la tâche kernel (idle).
-        // Cela evite un blocage si toutes les taches sont en attente.
-        if (next_task == current_task) {
-            // Si la tache courante est en attente, on doit trouver une autre tache.
-            if (current_task->state != TASK_READY && current_task->state != TASK_RUNNING) {
-                 // On cherche la tache kernel (ID 0) comme dernier recours.
-                task_t* kernel_task = task_queue;
-                while(kernel_task->id != 0) kernel_task = kernel_task->next;
-                next_task = kernel_task;
+        do {
+            t = t->next;
+            if (t->state == TASK_READY && t->type == TASK_TYPE_USER) {
+                next_task = t;
+                found_user = 1;
+                break;
             }
-            // Si la tache courante est encore prete, on la laisse tourner.
-            break;
+        } while (t != start);
+
+        if (!found_user && start->state == TASK_READY && start->type == TASK_TYPE_USER) {
+            next_task = start;
+            found_user = 1;
         }
+
+        if (!found_user) {
+            t = start;
+            do {
+                t = t->next;
+                if (t->state == TASK_READY) {
+                    next_task = t;
+                    break;
+                }
+            } while (t != start);
+        }
+
+        current_task = next_task;
     }
 
     print_string_serial("[SCHED] switching to task ");
-    write_serial('0' + (next_task->id % 10));
+    write_serial('0' + (current_task->id % 10));
     print_string_serial("\n");
-    current_task = next_task;
     current_task->state = TASK_RUNNING;
 
     // Mettre à jour le TSS avec la pile noyau de la nouvelle tâche

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -57,8 +57,8 @@ void timer_handler(cpu_state_t* cpu) {
     }
     
     // Un seul changement de contexte quand il est demandé (lancement du shell,
-    // exec/spawn). Planifier à chaque tick après EOI provoque un page fault :
-    // jump_to_task() ne revient pas, et l'état IRQ du kernel devient invalide.
+    // exec bloquant). spawn/yield basculent depuis int 0x80, pas depuis IRQ0 :
+    // un schedule() pendant un syscall (cadre noyau sans SS/ESP user) page-fault.
     if (g_reschedule_needed) {
         g_reschedule_needed = 0;
         schedule(cpu);

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -3,7 +3,7 @@
 # Keyboard is PS/2: HMP sendkey injects scancodes (host TTY would not reach SYS_GETS).
 # Hard timeout: QEMU stderr must not be a PIPE (deadlock on GitHub Actions).
 # Core smoke and shell extras are separate boots so extra sendkeys do not ghost the shell.
-# Overlay disk is zeroed before core and extras; persist uses its own image across two boots.
+# Overlay disk is zeroed before core, extras and spawn; persist uses its own image.
 
 set -euo pipefail
 
@@ -15,6 +15,7 @@ INITRD="${INITRD:-my_initrd.tar}"
 CORE_TIMEOUT="${CORE_TIMEOUT:-120}"
 EXTRAS_TIMEOUT="${EXTRAS_TIMEOUT:-90}"
 PERSIST_TIMEOUT="${PERSIST_TIMEOUT:-180}"
+SPAWN_TIMEOUT="${SPAWN_TIMEOUT:-90}"
 OVERLAY_DISK="${OVERLAY_DISK:-$ROOT/build/overlay.img}"
 PERSIST_DISK="${PERSIST_DISK:-$ROOT/build/overlay-persist.img}"
 export OVERLAY_DISK PERSIST_DISK
@@ -39,8 +40,8 @@ if ! grep -a -qF "Initrd / VFS" userspace/shell; then
     file userspace/shell || true
     exit 1
 fi
-if ! grep -a -qF "env ok" userspace/shell; then
-    echo "ERROR: userspace/shell is stale (no env ok needle)."
+if ! grep -a -qF "yield ok" userspace/shell; then
+    echo "ERROR: userspace/shell is stale (no yield ok needle)."
     exit 1
 fi
 
@@ -65,3 +66,5 @@ run_python core "$CORE_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_core_smoke.py"
 reset_overlay_disk "$OVERLAY_DISK"
 run_python extras "$EXTRAS_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_shell_extras.py"
 run_python persist "$PERSIST_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_persist.py"
+reset_overlay_disk "$OVERLAY_DISK"
+run_python spawn "$SPAWN_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_spawn.py"

--- a/tests/scripts/ci_qemu_spawn.py
+++ b/tests/scripts/ci_qemu_spawn.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""QEMU smoke: spawn idle actually runs (idle ok), yield switches, kill removes it."""
+from __future__ import print_function
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+KERNEL = os.environ.get("KERNEL", os.path.join(ROOT, "build", "ai_os.bin"))
+INITRD = os.environ.get("INITRD", os.path.join(ROOT, "my_initrd.tar"))
+LOG_DIR = os.path.join(ROOT, "test_logs")
+LOG = os.environ.get("SPAWN_LOG", os.path.join(LOG_DIR, "ci-qemu-spawn-serial.log"))
+QEMU_ERR = os.environ.get("SPAWN_ERR", os.path.join(LOG_DIR, "ci-qemu-spawn-stderr.log"))
+MON_SOCK = os.environ.get("SPAWN_MON_SOCK", os.path.join(LOG_DIR, "qemu-spawn-monitor.sock"))
+BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "40"))
+CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "20"))
+
+
+def say(message):
+    sys.stdout.write(message + "\n")
+    sys.stdout.flush()
+
+
+def log_text():
+    try:
+        with open(LOG, "r", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
+def wait_for(proc, needle, timeout, start=0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError("QEMU stopped unexpectedly; log tail:\n%s" % log_text()[-2000:])
+        if needle in log_text()[start:]:
+            time.sleep(0.35)
+            return
+        time.sleep(0.15)
+    raise RuntimeError("timeout waiting for %r; log tail:\n%s" % (needle, log_text()[-2000:]))
+
+
+def parse_spawn_pid(text):
+    key = "spawn ok pid "
+    idx = text.find(key)
+    if idx < 0:
+        raise RuntimeError("spawn ok pid not in log")
+    idx += len(key)
+    pid = []
+    while idx < len(text) and text[idx].isdigit():
+        pid.append(text[idx])
+        idx += 1
+    if not pid:
+        raise RuntimeError("no pid after spawn ok pid")
+    return "".join(pid)
+
+
+def qemu_disk_args():
+    disk = os.environ.get("OVERLAY_DISK", os.path.join(ROOT, "build", "overlay.img"))
+    if os.path.isfile(disk):
+        return ["-drive", "file=%s,format=raw,if=ide,cache=writethrough" % disk]
+    return []
+
+
+def monitor_connect():
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if os.path.exists(MON_SOCK):
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                client.connect(MON_SOCK)
+                client.settimeout(0.1)
+                try:
+                    client.recv(4096)
+                except socket.timeout:
+                    pass
+                return client
+            except OSError:
+                client.close()
+        time.sleep(0.1)
+    raise RuntimeError("QEMU monitor unavailable")
+
+
+def drain_monitor(client):
+    client.settimeout(0.05)
+    while True:
+        try:
+            data = client.recv(8192)
+            if not data:
+                break
+        except socket.timeout:
+            break
+
+
+def send_command(client, command):
+    aliases = {" ": "spc", "-": "minus", ".": "dot"}
+    for char in command:
+        client.sendall(("sendkey %s\n" % aliases.get(char, char.lower())).encode("ascii"))
+        drain_monitor(client)
+        time.sleep(0.20)
+    client.sendall(b"sendkey ret\n")
+    drain_monitor(client)
+
+
+def terminate(proc):
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=4)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def main():
+    if not os.path.isfile(KERNEL) or not os.path.isfile(INITRD):
+        raise RuntimeError("missing build artefacts; run make all first")
+    os.makedirs(LOG_DIR, exist_ok=True)
+    for path in (LOG, QEMU_ERR, MON_SOCK):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+    proc = None
+    monitor = None
+    try:
+        with open(QEMU_ERR, "wb") as err:
+            proc = subprocess.Popen([
+                "qemu-system-i386", "-cpu", "pentium3", "-kernel", KERNEL,
+                "-initrd", INITRD, "-m", "1024M", "-display", "none", "-vga", "none",
+                "-serial", "file:" + LOG, "-monitor", "unix:%s,server,nowait" % MON_SOCK,
+                "-machine", "type=pc,accel=tcg", "-no-reboot", "-no-shutdown",
+            ] + qemu_disk_args(), cwd=ROOT, stdout=err, stderr=err)
+            wait_for(proc, "(-.-)", BOOT_TIMEOUT)
+            wait_for(proc, "SYS_GETS: Debut", BOOT_TIMEOUT)
+            monitor = monitor_connect()
+
+            say("typing spawn idle ...")
+            start = len(log_text())
+            send_command(monitor, "spawn idle")
+            wait_for(proc, "idle ok", CMD_TIMEOUT, start)
+            wait_for(proc, "spawn ok pid", CMD_TIMEOUT, start)
+            idle_pid = parse_spawn_pid(log_text()[start:])
+            say("spawned idle pid %s" % idle_pid)
+
+            say("typing ps ...")
+            start = len(log_text())
+            send_command(monitor, "ps")
+            wait_for(proc, "user  idle", CMD_TIMEOUT, start)
+
+            say("typing yield ...")
+            start = len(log_text())
+            send_command(monitor, "yield")
+            wait_for(proc, "yield ok", CMD_TIMEOUT, start)
+
+            say("typing kill %s ..." % idle_pid)
+            start = len(log_text())
+            send_command(monitor, "kill %s" % idle_pid)
+            wait_for(proc, "Processus %s termine" % idle_pid, CMD_TIMEOUT, start)
+
+            say("typing ps (after kill) ...")
+            start = len(log_text())
+            send_command(monitor, "ps")
+            wait_for(proc, "Total:", CMD_TIMEOUT, start)
+            if "user  idle" in log_text()[start:]:
+                raise RuntimeError("idle still listed in ps after kill %s" % idle_pid)
+
+        say("QEMU spawn/yield smoke passed.")
+        return 0
+    finally:
+        if monitor is not None:
+            monitor.close()
+        terminate(proc)
+        try:
+            os.remove(MON_SOCK)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print("QEMU spawn smoke failed: %s" % error, file=sys.stderr)
+        raise SystemExit(1)

--- a/userspace/idle.c
+++ b/userspace/idle.c
@@ -1,12 +1,19 @@
-/* idle.c - tâche userspace de fond. Reste en file jusqu'à kill.
- * Ne pas la lancer via exec (bloquant). spawn ne change pas de contexte :
- * le shell garde le CPU, idle reste TASK_READY. */
+/* idle.c - tache userspace de fond. spawn lui cede le CPU une fois ;
+ * ensuite elle boucle sur SYS_YIELD jusqu'a kill. Ne pas la lancer via exec
+ * (bloquant). */
+
+void putc(char c) {
+    asm volatile("int $0x80" : : "a"(1), "b"(c));
+}
 
 void yield(void) {
     asm volatile("int $0x80" : : "a"(4));
 }
 
 void main(void) {
+    const char* msg = "idle ok\n";
+    int i;
+    for (i = 0; msg[i]; i++) putc(msg[i]);
     for (;;) {
         yield();
     }

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -508,7 +508,8 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     
     print_colored("\nCOMMANDES PROCESSUS :\n", COLOR_YELLOW);
     print_string("  ps                 - Afficher les processus\n");
-    print_string("  spawn <prog>       - Lancer un programme en arriere-plan\n");
+    print_string("  spawn <prog>       - Lancer un programme (cede le CPU une fois)\n");
+    print_string("  yield              - Ceder le CPU (SYS_YIELD, cooperatif)\n");
     print_string("  kill <pid>         - Terminer un processus\n");
     print_string("  jobs               - Afficher les tâches\n");
     print_string("  top                - Moniteur système\n");
@@ -1091,7 +1092,7 @@ static int is_builtin(const char* cmd) {
         "history", "env", "echo", "write", "append", "touch", "clear", "cls", "exit", "quit",
         "ai", "ai-mode", "ai-help", "ai-test", "ai-stats", "ai-provider", "ai-model", "ai-runtime",
         "cd", "pwd", "cat", "stat", "test", "[", "mkdir", "rmdir", "cp", "mv", "rm",
-        "kill", "spawn", "jobs", "top", "getpid", "uptime", "date", "whoami",
+        "kill", "spawn", "yield", "jobs", "top", "getpid", "uptime", "date", "whoami",
         "alias", "unalias", "export", "which", "rc",
         "grep", "wc", "sort", "head", "tail",
         "logout", "reboot", "shutdown",
@@ -1355,6 +1356,14 @@ static void cmd_spawn(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string(" ");
     print_string(args[0]);
     print_string("\n");
+}
+
+static void cmd_yield(shell_context_t* ctx, char args[][128], int arg_count) {
+    (void)args;
+    (void)arg_count;
+    yield();
+    print_string("yield ok\n");
+    ctx->last_rc = 0;
 }
 
 static void cmd_jobs(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -2160,6 +2169,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "spawn") == 0) {
         cmd_spawn(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "yield") == 0) {
+        cmd_yield(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "jobs") == 0) {
         cmd_jobs(ctx, args, arg_count);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cooperative task switch so `spawn idle` actually runs, without bringing back IRQ0 round-robin (that path page-faults because a timer interrupting a syscall has no user SS/ESP).

## What changed
- `SYS_YIELD` and successful `SYS_SPAWN` call `schedule()` from the `int 0x80` user frame. The timer still only reschedules when `g_reschedule_needed` is set (shell launch / blocking exec).
- The picker prefers `TASK_TYPE_USER` + `TASK_READY` so yield does not iret into the leftover kernel boot task.
- `idle` prints `idle ok` once (SYS_PUTC, visible on serial) then loops on `SYS_YIELD`.
- Shell builtin `yield` -> `yield ok`.
- Fourth QEMU smoke boot: `spawn idle` / `idle ok` / `ps` / `yield` / `kill`. Core overlay sendkeys stay identical to #73.

## Tests
- Unity **140** unchanged.
- `make qemu-smoke` = core 120s + extras 90s + persist 180s + spawn 90s.

Round-robin every PIT tick stays off on purpose.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

