### PR TITLE
Stop GPT-2 greedy loop repeating "The"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 # Liste des fichiers objets - MISE À JOUR avec tous les nouveaux fichiers
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
-          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/gpt2_model.o build/gpt2_tokenizer.o build/gpt2_infer.o build/interrupts.o \
+          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/gpt2_model.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
           build/keyboard.o build/timer.o build/multiboot.o build/kernel.o build/kbd_buffer.o
 
 # Cible par défaut : construire le système complet (noyau + initrd + disque overlay)
@@ -164,8 +164,13 @@ build/gpt2_tokenizer.o: kernel/llm/gpt2_tokenizer.c kernel/llm/gpt2_tokenizer.h 
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
+# Echantillonnage top-k GPT-2 (sans dependance heap / checkpoint).
+build/gpt2_sample.o: kernel/llm/gpt2_sample.c kernel/llm/gpt2_sample.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
 # Noyau d'inference GPT-2 CPU freestanding.
-build/gpt2_infer.o: kernel/llm/gpt2_infer.c kernel/llm/gpt2_infer.h kernel/llm/gpt2_model.h kernel/mem/heap.h
+build/gpt2_infer.o: kernel/llm/gpt2_infer.c kernel/llm/gpt2_infer.h kernel/llm/gpt2_sample.h kernel/llm/gpt2_model.h kernel/mem/heap.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
@@ -496,7 +501,7 @@ help:
 	@echo "Tests de non-régression:"
 	@echo "  make test-setup           # Configuration initiale (une fois)"
 	@echo "  make test-quick           # Tests pendant développement"
-	@echo "  make test-all             # 140 tests Unity avant push"
+	@echo "  make test-all             # 144 tests Unity avant push"
 
 .PHONY: all kernel-only run run-gui test-build info-initrd info-user user-program userspace-all clean distclean help pack-initrd test-setup test-quick test-kernel test-userspace test-all test-performance test-valgrind test-clean pre-commit-tests ci-tests qemu-smoke gpt2-recovery gpt2-benchmark gpt2-tests ci deps disk
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ git clone https://github.com/kamgueblondin/ai-os.git
 cd ai-os
 make deps          # ou : bash scripts/bootstrap-dev.sh
 make all
