### PR TITLE
Blocking exec waits cooperatively for the child

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run unit tests (make test-all)
         run: make test-all
 
-      - name: QEMU smoke (overlay + extras + persist + spawn)
+      - name: QEMU smoke (overlay + extras + persist + spawn + exec)
         run: make qemu-smoke
 
       - name: Upload logs

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ userspace/fake_ai
 userspace/test_program
 userspace/ai_assistant
 userspace/idle
+userspace/ok
 userspace/*.o
 userspace/*.bin
 initrd_content/bin/shell
@@ -11,6 +12,7 @@ initrd_content/bin/fake_ai
 initrd_content/bin/ai_assistant
 initrd_content/bin/user_program
 initrd_content/bin/idle
+initrd_content/bin/ok
 
 # Build and QEMU artefacts
 /build/

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ pack-initrd: userspace-all
 	@cp -f userspace/ai_assistant $(BIN_DEST_DIR)/ai_assistant
 	@cp -f userspace/test_program $(BIN_DEST_DIR)/user_program
 	@cp -f userspace/idle $(BIN_DEST_DIR)/idle
+	@cp -f userspace/ok $(BIN_DEST_DIR)/ok
 	@tar -C $(INITRD_DIR) -cf $(INITRD_IMAGE) .
 	@echo "[mkinitrd] Packed executables into $(INITRD_IMAGE)"
 
@@ -275,7 +276,7 @@ iso-clean:
 	@rm -rf build/isodir $(ISO_IMAGE)
 
 # Compile tous les programmes utilisateur
-user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle: userspace-all
+user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle userspace/ok: userspace-all
 
 # Cible pour exécuter l'OS dans QEMU avec initrd (mode console corrigé)
 run: $(OS_IMAGE) pack-initrd disk
@@ -468,7 +469,7 @@ help:
 	@echo "  test-kernel     - Tests des modules kernel uniquement"
 	@echo "  test-userspace  - Tests des modules userspace uniquement"  
 	@echo "  test-all        - Suite complète de tests (< 5 min)"
-	@echo "  qemu-smoke      - Boots QEMU : overlay, extras, persist, spawn/yield"
+	@echo "  qemu-smoke      - Boots QEMU : overlay, extras, persist, spawn, exec"
 	@echo "  disk            - Cree build/overlay.img (IDE, 32 Kio) si absent"
 	@echo "  gpt2-recovery   - Modèle requis : réponse GPT-2 puis reprise shell (rc)"
 	@echo "  gpt2-benchmark  - Modèle requis : mesure de latence QEMU SSE2"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ La branche par défaut est **`master`**.
 - **Shell Ring 3** - prompt `/ (-.-) :`. `ls`/`cat` lisent initrd + overlay ; `mkdir`/`rm`/`cp`/`mv`/`touch`/`write`/`append` mutent l'overlay (snapshot ATA PIO si un disque IDE est présent). `ps`/`kill`/`getpid`/`mem`/`uptime` interrogent le noyau.
 - **GPT-2 local optionnel** - `ai <texte>` -> `[GPT-2 local]` si le checkpoint est dans l'initrd ; sinon message d'indisponibilité. Le binaire historique `bin/ai_assistant` reste empaqueté.
 - **Isolation** - GDT/IDT, Ring 0/3, chargeur ELF, syscalls (0-22, `MAX_SYSCALLS` = 23).
-- **Tâches** - passage kernel -> shell via `jump_to_task()` ; `spawn`/`yield` basculent de façon coopérative (int 0x80). Le round-robin à chaque tick PIT n'est pas le mode actuel.
+- **Tâches** - passage kernel -> shell via `jump_to_task()` ; `spawn`/`yield`/`exec` basculent de façon coopérative (int 0x80). Le round-robin à chaque tick PIT n'est pas le mode actuel.
 - **Fichiers** - initrd TAR en lecture seule + overlay RAM 32 nœuds (fichiers <= 256 octets). Snapshot persisté sur le disque IDE QEMU (`build/overlay.img`) en ATA PIO LBA28, sans IRQ14.
 - **Matériel QEMU** - PIC, clavier PS/2, PIT 100 Hz, IDE primaire (maître). Historique clavier (EOI IRQ0) : [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
 
@@ -43,7 +43,7 @@ make run           # QEMU curses ; le shell lit le clavier PS/2, pas le port sé
 |---|---|
 | `make all` | Noyau + initrd + `build/overlay.img` (disque IDE 32 Kio) |
 | `make test-all` | Unity 32-bit (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_shell` 25, `test_ramfs` 10) |
-| `make qemu-smoke` | Quatre boots QEMU (overlay + extras shell + persist disque + spawn/yield), sans modèle |
+| `make qemu-smoke` | Cinq boots QEMU (overlay + extras + persist + spawn/yield + exec), sans modèle |
 | `make ci` | `all` + `test-all` + `qemu-smoke` (gate PR) |
 | `make run` / `make run-gui` | Session interactive (voir [docs/GUIDE_EXECUTION.md](docs/GUIDE_EXECUTION.md)) |
 
@@ -112,7 +112,7 @@ ai-os/
 │   ├── input/            # buffer clavier
 │   └── llm/              # GPT-2 freestanding
 ├── fs/                   # initrd TAR + overlay RAM (snapshot IDE)
-├── userspace/            # shell, idle, fake_ai, ai_assistant
+├── userspace/            # shell, idle, ok, fake_ai, ai_assistant
 ├── include/              # ABI syscalls
 ├── initrd_content/       # contenu empaqueté dans my_initrd.tar
 ├── models/               # local, gitignoré - poids GPT-2 optionnels
@@ -131,6 +131,7 @@ Le dossier [`US/`](US/README.md) décrit la vision MOHHOS (spécifications, pas 
 - [x] Tokenizer BPE GPT-2 (entree et sortie)
 - [x] Overlay persisté (snapshot ATA PIO sur disque IDE QEMU)
 - [x] `spawn` / `yield` coopératifs (l'enfant tourne vraiment)
+- [x] `exec` bloquant coopératif (parent TASK_WAITING, enfant SYS_EXIT)
 - [ ] Quantification, chargeur GGUF, latence &lt; 1 s
 - [ ] Réseau, DNS, TLS, fournisseur OpenAI effectif
 - [ ] Système de fichiers disque général (ext2/FAT)

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -29,14 +29,14 @@ Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavi
 - PMM / VMM / heap, paging
 - Initrd format TAR POSIX (`fs/initrd.c`)
 - Chargeur ELF 32-bit
-- Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3) ; `SYS_SPAWN` / `SYS_YIELD` basculent depuis le cadre user (pas depuis IRQ0)
+- Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3) ; `SYS_SPAWN` / `SYS_YIELD` / `SYS_EXEC` basculent depuis le cadre user (pas depuis IRQ0)
 - Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME`, `SYS_COPY`, `SYS_APPEND` et `SYS_GPT2_GENERATE` (ABI : `include/os_syscalls.h`)
 - Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`, concatène sans écraser) / `touch` (fichier vide) / `echo >` visibles par `ls`/`cat` ; l'initrd reste en lecture seule ; `rmdir` d'un dossier non vide échoue. Après chaque mutation réussie, un snapshot binaire (magic `AIOV`, 32 nœuds, 24 secteurs) est écrit en ATA PIO LBA28 sur le maître IDE primaire (`kernel/ata.c`, ports `0x1F0`, sans IRQ14). Au boot, si IDENTIFY réussit, l'overlay est restauré. Sans disque QEMU, IDENTIFY échoue tout de suite et l'overlay reste volatile.
 
 ### Espace utilisateur
 
 - `userspace/shell.c` s'exécute vraiment en Ring 3 (plus de boucle shell simulée dans le kernel)
-- Programmes empaquetés dans l'initrd : `shell`, `fake_ai`, `ai_assistant`, `user_program`, `idle`, ainsi que les fichiers de modèle lorsqu'ils sont fournis au build
+- Programmes empaquetés dans l'initrd : `shell`, `fake_ai`, `ai_assistant`, `user_program`, `idle`, `ok`, ainsi que les fichiers de modèle lorsqu'ils sont fournis au build
 - Commande `ai <texte>` appelle `SYS_GPT2_GENERATE` pour le profil local GPT-2 et produit une sortie `[GPT-2 local]` ; le binaire historique `ai_assistant` reste disponible comme compatibilité
 
 ### Clavier (août 2026)
@@ -46,7 +46,7 @@ Les nombreuses notes "clavier corrigé" des versions 6.0/6.1 étaient **partiell
 Correctif actuel :
 
 1. EOI IRQ0 **avant** `timer_handler` / `schedule()` (`boot/isr_stubs.s`)
-2. Planification seulement si `g_reschedule_needed` (lancement du shell, exec bloquant) - plus à chaque tick, ce qui provoquait un page fault une fois l'EOI rétabli (`kernel/timer.c`). `SYS_SPAWN` et `SYS_YIELD` appellent `schedule()` depuis le cadre **user** de `int 0x80`.
+2. Planification seulement si `g_reschedule_needed` (lancement du shell) - plus à chaque tick, ce qui provoquait un page fault une fois l'EOI rétabli (`kernel/timer.c`). `SYS_SPAWN`, `SYS_YIELD` et `SYS_EXEC` appellent `schedule()` depuis le cadre **user** de `int 0x80`. Le parent d'`exec` passe `TASK_WAITING` jusqu'au `SYS_EXIT` de l'enfant.
 
 Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` reçus par `SYS_GETS`.
 
@@ -119,7 +119,7 @@ Malgré la roadmap README v7/v8 et le dossier `US/` :
 - Réseau P2P, multi-plateforme, économie collaborative
 - Les 120 User Stories MOHHOS : **spécifications**, pas d'implémentation (sauf recouvrement accidentel avec le noyau actuel : mémoire, tests unitaires partiels)
 
-Le préemptif "à chaque tick" est volontairement **limité** : après le premier passage au shell, le timer n'appelle plus `schedule()` sauf `g_reschedule_needed` (exec bloquant). `spawn` et `yield` basculent depuis le syscall, sans round-robin IRQ0 (stabilité clavier).
+Le préemptif "à chaque tick" est volontairement **limité** : après le premier passage au shell, le timer n'appelle plus `schedule()` sauf `g_reschedule_needed` (premier saut vers le shell). `spawn`, `yield` et `exec` basculent depuis le syscall, sans round-robin IRQ0 (stabilité clavier).
 
 ## Documents historiques à ne pas prendre pour l'état courant
 
@@ -136,7 +136,7 @@ Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusio
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
 make clean && make all
 make test-all
-make qemu-smoke       # quatre boots QEMU : overlay (#73) + extras + persist + spawn/yield
+make qemu-smoke       # cinq boots QEMU : overlay (#73) + extras + persist + spawn/yield + exec ok
 make gpt2-recovery    # modèle requis : réponse GPT-2, puis validation de `rc`
 make gpt2-benchmark   # modèle requis : mesure avec CPU QEMU Pentium III SSE2
 make gpt2-tests       # modèle requis : reprise shell + benchmark
@@ -145,7 +145,7 @@ make run              # console curses (recommandé en local)
 make run-gui          # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU fait **quatre boots** : un scénario cœur (`ls`, `ai-runtime`, création et copie récursive d'un répertoire overlay, `append`, `cat`, `rc`) puis les extras (`which idle`, `history`, `jobs`, `top`, `env`, `date`, `echo hi`, `rc`, `test no zz`, `aistats`/`aimode`/`aihelp`), une persistance disque (`write k.txt v7ok`, kill QEMU, reboot, `cat k.txt` voit `v7ok`), puis `spawn idle` (aiguille `idle ok`), `yield`, `kill`. Le disque cœur/extras/spawn est remis à zéro entre ces boots. Le scénario cœur attend le retour du shell après chaque commande afin d'éviter les touches fantômes. Timeouts : 120 s cœur + 90 s extras + 180 s persist + 90 s spawn.
+GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU fait **cinq boots** : un scénario cœur (`ls`, `ai-runtime`, création et copie récursive d'un répertoire overlay, `append`, `cat`, `rc`) puis les extras (`which idle`, `history`, `jobs`, `top`, `env`, `date`, `echo hi`, `rc`, `test no zz`, `aistats`/`aimode`/`aihelp`), une persistance disque (`write k.txt v7ok`, kill QEMU, reboot, `cat k.txt` voit `v7ok`), `spawn idle` (aiguille `idle ok`), `yield`, `kill`, puis `ok` (ELF `exec ok`, retour au shell, `rc ok 0`). Le disque cœur/extras/spawn/exec est remis à zéro entre ces boots. Le scénario cœur attend le retour du shell après chaque commande afin d'éviter les touches fantômes. Timeouts : 120 s cœur + 90 s extras + 180 s persist + 90 s spawn + 90 s exec.
 
 En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n'atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -54,6 +54,7 @@
 - [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` (fichier et dossier via `SYS_COPY`) / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`) / `touch` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
 - [x] Overlay persisté : snapshot ATA PIO LBA28 sur disque IDE QEMU (`write` survit à un reboot) ; pas un FS général
 - [x] `spawn` / `yield` coopératifs (cadre syscall user ; pas de round-robin IRQ0)
+- [x] `exec` bloquant : parent `TASK_WAITING`, enfant reveille via `SYS_EXIT` (plus de `int $0x30` noyau)
 - [ ] Préemption round-robin continue (aujourd'hui limitée pour la stabilité)
 - [ ] Réseau, vrai moteur IA - voir roadmap README / dossier `US/`
 

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -37,11 +37,10 @@ void syscall_handler(cpu_state_t* cpu) {
     // Le numéro de syscall est dans le registre EAX
     switch (cpu->eax) {
         case SYS_EXIT:
+            task_wake_waiter(current_task);
             current_task->state = TASK_TERMINATED;
             print_string_serial("[EXIT] task terminated, scheduling...\n");
-            // Basculer directement via l'ordonnanceur en utilisant l'état CPU courant
             schedule(cpu);
-            // Ne devrait jamais revenir
             break;
         
         case SYS_PUTC:
@@ -101,8 +100,15 @@ void syscall_handler(cpu_state_t* cpu) {
             
         case SYS_EXEC:
             print_string_serial("[EXEC] starting child\n");
-            cpu->eax = sys_exec((const char*)cpu->ebx, (char**)cpu->ecx);
-            print_string_serial("[EXEC] child finished\n");
+            {
+                int rc = sys_exec((const char*)cpu->ebx, (char**)cpu->ecx);
+                cpu->eax = (uint32_t)rc;
+                if (rc >= 0) {
+                    print_string_serial("[EXEC] waiting for child\n");
+                    current_task->state = TASK_WAITING;
+                    schedule(cpu);
+                }
+            }
             break;
         case SYS_SPAWN:
             print_string_serial("[SPAWN] starting child\n");
@@ -229,15 +235,15 @@ void syscall_init() {
     register_interrupt_handler(0x80, (interrupt_handler_t)syscall_handler);
 }
 
-// Nouveau: SYS_EXEC - Exécuter un programme
+/* SYS_EXEC : cree l'enfant, le parent passe TASK_WAITING. Le handler
+ * appelle schedule() depuis le cadre user. SYS_EXIT reveille le waiter. */
 int sys_exec(const char* path, char* argv[]) {
     task_t* new_task = create_task_from_initrd_file(path);
 
     if (!new_task) {
-        return -1; // Echec
+        return -1;
     }
 
-    // Passer premier argument (question) comme pour spawn
     if (argv) {
         char** argv_list = (char**)argv;
         const char* src = 0;
@@ -259,16 +265,8 @@ int sys_exec(const char* path, char* argv[]) {
             new_task->cpu_state.ebx = (uint32_t)(0xB0000000 - 512);
         }
     }
-    // Demander un reschedule immediat
-    extern volatile int g_reschedule_needed;
-    g_reschedule_needed = 1;
-
-    // L'exec actuel est bloquant. On attend la fin de la tâche.
-    while (new_task->state != TASK_TERMINATED) {
-        asm volatile("int $0x30");
-    }
-
-    return 0; // Succès
+    new_task->waiter_pid = current_task ? current_task->id : 0;
+    return 0;
 }
 
 /* Cree la tache et retourne son pid. Le handler appelle schedule() pour

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -33,6 +33,7 @@ void tasking_init() {
     current_task->type = TASK_TYPE_KERNEL;
     current_task->vmm_dir = kernel_directory;
     current_task->kernel_stack_p = 0;
+    current_task->waiter_pid = 0;
     current_task->name[0] = 'k';
     current_task->name[1] = 'e';
     current_task->name[2] = 'r';
@@ -240,6 +241,7 @@ task_t* create_task_from_initrd_file(const char* filename) {
     new_task->state = TASK_READY;
     new_task->type = TASK_TYPE_USER;
     new_task->vmm_dir = vmm_dir;
+    new_task->waiter_pid = 0;
     {
         int i = 0;
         const char* n = name_src ? name_src : "user";
@@ -406,9 +408,19 @@ int task_kill(int pid) {
     t = get_task_by_id(pid);
     if (!t) return -1;
     if (current_task && t->id == current_task->id) return -3;
+    task_wake_waiter(t);
     t->state = TASK_TERMINATED;
     unlink_task(t);
     return 0;
+}
+
+void task_wake_waiter(task_t* child) {
+    task_t* parent;
+    if (!child || child->waiter_pid <= 0) return;
+    parent = get_task_by_id(child->waiter_pid);
+    if (parent && parent->state == TASK_WAITING) {
+        parent->state = TASK_READY;
+    }
 }
 
 static int32_t map_task_state(task_state_t s) {

--- a/kernel/task/task.h
+++ b/kernel/task/task.h
@@ -42,6 +42,7 @@ typedef struct task {
     vmm_directory_t* vmm_dir;  // Répertoire de pages de la tâche
     uint32_t kernel_stack_p;   // Pointeur vers le sommet de la pile noyau
     char name[32];
+    int waiter_pid;            // Parent TASK_WAITING (SYS_EXEC), 0 sinon
     struct task* next;         // Pour la liste chaînée de tâches
     struct task* prev;         // Liste doublement chaînée
 } task_t;
@@ -70,6 +71,7 @@ int get_task_count();
 task_t* find_task_waiting_for_input();
 int task_kill(int pid);
 int task_fill_ps(os_proc_t* out, int max_n);
+void task_wake_waiter(task_t* child);
 
 #endif
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -56,8 +56,8 @@ void timer_handler(cpu_state_t* cpu) {
         print_string_serial("\n");
     }
     
-    // Un seul changement de contexte quand il est demandé (lancement du shell,
-    // exec bloquant). spawn/yield basculent depuis int 0x80, pas depuis IRQ0 :
+    // Un seul changement de contexte quand il est demandé (lancement du shell).
+    // exec/spawn/yield basculent depuis int 0x80, pas depuis IRQ0 :
     // un schedule() pendant un syscall (cadre noyau sans SS/ESP user) page-fault.
     if (g_reschedule_needed) {
         g_reschedule_needed = 0;

--- a/tests/framework/kernel_mocks.c
+++ b/tests/framework/kernel_mocks.c
@@ -110,6 +110,7 @@ int task_kill(int pid) {
     t = get_task_by_id(pid);
     if (!t) return -1;
     if (current_task && t->id == current_task->id) return -3;
+    task_wake_waiter(t);
     t->state = TASK_TERMINATED;
     remove_task(t);
     return 0;
@@ -169,6 +170,15 @@ void schedule(cpu_state_t* cpu) {
     current_task = next_task;
     current_task->state = TASK_RUNNING;
     g_reschedule_needed = 0;
+}
+
+void task_wake_waiter(task_t* child) {
+    task_t* parent;
+    if (!child || child->waiter_pid <= 0) return;
+    parent = get_task_by_id(child->waiter_pid);
+    if (parent && parent->state == TASK_WAITING) {
+        parent->state = TASK_READY;
+    }
 }
 
 void task_yield(void) {

--- a/tests/scripts/ci_qemu_exec.py
+++ b/tests/scripts/ci_qemu_exec.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""QEMU smoke: blocking SYS_EXEC runs bin/ok then returns to the shell."""
+from __future__ import print_function
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+KERNEL = os.environ.get("KERNEL", os.path.join(ROOT, "build", "ai_os.bin"))
+INITRD = os.environ.get("INITRD", os.path.join(ROOT, "my_initrd.tar"))
+LOG_DIR = os.path.join(ROOT, "test_logs")
+LOG = os.environ.get("EXEC_LOG", os.path.join(LOG_DIR, "ci-qemu-exec-serial.log"))
+QEMU_ERR = os.environ.get("EXEC_ERR", os.path.join(LOG_DIR, "ci-qemu-exec-stderr.log"))
+MON_SOCK = os.environ.get("EXEC_MON_SOCK", os.path.join(LOG_DIR, "qemu-exec-monitor.sock"))
+BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "40"))
+CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "20"))
+
+
+def say(message):
+    sys.stdout.write(message + "\n")
+    sys.stdout.flush()
+
+
+def log_text():
+    try:
+        with open(LOG, "r", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
+def wait_for(proc, needle, timeout, start=0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError("QEMU stopped unexpectedly; log tail:\n%s" % log_text()[-2000:])
+        if needle in log_text()[start:]:
+            time.sleep(0.35)
+            return
+        time.sleep(0.15)
+    raise RuntimeError("timeout waiting for %r; log tail:\n%s" % (needle, log_text()[-2000:]))
+
+
+def qemu_disk_args():
+    disk = os.environ.get("OVERLAY_DISK", os.path.join(ROOT, "build", "overlay.img"))
+    if os.path.isfile(disk):
+        return ["-drive", "file=%s,format=raw,if=ide,cache=writethrough" % disk]
+    return []
+
+
+def monitor_connect():
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if os.path.exists(MON_SOCK):
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                client.connect(MON_SOCK)
+                client.settimeout(0.1)
+                try:
+                    client.recv(4096)
+                except socket.timeout:
+                    pass
+                return client
+            except OSError:
+                client.close()
+        time.sleep(0.1)
+    raise RuntimeError("QEMU monitor unavailable")
+
+
+def drain_monitor(client):
+    client.settimeout(0.05)
+    while True:
+        try:
+            data = client.recv(8192)
+            if not data:
+                break
+        except socket.timeout:
+            break
+
+
+def send_command(client, command):
+    aliases = {" ": "spc", "-": "minus", ".": "dot"}
+    for char in command:
+        client.sendall(("sendkey %s\n" % aliases.get(char, char.lower())).encode("ascii"))
+        drain_monitor(client)
+        time.sleep(0.20)
+    client.sendall(b"sendkey ret\n")
+    drain_monitor(client)
+
+
+def terminate(proc):
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=4)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def main():
+    if not os.path.isfile(KERNEL) or not os.path.isfile(INITRD):
+        raise RuntimeError("missing build artefacts; run make all first")
+    os.makedirs(LOG_DIR, exist_ok=True)
+    for path in (LOG, QEMU_ERR, MON_SOCK):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+    proc = None
+    monitor = None
+    try:
+        with open(QEMU_ERR, "wb") as err:
+            proc = subprocess.Popen([
+                "qemu-system-i386", "-cpu", "pentium3", "-kernel", KERNEL,
+                "-initrd", INITRD, "-m", "1024M", "-display", "none", "-vga", "none",
+                "-serial", "file:" + LOG, "-monitor", "unix:%s,server,nowait" % MON_SOCK,
+                "-machine", "type=pc,accel=tcg", "-no-reboot", "-no-shutdown",
+            ] + qemu_disk_args(), cwd=ROOT, stdout=err, stderr=err)
+            wait_for(proc, "(-.-)", BOOT_TIMEOUT)
+            wait_for(proc, "SYS_GETS: Debut", BOOT_TIMEOUT)
+            monitor = monitor_connect()
+
+            say("typing ok ...")
+            start = len(log_text())
+            send_command(monitor, "ok")
+            wait_for(proc, "exec ok", CMD_TIMEOUT, start)
+            wait_for(proc, "SYS_GETS: Debut", CMD_TIMEOUT, start)
+
+            say("typing rc ...")
+            start = len(log_text())
+            send_command(monitor, "rc")
+            wait_for(proc, "rc ok 0", CMD_TIMEOUT, start)
+
+        say("QEMU exec smoke passed.")
+        return 0
+    finally:
+        if monitor is not None:
+            monitor.close()
+        terminate(proc)
+        try:
+            os.remove(MON_SOCK)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print("QEMU exec smoke failed: %s" % error, file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -16,6 +16,7 @@ CORE_TIMEOUT="${CORE_TIMEOUT:-120}"
 EXTRAS_TIMEOUT="${EXTRAS_TIMEOUT:-90}"
 PERSIST_TIMEOUT="${PERSIST_TIMEOUT:-180}"
 SPAWN_TIMEOUT="${SPAWN_TIMEOUT:-90}"
+EXEC_TIMEOUT="${EXEC_TIMEOUT:-90}"
 OVERLAY_DISK="${OVERLAY_DISK:-$ROOT/build/overlay.img}"
 PERSIST_DISK="${PERSIST_DISK:-$ROOT/build/overlay-persist.img}"
 export OVERLAY_DISK PERSIST_DISK
@@ -44,6 +45,10 @@ if ! grep -a -qF "yield ok" userspace/shell; then
     echo "ERROR: userspace/shell is stale (no yield ok needle)."
     exit 1
 fi
+if ! grep -a -qF "exec ok" userspace/ok; then
+    echo "ERROR: userspace/ok is stale (no exec ok needle). Expected 'make -C userspace all'."
+    exit 1
+fi
 
 run_python() {
     local name="$1"
@@ -68,3 +73,5 @@ run_python extras "$EXTRAS_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_shell_extras.py
 run_python persist "$PERSIST_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_persist.py"
 reset_overlay_disk "$OVERLAY_DISK"
 run_python spawn "$SPAWN_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_spawn.py"
+reset_overlay_disk "$OVERLAY_DISK"
+run_python exec "$EXEC_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_exec.py"

--- a/userspace/Makefile
+++ b/userspace/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -nostdlib -Ttext=0x40000000
 ASFLAGS = --32
 
 # Programmes à compiler
-PROGRAMS = shell fake_ai test_program ai_assistant idle
+PROGRAMS = shell fake_ai test_program ai_assistant idle ok
 
 all: $(PROGRAMS)
 
@@ -30,6 +30,10 @@ test_program: test_program.o start.o
 
 idle: idle.o start.o
 	@echo "Linking idle..."
+	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
+
+ok: ok.o start.o
+	@echo "Linking ok..."
 	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
 
 %.o: %.c

--- a/userspace/ok.c
+++ b/userspace/ok.c
@@ -1,0 +1,12 @@
+/* ok.c - ELF minimal pour SYS_EXEC. Affiche exec ok et sort (start.s). */
+
+void putc(char c) {
+    asm volatile("int $0x80" : : "a"(1), "b"(c));
+}
+
+int main(void) {
+    const char* msg = "exec ok\n";
+    int i;
+    for (i = 0; msg[i]; i++) putc(msg[i]);
+    return 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Blocking `SYS_EXEC` now waits the same way as spawn/yield: from the `int 0x80` user frame, not via `int $0x30` in kernel mode.

## What changed
- Parent goes `TASK_WAITING` after a successful exec. The child stores `waiter_pid`. `SYS_EXIT` (and `kill`) wake the parent to `TASK_READY` then `schedule()`.
- The IRQ0 round-robin stays off. `g_reschedule_needed` is only for the first jump to the shell.
- New ELF `bin/ok` prints `exec ok` (SYS_PUTC, serial-visible) and exits 0. Unknown shell commands already used blocking exec; `ok` is sendkey-safe.
- Fifth QEMU smoke boot: `ok` -> `exec ok` -> shell `SYS_GETS` again -> `rc ok 0`. Overlay sendkeys stay identical to #73.

## Tests
- Unity **140** unchanged.
- `make qemu-smoke` = core 120s + extras 90s + persist 180s + spawn 90s + exec 90s.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