-make test-all      # 140 tests Unity, sans poids GPT-2
+make test-all      # 144 tests Unity, sans poids GPT-2
 make run           # QEMU curses ; le shell lit le clavier PS/2, pas le port série
 ```
 
@@ -42,7 +42,7 @@ make run           # QEMU curses ; le shell lit le clavier PS/2, pas le port sé
 | Cible | Rôle |
 |---|---|
 | `make all` | Noyau + initrd + `build/overlay.img` (disque IDE 32 Kio) |
-| `make test-all` | Unity 32-bit (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_shell` 25, `test_ramfs` 10) |
+| `make test-all` | Unity 32-bit (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_gpt2_sample` 4, `test_shell` 25, `test_ramfs` 10) |
 | `make qemu-smoke` | Cinq boots QEMU (overlay + extras + persist + spawn/yield + exec), sans modèle |
 | `make ci` | `all` + `test-all` + `qemu-smoke` (gate PR) |
 | `make run` / `make run-gui` | Session interactive (voir [docs/GUIDE_EXECUTION.md](docs/GUIDE_EXECUTION.md)) |
@@ -94,7 +94,7 @@ make qemu-smoke    # smoke QEMU (CI)
 make ci            # même gate que GitHub Actions
 ```
 
-Unity 32-bit : **140** tests (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_shell` 25, `test_ramfs` 10). Les dossiers `tests/integration`, `tests/system`, `tests/performance` et `tests/robustness` sont vides. Les pourcentages de "couverture" affiches par d'anciens scripts ne sont pas mesures par gcov.
+Unity 32-bit : **144** tests (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_gpt2_sample` 4, `test_shell` 25, `test_ramfs` 10). Les dossiers `tests/integration`, `tests/system`, `tests/performance` et `tests/robustness` sont vides. Les pourcentages de "couverture" affiches par d'anciens scripts ne sont pas mesures par gcov.
 
 GitHub Actions (`.github/workflows/ci.yml`) : à chaque push/PR vers `master` (et `main` si la branche est renommée) - `make all`, `make test-all`, `make qemu-smoke`.
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -61,10 +61,11 @@ Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` re�
 | `test_task` | 21/21 |
 | `test_overlay` | 6/6 |
 | `test_tokenizer` | 13/13 |
+| `test_gpt2_sample` | 4/4 |
 | `test_shell` | 25/25 |
 | `test_ramfs` | 10/10 |
 
-Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé "Total Tests" de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des sept binaires (**140** = 17+48+21+6+13+25+10).
+Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé "Total Tests" de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des huit binaires (**144** = 17+48+21+6+13+4+25+10).
 
 Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en plus de `nasm` et `qemu-system-i386`).
 
@@ -101,7 +102,7 @@ Les commandes listées par `help` sont branchées dans `execute_builtin_command(
 
 ## Intelligence artificielle locale
 
-Le chemin local de `ai <texte>` appelle `SYS_GPT2_GENERATE`. Le noyau charge au boot le checkpoint GPT-2 124M en format `llm.c v3` et le tokenizer binaire depuis l'initrd. L'inférence est écrite en C freestanding ; elle utilise un cache clé/valeur par couche et position. L'entrée est tokenisée en **BPE GPT-2** (fusions par plus petit identifiant de vocabulaire, découpage type regex). La sortie décode les octets bruts tiktoken (espaces, sauts de ligne, UTF-8) sans les remplacer par des espaces. La génération est **greedy**, jusqu'à 12 jetons ou le premier saut de ligne / EOT.
+Le chemin local de `ai <texte>` appelle `SYS_GPT2_GENERATE`. Le noyau charge au boot le checkpoint GPT-2 124M en format `llm.c v3` et le tokenizer binaire depuis l'initrd. L'inférence est écrite en C freestanding ; elle utilise un cache clé/valeur par couche et position. L'entrée est tokenisée en **BPE GPT-2** (fusions par plus petit identifiant de vocabulaire, découpage type regex). La sortie décode les octets bruts tiktoken (espaces, sauts de ligne, UTF-8) sans les remplacer par des espaces. La génération est un **échantillonnage top-k** (k=8, température 1,10, pénalité de fréquence, interdiction du jeton précédent) afin d'éviter la boucle greedy GPT-2 ` The The The`. Arrêt au bout de 12 jetons, d'un saut de ligne, d'un EOT, ou d'une répétition consécutive.
 
 La démonstration limite le prompt à 64 jetons et génère jusqu'à 12 jetons (arrêt sur newline ou EOT). L'encodeur BPE couvre le vocabulaire llm.c ; le regex unicode `\p{L}` complet n'est pas reproduit (ASCII + séquences UTF-8). Les poids et le tokenizer ne sont pas distribués dans Git ; sans ces deux fichiers, le moteur local est signalé comme indisponible. `userspace/ai_assistant.c` et `userspace/fake_ai.c` sont conservés comme programmes historiques de compatibilité.
 

--- a/kernel/llm/gpt2_infer.c
+++ b/kernel/llm/gpt2_infer.c
@@ -1,9 +1,9 @@
 #include "gpt2_infer.h"
 #include "gpt2_model.h"
+#include "gpt2_sample.h"
 #include "../mem/heap.h"
 
 #define GPT2_BAREMETAL_MAX_CONTEXT 64U
-#define GPT2_SAMPLE_TOP_K 8U
 
 typedef struct {
     const float* wte;
@@ -265,35 +265,6 @@ static void gpt2_forward_cached_token(const gpt2_params_t* params, const gpt2_co
         for (uint32_t i = 0; i < c; i++) logit += workspace.normalized[i] * output_embedding[i];
         workspace.logits[token] = logit;
     }
-}
-
-static uint32_t gpt2_sample_top_k(const float* logits, uint32_t vocab, const uint32_t* history,
-                                  uint32_t history_count, uint32_t* rng_state) {
-    uint32_t ids[GPT2_SAMPLE_TOP_K];
-    float values[GPT2_SAMPLE_TOP_K];
-    float weights[GPT2_SAMPLE_TOP_K];
-    uint32_t count = 0;
-    uint32_t state = rng_state && *rng_state ? *rng_state : 0x9e3779b9U;
-
-    for (uint32_t i = 0; i < vocab; i++) {
-        float value = logits[i];
-        uint32_t begin = history_count > 16U ? history_count - 16U : 0U;
-        for (uint32_t j = begin; j < history_count; j++) if (history[j] == i) value -= 1.35f;
-        uint32_t pos = count < GPT2_SAMPLE_TOP_K ? count++ : GPT2_SAMPLE_TOP_K;
-        while (pos > 0U && value > values[pos - 1U]) {
-            if (pos < GPT2_SAMPLE_TOP_K) { values[pos] = values[pos - 1U]; ids[pos] = ids[pos - 1U]; }
-            pos--;
-        }
-        if (pos < GPT2_SAMPLE_TOP_K) { values[pos] = value; ids[pos] = i; }
-    }
-    if (count == 0U) return 0U;
-    float total = 0.0f;
-    for (uint32_t i = 0; i < count; i++) { weights[i] = gpt2_fast_exp((values[i] - values[0]) / 1.10f); total += weights[i]; }
-    state = state * 1664525U + 1013904223U;
-    if (rng_state) *rng_state = state;
-    float target = ((float)(state & 0x00ffffffU) / 16777216.0f) * total;
-    for (uint32_t i = 0; i < count; i++) { if (target <= weights[i]) return ids[i]; target -= weights[i]; }
-    return ids[count - 1U];
 }
 
 static int gpt2_generate_next_impl(const uint32_t* tokens, uint32_t token_count,

--- a/kernel/llm/gpt2_infer.h
+++ b/kernel/llm/gpt2_infer.h
@@ -9,7 +9,7 @@
  * memory during the first bare-metal implementation.
  */
 int gpt2_generate_next(const uint32_t* tokens, uint32_t token_count, uint32_t* next_token);
-/* Top-k, temperature implicite et penalite des repetitions recentes. */
+/* Top-k, temperature 1.10, penalite de frequence, interdiction du jeton precedent. */
 int gpt2_generate_next_sampled(const uint32_t* tokens, uint32_t token_count,
                                uint32_t* next_token, uint32_t* rng_state);
 const char* gpt2_infer_status(void);

--- a/kernel/llm/gpt2_sample.c
+++ b/kernel/llm/gpt2_sample.c
@@ -1,0 +1,72 @@
+#include "gpt2_sample.h"
+
+#define GPT2_REPEAT_WINDOW 16U
+#define GPT2_REPEAT_PENALTY 8.0f
+#define GPT2_SAMPLE_TEMPERATURE 1.10f
+
+static float gpt2_fast_exp(float value) {
+    union { float f; uint32_t u; } convert;
+    if (value < -80.0f) return 0.0f;
+    if (value > 80.0f) value = 80.0f;
+    convert.u = (uint32_t)(12102203.0f * value + 1064866805.0f);
+    return convert.f;
+}
+
+uint32_t gpt2_sample_top_k(const float* logits, uint32_t vocab, const uint32_t* history,
+                           uint32_t history_count, uint32_t* rng_state) {
+    uint32_t ids[GPT2_SAMPLE_TOP_K];
+    float values[GPT2_SAMPLE_TOP_K];
+    float weights[GPT2_SAMPLE_TOP_K];
+    uint32_t count = 0;
+    uint32_t state = rng_state && *rng_state ? *rng_state : 0x9e3779b9U;
+    uint32_t banned = (history && history_count > 0U) ? history[history_count - 1U] : 0xFFFFFFFFu;
+
+    if (!logits || vocab == 0U) return 0U;
+
+    for (uint32_t i = 0; i < vocab; i++) {
+        float value;
+        uint32_t begin;
+        uint32_t repeats = 0;
+        uint32_t pos;
+
+        if (i == banned) continue;
+        value = logits[i];
+        begin = history_count > GPT2_REPEAT_WINDOW ? history_count - GPT2_REPEAT_WINDOW : 0U;
+        if (history) {
+            for (uint32_t j = begin; j < history_count; j++) {
+                if (history[j] == i) repeats++;
+            }
+        }
+        if (repeats > 0U) value -= GPT2_REPEAT_PENALTY * (float)repeats;
+        pos = count < GPT2_SAMPLE_TOP_K ? count++ : GPT2_SAMPLE_TOP_K;
+        while (pos > 0U && value > values[pos - 1U]) {
+            if (pos < GPT2_SAMPLE_TOP_K) {
+                values[pos] = values[pos - 1U];
+                ids[pos] = ids[pos - 1U];
+            }
+            pos--;
+        }
+        if (pos < GPT2_SAMPLE_TOP_K) {
+            values[pos] = value;
+            ids[pos] = i;
+        }
+    }
+    if (count == 0U) return banned == 0xFFFFFFFFu ? 0U : banned;
+
+    {
+        float total = 0.0f;
+        float target;
+        for (uint32_t i = 0; i < count; i++) {
+            weights[i] = gpt2_fast_exp((values[i] - values[0]) / GPT2_SAMPLE_TEMPERATURE);
+            total += weights[i];
+        }
+        state = state * 1664525U + 1013904223U;
+        if (rng_state) *rng_state = state;
+        target = ((float)(state & 0x00ffffffU) / 16777216.0f) * total;
+        for (uint32_t i = 0; i < count; i++) {
+            if (target <= weights[i]) return ids[i];
+            target -= weights[i];
+        }
+        return ids[count - 1U];
+    }
+}

--- a/kernel/llm/gpt2_sample.h
+++ b/kernel/llm/gpt2_sample.h
@@ -1,0 +1,16 @@
+#ifndef AIOS_GPT2_SAMPLE_H
+#define AIOS_GPT2_SAMPLE_H
+
+#include <stdint.h>
+
+#define GPT2_SAMPLE_TOP_K 8U
+
+/*
+ * Top-k sampling with a temperature of 1.10, a frequency penalty on the last
+ * 16 history tokens, and a hard ban of the immediately previous token.
+ * The ban stops greedy-like loops such as GPT-2 token 262 (" The").
+ */
+uint32_t gpt2_sample_top_k(const float* logits, uint32_t vocab, const uint32_t* history,
+                           uint32_t history_count, uint32_t* rng_state);
+
+#endif

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -13,7 +13,7 @@
 #include "../llm/gpt2_infer.h"
 #include "../llm/gpt2_model.h"
 #include "../llm/gpt2_tokenizer.h"
-/* Completions locales : BPE en entree, greedy, arret newline/EOT, 12 jetons max. */
+/* Completions locales : BPE en entree, top-k, arret newline/EOT/repetition, 12 jetons max. */
 #define GPT2_BAREMETAL_GENERATION_STEPS 12U
 
 // Externs VMM
@@ -180,6 +180,8 @@ int sys_gpt2_generate(const char* prompt, char* out, uint32_t max) {
     uint32_t tokens[64];
     uint32_t token_count = 0;
     uint32_t written = 0;
+    uint32_t rng_state;
+    uint32_t prev_generated = 0xFFFFFFFFu;
     const gpt2_model_t* model;
     int rc;
 
@@ -201,13 +203,21 @@ int sys_gpt2_generate(const char* prompt, char* out, uint32_t max) {
     model = gpt2_model_current();
     if (!model->ready || token_count > model->config.max_seq_len) return -5;
 
+    rng_state = timer_get_ticks() + 1U;
+    for (uint32_t i = 0; prompt_copy[i] != '\0'; i++) {
+        rng_state = rng_state * 16777619U + (uint8_t)prompt_copy[i];
+    }
+    if (rng_state == 0U) rng_state = 0x9e3779b9U;
+
     for (uint32_t step = 0; step < GPT2_BAREMETAL_GENERATION_STEPS && token_count < 64 && token_count < model->config.max_seq_len; step++) {
         uint32_t next_token = 0;
         const char* piece;
         int saw_newline = 0;
-        rc = gpt2_generate_next(tokens, token_count, &next_token);
+        rc = gpt2_generate_next_sampled(tokens, token_count, &next_token, &rng_state);
         if (rc != 0) return -30 + rc;
         if (next_token == gpt2_tokenizer_eot()) break;
+        if (next_token == prev_generated) break;
+        prev_generated = next_token;
         tokens[token_count++] = next_token;
         piece = gpt2_tokenizer_decode(next_token);
         if (!piece) return -4;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -87,6 +87,11 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_tokenizer: $(UNIT_DIR)/kernel/test_tokenize
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_tokenizer.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_sample: $(UNIT_DIR)/kernel/test_gpt2_sample.c ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_%: $(UNIT_DIR)/kernel/test_%.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -102,6 +102,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_tokenizer.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_tokenizer.c"
     fi
+    if [ "$(basename "$test_file")" = "test_gpt2_sample.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_sample.c"
+    fi
     
     # Compiler
     echo "gcc $cflags -o \"$test_binary\" \"$test_file\" $extra_src \"$TEST_DIR/framework/unity.c\" \"$TEST_DIR/framework/test_kernel.c\" \"$TEST_DIR/framework/kernel_mocks.c\"" >> "$RESULTS_FILE"

--- a/tests/unit/kernel/test_gpt2_sample.c
+++ b/tests/unit/kernel/test_gpt2_sample.c
@@ -1,0 +1,91 @@
+/* test_gpt2_sample.c - top-k sampling without a 124M checkpoint */
+
+#include "../../framework/unity.h"
+#include "../../../kernel/llm/gpt2_sample.h"
+
+#define SAMPLE_VOCAB 16U
+
+static void fill_the_loop_logits(float* logits) {
+    uint32_t i;
+    for (i = 0; i < SAMPLE_VOCAB; i++) logits[i] = 0.0f;
+    /* Token 3 stands in for GPT-2 262 (" The"): far above the rest. */
+    logits[3] = 20.0f;
+    logits[5] = 12.0f;
+    logits[7] = 11.0f;
+}
+
+static void test_sample_bans_previous_the_token(void) {
+    float logits[SAMPLE_VOCAB];
+    uint32_t history[4];
+    uint32_t rng = 1U;
+    uint32_t picked;
+    uint32_t i;
+
+    fill_the_loop_logits(logits);
+    history[0] = 1;
+    history[1] = 2;
+    history[2] = 3;
+    picked = gpt2_sample_top_k(logits, SAMPLE_VOCAB, history, 3, &rng);
+    TEST_ASSERT_NOT_EQUAL(3, (int)picked);
+    TEST_ASSERT_TRUE(picked < SAMPLE_VOCAB);
+    for (i = 0; i < 12U; i++) {
+        rng = i + 1U;
+        picked = gpt2_sample_top_k(logits, SAMPLE_VOCAB, history, 3, &rng);
+        TEST_ASSERT_NOT_EQUAL(3, (int)picked);
+    }
+}
+
+static void test_sample_picks_peak_without_history(void) {
+    float logits[SAMPLE_VOCAB];
+    uint32_t rng = 1U;
+    uint32_t picked;
+
+    fill_the_loop_logits(logits);
+    picked = gpt2_sample_top_k(logits, SAMPLE_VOCAB, 0, 0, &rng);
+    TEST_ASSERT_EQUAL(3, (int)picked);
+}
+
+static void test_sample_penalizes_repeated_history(void) {
+    float logits[SAMPLE_VOCAB];
+    uint32_t history[5];
+    uint32_t rng = 1U;
+    uint32_t picked;
+
+    fill_the_loop_logits(logits);
+    history[0] = 3;
+    history[1] = 3;
+    history[2] = 3;
+    history[3] = 3;
+    history[4] = 7;
+    picked = gpt2_sample_top_k(logits, SAMPLE_VOCAB, history, 5, &rng);
+    TEST_ASSERT_NOT_EQUAL(3, (int)picked);
+    TEST_ASSERT_NOT_EQUAL(7, (int)picked);
+    TEST_ASSERT_EQUAL(5, (int)picked);
+}
+
+static void test_sample_same_seed_is_deterministic(void) {
+    float logits[SAMPLE_VOCAB];
+    uint32_t history[1];
+    uint32_t rng_a = 42U;
+    uint32_t rng_b = 42U;
+    uint32_t first;
+    uint32_t second;
+
+    fill_the_loop_logits(logits);
+    history[0] = 3;
+    first = gpt2_sample_top_k(logits, SAMPLE_VOCAB, history, 1, &rng_a);
+    second = gpt2_sample_top_k(logits, SAMPLE_VOCAB, history, 1, &rng_b);
+    TEST_ASSERT_EQUAL((int)first, (int)second);
+    TEST_ASSERT_NOT_EQUAL(3, (int)first);
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_sample_bans_previous_the_token);
+    RUN_TEST(test_sample_picks_peak_without_history);
+    RUN_TEST(test_sample_penalizes_repeated_history);
+    RUN_TEST(test_sample_same_seed_is_deterministic);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GPT-2 local generation used greedy argmax. On the 124M checkpoint that latches onto token 262 (` The`) and prints `The The The The...` for every `ai` prompt.

`SYS_GPT2_GENERATE` now uses the existing top-k sampler, with a hard ban of the previous token, a stronger frequency penalty, and an RNG seed mixed from PIT ticks and the prompt. Consecutive repeats also stop the loop.

Sampling is extracted to `kernel/llm/gpt2_sample.c` so unit tests can cover the anti-loop behavior without the 124M weights.

Unity total: 144 (adds `test_gpt2_sample` 4).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

