### PR TITLE
Aligner les user stories sur le prototype i386

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,26 +119,29 @@ ai-os/
 ├── tests/                # Unity + scripts QEMU
 ├── scripts/              # bootstrap-dev.sh
 ├── docs/
+├── US/                   # AOS-* (prototype) + archives MOHHOS
 ├── .cursor/environment.json
 └── .github/workflows/ci.yml
 ```
 
 ## Roadmap (extrait)
 
-Le dossier [`US/`](US/README.md) décrit la vision MOHHOS (spécifications, pas l'état du dépôt).
+Backlog du prototype : [`US/ai_os_us.md`](US/ai_os_us.md). Vision MOHHOS (hors code) : [`US/README.md`](US/README.md).
 
-- [x] Inférence GPT-2 locale + cache KV / SSE2
+- [x] Inférence GPT-2 locale + cache KV / SSE2 (top-k borné, pénalité sur jetons émis)
 - [x] Tokenizer BPE GPT-2 (entree et sortie)
 - [x] Overlay persisté (snapshot ATA PIO sur disque IDE QEMU)
 - [x] `spawn` / `yield` coopératifs (l'enfant tourne vraiment)
 - [x] `exec` bloquant coopératif (parent TASK_WAITING, enfant SYS_EXIT)
 - [ ] Quantification, chargeur GGUF, latence &lt; 1 s
+- [ ] BPE unicode `\p{L}` ; tests d'intégration non vides
 - [ ] Réseau, DNS, TLS, fournisseur OpenAI effectif
 - [ ] Système de fichiers disque général (ext2/FAT)
 
 ## Documentation
 
 - [docs/ETAT_REEL.md](docs/ETAT_REEL.md) - ce qui tourne vraiment
+- [US/ai_os_us.md](US/ai_os_us.md) - user stories du prototype
 - [docs/README.md](docs/README.md) - index (actuel vs historique)
 - [docs/GUIDE_EXECUTION.md](docs/GUIDE_EXECUTION.md) - modes QEMU
 - [docs/gpt2_baremetal_deployment.md](docs/gpt2_baremetal_deployment.md) - ISO autonome avec modèle
@@ -155,4 +158,4 @@ Code commenté en français. Une PR = une tranche visible par la CI (`make ci`),
 
 **Dépôt :** [github.com/kamgueblondin/ai-os](https://github.com/kamgueblondin/ai-os)
 
-*Prototype i386 + shell userspace + GPT-2 local optionnel sous QEMU. Dernière mise à jour documentation : 2026-08-13, overlay persisté sur IDE.*
+*Prototype i386 + shell userspace + GPT-2 local optionnel sous QEMU. Dernière mise à jour documentation : 2026-08-13.*

--- a/US/README.md
+++ b/US/README.md
@@ -1,142 +1,57 @@
-# MOHHOS - Dossier User Stories (US)
+# User Stories — AI-OS et vision MOHHOS
 
-> **État réel (août 2026).** Ce dossier est un **plan / spécification**. Aucune des 8 phases MOHHOS n’est livrée dans le noyau actuel (toujours un kernel monolithique pédagogique + simulateur `fake_ai`). Les fichiers US restent la référence de conception. Implémenté aujourd’hui : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+Deux couches distinctes. Ne pas les mélanger.
 
-## Vue d'Ensemble
+| Couche | Document | Statut |
+|---|---|---|
+| **Prototype qui tourne** | [ai_os_us.md](ai_os_us.md) + [docs/ETAT_REEL.md](../docs/ETAT_REEL.md) | Fait / suite proche |
+| **Vision MOHHOS** | fichiers `mohhos_*.md` + [individual_us/](individual_us/INDEX.md) | Spécifications uniquement |
 
-Ce dossier contient l'ensemble des User Stories (US) et spécifications techniques pour transformer AI-OS v5.0 en **MOHHOS** (Manus Operating Hybrid Hosted OS), un système d'exploitation révolutionnaire basé sur l'intelligence artificielle.
+En cas de contradiction, **ETAT_REEL** et **ai_os_us.md** priment.
 
-## Vision MOHHOS
+## Couche 1 — AI-OS (à utiliser)
 
-MOHHOS sera le premier système d'exploitation où l'IA constitue le cœur du système, capable de :
-- Comprendre les instructions utilisateur en langage naturel
-- Apprendre et s'adapter aux habitudes d'utilisation
-- Fonctionner sur toutes les plateformes (desktop, mobile, etc.)
-- Utiliser un navigateur amélioré comme système de fichiers
-- Créer un réseau distribué P2P pour partager les ressources
-- Implémenter une économie collaborative avec système de points
+Hobby OS i386 32-bit : boot QEMU, shell Ring 3, overlay persisté, `spawn`/`yield`/`exec` coopératifs, GPT-2 124M optionnel.
 
-## Structure du Dossier
+- Backlog réel : [ai_os_us.md](ai_os_us.md) (`AOS-001` … `AOS-012` faits, `AOS-020` … `AOS-025` suite)
+- Runtime : [docs/ETAT_REEL.md](../docs/ETAT_REEL.md)
+- Roadmap courte : [README.md](../README.md)
 
-### Documents Principaux
+Ce n'est **pas** TensorFlow Lite, pas un microkernel, pas `fake_ai` comme moteur principal (`fake_ai` est un binaire historique ; `ai <texte>` appelle `SYS_GPT2_GENERATE`).
 
-#### 1. `mohhos_user_stories_master.md`
-**Document maître** contenant :
-- Vue d'ensemble complète du projet MOHHOS
-- Index de toutes les 120 User Stories organisées en 8 phases
-- Estimation globale des ressources et du planning
-- Méthodologie de développement
+## Couche 2 — MOHHOS (archives de conception)
 
-#### 2. `recherche_technologies_mohhos.md`
-**Recherche technologique approfondie** couvrant :
-- État de l'art des OS basés sur l'IA
-- Technologies de systèmes distribués P2P
-- Navigateurs comme systèmes d'exploitation
-- IA locale et apprentissage fédéré
-- Architectures hybrides cloud-edge
+Plan historique pour transformer AI-OS v5 en « Manus Operating Hybrid Hosted OS » (8 phases, 120 US, ~1640 j-h). **Aucune phase n'est livrée** dans le noyau.
 
-#### 3. `mohhos_us_phase1_foundation.md`
-**Phase 1 - Foundation** (US-001 à US-015) :
-- Migration vers architecture microkernel
-- Gestionnaire de ressources intelligent
-- Système de sécurité adaptatif
-- Framework de plugins modulaires
-- Système de logging distribué
+Quelques fichiers MOHHOS **chevauchent** le prototype (mémoire, tests, moteur IA local, assistant). Le recouvrement est accidentel et partiel : voir le tableau dans [individual_us/INDEX.md](individual_us/INDEX.md). Un ✅ dans l'index MOHHOS signifie « fichier de spec présent », **pas** « implémenté ».
 
-#### 4. `mohhos_us_phase2_ai_core.md`
-**Phase 2 - AI Core** (US-016 à US-030) :
-- Intégration moteur IA local TensorFlow Lite
-- Système de compréhension du langage naturel
-- Gestionnaire de modèles IA distribués
-- Implémentation de l'apprentissage fédéré
-- Orchestrateur cloud-edge intelligent
+### Fichiers MOHHOS
 
-## Phases de Développement
+| Fichier | Contenu |
+|---|---|
+| [mohhos_user_stories_master.md](mohhos_user_stories_master.md) | Index historique des 120 titres (numérotation parfois **différente** des fichiers) |
+| [recherche_technologies_mohhos.md](recherche_technologies_mohhos.md) | Veille (P2P, federated learning, navigateur-OS) |
+| [mohhos_us_phase1_foundation.md](mohhos_us_phase1_foundation.md) | Phase 1 détaillée (microkernel) — non commencée dans le code |
+| [mohhos_us_phase2_ai_core.md](mohhos_us_phase2_ai_core.md) | Phase 2 (TensorFlow Lite, NLU, fédéré) — non livrée ; l'IA réelle est GPT-2 freestanding |
+| [mohhos_us_phase3_web_runtime.md](mohhos_us_phase3_web_runtime.md) | Phase 3 navigateur-OS — absente |
+| [mohhos_us_phases_4_8_synthese.md](mohhos_us_phases_4_8_synthese.md) | Phases 4-8 (PromptMessage, P2P, etc.) — absentes |
+| [individual_us/](individual_us/INDEX.md) | ~78 fichiers de spec ; IDs **023/024/025 dupliqués** ; pas 120 fichiers |
 
-### 🏗️ Phase 1 - Foundation (180 jours-homme)
-Modernisation de l'architecture AI-OS existante vers un microkernel modulaire et sécurisé.
+### Phases MOHHOS (rappel)
 
-### 🧠 Phase 2 - AI Core (240 jours-homme)
-Intégration de l'intelligence artificielle au cœur du système d'exploitation.
+1. Foundation — microkernel, plugins, logging distribué  
+2. AI Core — TFLite, NLU, apprentissage fédéré, cloud-edge  
+3. Web Runtime — navigateur comme FS  
+4. PromptMessage — langage universel  
+5. P2P Network  
+6. Multi-platform  
+7. Collaborative (points)  
+8. Production  
 
-### 🌐 Phase 3 - Web Runtime (200 jours-homme)
-Développement du navigateur-OS et du système de fichiers web.
-
-### 💬 Phase 4 - PromptMessage (220 jours-homme)
-Création du langage universel PromptMessage pour programmer et communiquer.
-
-### 🔗 Phase 5 - P2P Network (260 jours-homme)
-Implémentation du réseau distribué P2P pour l'interconnexion des instances.
-
-### 📱 Phase 6 - Multi-Platform (180 jours-homme)
-Adaptation du système pour fonctionner sur toutes les plateformes.
-
-### 🤝 Phase 7 - Collaborative (200 jours-homme)
-Système de points et économie collaborative pour partager les ressources.
-
-### 🚀 Phase 8 - Production (160 jours-homme)
-Optimisation, monitoring et déploiement en production.
-
-## Utilisation des Documents
-
-### Pour les Développeurs
-1. Commencer par lire le **document maître** pour comprendre la vision globale
-2. Étudier la **recherche technologique** pour comprendre les choix techniques
-3. Implémenter les US **phase par phase** en suivant les spécifications détaillées
-4. Respecter les dépendances entre US indiquées dans chaque document
-
-### Pour les Chefs de Projet
-1. Utiliser les **estimations** pour planifier les ressources et le budget
-2. Suivre les **critères d'acceptation** pour valider les livraisons
-3. Monitorer les **risques** identifiés dans chaque US
-4. Adapter le planning selon les **dépendances** entre phases
-
-### Pour les Architectes
-1. Analyser les **spécifications techniques** détaillées
-2. Valider la cohérence des **APIs** proposées
-3. Adapter l'**architecture** selon les contraintes spécifiques
-4. Contribuer aux **choix technologiques** basés sur la recherche
-
-## Métriques de Succès Global
-
-### Performance
-- **Amélioration globale** : +20% par rapport à AI-OS v5.0
-- **Temps de réponse IA** : < 100ms pour les requêtes standard
-- **Consommation mémoire** : Optimisée pour fonctionner sur 4GB RAM minimum
-
-### Intelligence
-- **Compréhension NLU** : 90% de précision sur les intentions utilisateur
-- **Apprentissage fédéré** : Amélioration de 5% des modèles collectifs
-- **Adaptation automatique** : Personnalisation effective après 7 jours d'usage
-
-### Écosystème
-- **Support multi-plateforme** : Desktop, mobile, IoT
-- **Réseau P2P** : Support de 1000+ nœuds simultanés
-- **Économie collaborative** : Système de points opérationnel
-
-## Prochaines Étapes
-
-1. **Validation du Plan** : Révision et approbation par l'équipe technique
-2. **Constitution de l'Équipe** : Recrutement des 25-30 experts nécessaires
-3. **Setup Infrastructure** : Environnement de développement et CI/CD
-4. **Démarrage Phase 1** : Lancement des premiers sprints Foundation
-5. **Itération Agile** : Développement avec feedback continu
+Ne pas planifier un sprint « US-001 microkernel » comme suite d'AI-OS. La suite proche est dans [ai_os_us.md](ai_os_us.md) (GGUF, BPE unicode, FS disque, tests d'intégration).
 
 ## Contribution
 
-Pour contribuer au développement MOHHOS :
-1. Lire attentivement les spécifications de la phase concernée
-2. Respecter les APIs et architectures définies
-3. Implémenter les tests d'acceptation spécifiés
-4. Documenter toute modification ou extension
-5. Participer aux revues de code et validations techniques
-
-## Contact et Support
-
-Ce projet représente une vision ambitieuse de l'avenir des systèmes d'exploitation. Pour toute question ou contribution, référez-vous aux spécifications détaillées dans chaque document de phase.
-
----
-
-**MOHHOS v1.0** - *Le futur des systèmes d'exploitation intelligents*  
-*Développé avec ❤️ pour révolutionner l'interaction homme-machine* 🤖
-
+1. Une PR = une tranche visible par `make ci` (code) **ou** un alignement doc (ce dossier).  
+2. Nouvelles user stories du prototype : les ajouter dans `ai_os_us.md` (préfixe `AOS-`), pas en renumérotant MOHHOS.  
+3. Les specs MOHHOS peuvent rester ; mettre à jour seulement la bannière « état réel » si le recouvrement change.

--- a/US/ai_os_us.md
+++ b/US/ai_os_us.md
@@ -1,0 +1,88 @@
+# User Stories AI-OS (implémentation actuelle)
+
+**Date :** 13 août 2026  
+**Source de vérité runtime :** [docs/ETAT_REEL.md](../docs/ETAT_REEL.md)  
+**Rôle :** backlog du **prototype i386** qui tourne sous QEMU. Ce n'est pas le plan MOHHOS (120 US, 8 phases).
+
+Légende : **fait** = observable dans le code et vérifié par `make test-all` / `make qemu-smoke` (GPT-2 : aussi `make gpt2-recovery` si les poids sont présents). **suite** = prochaine tranche cohérente, pas une vision à 6 ans.
+
+---
+
+## Fait (noyau et shell)
+
+### AOS-001 — Boot Multiboot sous QEMU
+**En tant que** développeur, **je veux** un binaire Multiboot i386 qui démarre dans QEMU, **afin de** travailler sur un hobby OS réel.
+
+Fait : `boot/boot.s`, VGA + série, `make run` / `make run-gui`. Pas d'UEFI.
+
+### AOS-002 — Mémoire physique, virtuelle et tas
+**En tant que** noyau, **je veux** allouer des pages et un tas, **afin d'** héberger tâches, initrd et (optionnellement) GPT-2.
+
+Fait : PMM / VMM / heap, paging. `SYS_MEMINFO` (`mem`). Pas de prédiction IA des ressources (US-002 MOHHOS).
+
+### AOS-003 — Interruptions, timer et clavier
+**En tant que** utilisateur du shell, **je veux** taper des commandes au clavier PS/2, **afin d'** interagir avec le système.
+
+Fait : PIC 8259, PIT 100 Hz, i8042, EOI IRQ0 **avant** `schedule()` (sinon IRQ1 bloquée). Le round-robin à chaque tick est **volontairement off** après le premier saut vers le shell.
+
+### AOS-004 — Initrd TAR en lecture seule
+**En tant que** shell, **je veux** lister et lire des fichiers empaquetés, **afin d'** avoir un disque racine au boot.
+
+Fait : TAR POSIX, `SYS_LISTDIR` / `SYS_READFILE`. Programmes : `shell`, `idle`, `ok`, `fake_ai`, `ai_assistant`, `user_program`.
+
+### AOS-005 — Shell ELF en Ring 3
+**En tant que** utilisateur, **je veux** un prompt interactif isolé du noyau, **afin de** lancer des commandes sans rester dans une boucle kernel.
+
+Fait : `userspace/shell.c`, prompt `/ (-.-) :`, `jump_to_task()`. Builtins : voir le tableau dans ETAT_REEL.
+
+### AOS-006 — ABI de syscalls
+**En tant que** programme userspace, **je veux** un ensemble d'appels `int 0x80` documenté, **afin de** parler au noyau sans bidouiller.
+
+Fait : `include/os_syscalls.h`, numéros 0-22 (`MAX_SYSCALLS` = 23), dont overlay, tâches et `SYS_GPT2_GENERATE`.
+
+### AOS-007 — Overlay RAM persisté
+**En tant que** utilisateur, **je veux** créer et modifier de petits fichiers qui survivent à un reboot QEMU, **afin de** ne pas tout perdre à chaque `make run`.
+
+Fait : 32 nœuds, fichiers ≤ 256 octets, snapshot ATA PIO LBA28 (`AIOV`) sur le maître IDE. Pas d'ext2/FAT.
+
+### AOS-008 — Tâches coopératives
+**En tant que** utilisateur, **je veux** `spawn` / `yield` / `ps` / `kill`, **afin de** voir une deuxième tâche tourner sans casser le clavier.
+
+Fait : bascule depuis le cadre user de `int 0x80`. `idle` affiche `idle ok` puis yield. Pas de préemption IRQ0 continue.
+
+### AOS-009 — Exec bloquant
+**En tant que** shell, **je veux** lancer un ELF et attendre sa fin, **afin de** récupérer un code de retour.
+
+Fait : parent `TASK_WAITING`, enfant `SYS_EXIT` réveille le waiter. `ok` → `exec ok` → `rc ok 0`.
+
+### AOS-010 — Inférence GPT-2 locale
+**En tant que** utilisateur, **je veux** `ai <texte>` hors ligne, **afin d'** obtenir une complétion courte sans réseau.
+
+Fait si `models/gpt2_124M.bin` + `gpt2_tokenizer.bin` sont dans l'initrd : `SYS_GPT2_GENERATE`, cache KV, SSE2, top-k (k=8, température 0,6), pénalité **uniquement sur les jetons déjà émis**. 64 jetons de prompt, 12 de sortie. Pas TensorFlow Lite, pas GGUF, pas OpenAI effectif. Sans poids : message d'indisponibilité (le shell reste utilisable).
+
+### AOS-011 — Tokenizer BPE
+**En tant que** moteur GPT-2, **je veux** encoder le prompt et décoder les jetons en octets tiktoken, **afin que** la sortie ne soit pas une suite d'espaces artificiels.
+
+Fait : fusions par plus petit id vocabulaire, decode brut (espace, UTF-8). Regex unicode `\p{L}` complet : non.
+
+### AOS-012 — Tests et CI
+**En tant que** contributeur, **je veux** un gate reproductible, **afin de** ne pas casser le shell à chaque PR.
+
+Fait : Unity **144** (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_gpt2_sample` 4, `test_shell` 25, `test_ramfs` 10). `make qemu-smoke` : cinq boots. GitHub Actions = `make ci`. Dossiers `tests/integration`, `system`, `performance`, `robustness` : **vides**.
+
+---
+
+## Suite cohérente (prochaines tranches)
+
+Ordre volontaire : rester sur i386 / QEMU / Ring 3. Ne pas commencer un microkernel, du P2P ou PromptMessage tant que le prototype n'a pas ces briques.
+
+| ID | User story | Pourquoi maintenant |
+|---|---|---|
+| AOS-020 | Quantification / GGUF / latence &lt; 1 s sous QEMU | GPT-2 marche, ~7,7 s pour 4 jetons |
+| AOS-021 | BPE `\p{L}` (unicode lettres) | L'encodeur ASCII+UTF-8 chunké limite les prompts |
+| AOS-022 | Tests d'intégration non vides (scripts QEMU déjà là) | Unity ne couvre pas `ai` sans poids |
+| AOS-023 | FS disque général (ext2 ou FAT) au-delà du snapshot 32 nœuds | L'overlay ATA est un cache, pas un FS |
+| AOS-024 | Préemption round-robin IRQ0 **sans** tuer IRQ1 | Coopératif seulement, par stabilité clavier |
+| AOS-025 | Pile réseau minimale (ou stub OpenAI documenté comme absent) | `ai-provider openai` est un profil vide |
+
+Hors suite proche (vision MOHHOS, pas le backlog courant) : microkernel, apprentissage fédéré, navigateur-OS, PromptMessage, P2P, multi-plateforme, économie de points. Voir [README.md](README.md) et [individual_us/INDEX.md](individual_us/INDEX.md).

--- a/US/individual_us/INDEX.md
+++ b/US/individual_us/INDEX.md
@@ -1,306 +1,127 @@
-# Index des User Stories MOHHOS - Fichiers Détaillés
+# Index MOHHOS — fichiers de spécification
 
 > **Légende (août 2026)**  
-> - ✅ dans cet index = **spécification rédigée** (fichier présent), **pas** « implémenté dans le noyau ».  
-> - Dans le code AI-OS actuel : **aucune US MOHHOS n’est livrée** en tant que telle. Recouvrement partiel non revendiqué : PMM/VMM (voisinage US-002), tests unitaires Unity (voisinage US-008), isolation Ring 0/3.  
-> - État du dépôt : [../../docs/ETAT_REEL.md](../../docs/ETAT_REEL.md).
+> - **Spec** = fichier rédigé, **pas** livré dans le noyau.  
+> - **Chevauchement** = le prototype AI-OS a un voisinage technique (souvent une fraction du besoin).  
+> - Backlog du code réel : [../ai_os_us.md](../ai_os_us.md). Runtime : [../../docs/ETAT_REEL.md](../../docs/ETAT_REEL.md).
 
-## Vue d'Ensemble
+Les titres du [document maître](../mohhos_user_stories_master.md) **ne correspondent pas toujours** aux noms de fichiers ci-dessous (ex. maître US-008 = « mise à jour automatique », fichier = tests automatisés). **Le fichier individuel fait foi** pour le texte de la spec. Les IDs **US-023, US-024 et US-025 existent en double**.
 
-Ce dossier contient les spécifications détaillées de chaque User Story du projet MOHHOS. Chaque fichier fournit une analyse technique approfondie, des spécifications complètes, et des critères d'acceptation précis pour guider l'implémentation.
+Il n'y a **pas** 120 fichiers : environ 78 specs détaillées + des phases décrites seulement dans les documents `mohhos_*.md`.
 
-## Structure des Fichiers US
+## Chevauchement avec AI-OS
 
-Chaque fichier User Story suit une structure standardisée :
+| US fichier | Spec MOHHOS | Dans le prototype |
+|---|---|---|
+| US-001 | Microkernel + IPC | Non. Noyau monolithique `kernel/kernel.c` |
+| US-002 | Gestionnaire de ressources IA | PMM / VMM / heap / `SYS_MEMINFO` seulement |
+| US-003 | Sécurité adaptative IA | Isolation Ring 0/3, pas de détection de menaces |
+| US-007 | Monitoring temps réel | `ps` / `mem` / `uptime` / `SYS_TICKS`, pas de télémétrie |
+| US-008 | Framework de tests IA | Unity 144 + `make qemu-smoke` + GitHub Actions ; dossiers integration/system/performance/robustness vides |
+| US-010 | Pilotes modulaires | PIC, PIT, PS/2, ATA PIO ; pas de framework de drivers |
+| US-012 | APIs unifiées | `include/os_syscalls.h` (23 syscalls) |
+| US-016 | Moteur TensorFlow Lite | GPT-2 124M freestanding (`SYS_GPT2_GENERATE`), pas TFLite |
+| US-017 | NLU 90 % d'intentions | BPE + complétion 12 jetons, pas d'analyse d'intention |
+| US-021 | Assistant IA proactif | Builtin `ai <texte>` synchrone et borné |
+| US-066 | Gestion mémoire avancée | Même voisinage que US-002 (PMM/VMM) |
+| Autres | — | **Spec uniquement** |
 
-### 📋 **Informations Générales**
-- ID, Titre, Phase, Priorité
-- Complexité, Effort, Risque
+## Fichiers présents (`individual_us/`)
 
-### 👤 **Description Utilisateur**
-- Format "En tant que... Je veux... Afin de..."
-- Contexte métier et technique
+Chaque entrée : `US-XXX` + nom de fichier. Statut implicite **Spec**, sauf mention dans le tableau ci-dessus.
 
-### 🔧 **Spécifications Techniques**
-- Architecture détaillée
-- APIs et structures de données
-- Algorithmes et implémentations
+### Phase 1 — Foundation (fichiers)
 
-### ✅ **Critères d'Acceptation**
-- Critères fonctionnels
-- Critères de performance
-- Critères de qualité
+- US-001 `US-001_Architecture_Microkernel.md`
+- US-002 `US-002_Gestionnaire_Ressources_Intelligent.md` (chevauchement mémoire)
+- US-003 `US-003_Systeme_Securite_Adaptatif.md`
+- US-004 `US-004_Framework_Plugins_Modulaires.md`
+- US-005 `US-005_Systeme_Logging_Distribue.md`
+- US-006 `US-006_Gestionnaire_Configuration_Dynamique.md`
+- US-007 `US-007_Systeme_Monitoring_Temps_Reel.md` (chevauchement `ps`/`mem`/`uptime`)
+- US-008 `US-008_Framework_Tests_Automatises.md` (chevauchement Unity + CI)
+- US-009 `US-009_Systeme_Mise_A_Jour_Incrementale.md`
+- US-010 `US-010_Gestionnaire_Pilotes_Modulaires.md` (chevauchement pilotes QEMU)
+- US-011 `US-011_Systeme_Virtualisation_Leger.md`
+- US-012 `US-012_Framework_APIs_Unifiees.md` (chevauchement ABI syscalls)
+- US-013 `US-013_Communication_Inter_Services.md`
+- US-014 `US-014_Gestionnaire_Performance_Metriques.md`
+- US-015 `US-015_Framework_Deploiement_Orchestration.md`
 
-### 🧪 **Tests et Validation**
-- Tests d'acceptation
-- Métriques de succès
-- Benchmarks
+### Phase 2 — AI Core (fichiers)
 
-## User Stories Disponibles
+- US-016 `US-016_Moteur_IA_Local.md` (chevauchement GPT-2, **pas** TFLite)
+- US-017 `US-017_Systeme_Comprehension_Langage_Naturel.md`
+- US-018 `US-018_Gestionnaire_Modeles_IA_Distribues.md`
+- US-019 `US-019_Systeme_Apprentissage_Federe.md`
+- US-020 `US-020_Orchestrateur_Cloud_Edge.md`
+- US-021 `US-021_Assistant_IA_Integre.md` (chevauchement commande `ai`)
+- US-022 `US-022_Systeme_Personnalisation_IA.md`
+- US-023 **doublon** `US-023_Systeme_Apprentissage_Machine_Adaptatif.md` et `US-023_Moteur_Recommandations_Intelligent.md`
+- US-024 **doublon** `US-024_Systeme_Optimisation_Automatique.md` et `US-024_Framework_Integration_IA_Tiers.md`
+- US-025 **doublon** `US-025_Systeme_Prediction_Maintenance.md` et `US-025_Framework_Explicabilite_IA.md`
+- US-026 `US-026_Orchestrateur_Workflows_IA.md`
+- US-027 `US-027_Systeme_Analyse_Comportementale.md`
+- US-028 `US-028_Module_Intelligence_Conversationnelle.md`
+- US-029 `US-029_Framework_Optimisation_Automatique.md`
+- US-030 `US-030_Plateforme_IA_Ethique_Explicable.md`
 
-### 🏗️ Phase 1 - Foundation
+### Phases 3+ (fichiers, IDs ≠ découpage maître 031=navigateur)
 
-#### ✅ **US-001 : Architecture Microkernel**
-**Fichier** : `US-001_Architecture_Microkernel.md`  
-**Complexité** : Très Élevée | **Effort** : 25 j-h | **Risque** : Très Élevé
+Les numéros 031-075 des **fichiers** parlent surtout écosystème, sécurité et performance (marketplace, RGPD, zero-trust, etc.). Ce n'est **pas** la liste « navigateur-OS / PromptMessage / P2P » du document maître. Les phases 4-8 du maître (US-046 à US-120 : PromptMessage, P2P, mobile, points, production) n'ont **pas** de fichier individuel homonyme.
 
-Migration complète vers une architecture microkernel modulaire avec :
-- Gestionnaire IPC haute performance
-- Isolation complète des services
-- Sécurité renforcée par design
-- Support pour l'intégration IA
+- US-031 `US-031_Centre_Distribution_Applications.md`
+- US-032 `US-032_SDK_Developpeur_Multi_Plateforme.md`
+- US-033 `US-033_Marketplace_Ecosysteme_Communautaire.md`
+- US-034 `US-034_Connecteurs_Systemes_Entreprise.md`
+- US-035 `US-035_Plateforme_Integration_Cloud_Hybride.md`
+- US-036 `US-036_Systeme_Federation_Identites.md`
+- US-037 `US-037_Hub_Collaboration_Etendue.md`
+- US-038 `US-038_Passerelle_IoT_Edge_Computing.md`
+- US-039 `US-039_Ecosysteme_Plugins_Modulaires.md`
+- US-040 `US-040_Interface_Programmation_Universelle.md`
+- US-041 `US-041_Reseau_Partenaires_Certifies.md`
+- US-042 `US-042_Plateforme_Innovation_Ouverte.md`
+- US-043 `US-043_Systeme_Metriques_Analytics_Ecosysteme.md`
+- US-044 `US-044_Programme_Gouvernance_Ecosysteme.md`
+- US-045 `US-045_Initiatives_Durabilite_Impact_Social.md`
+- US-046 `US-046_Systeme_Securite_Multi_Couches.md`
+- US-047 `US-047_Gestion_Avancee_Identites_Acces.md`
+- US-048 `US-048_Conformite_RGPD_Protection_Donnees.md`
+- US-049 `US-049_Audit_Compliance_Automatiques.md`
+- US-050 `US-050_Systeme_Gestion_Incidents_Securite.md`
+- US-051 `US-051_Chiffrement_Avance_Gestion_Cles.md`
+- US-052 `US-052_Tests_Penetration_Vulnerabilites.md`
+- US-053 `US-053_Surveillance_Comportementale_Avancee.md`
+- US-054 `US-054_Backup_Disaster_Recovery_Securises.md`
+- US-055 `US-055_Securite_Chaines_Approvisionnement.md`
+- US-056 `US-056_Formation_Sensibilisation_Securite.md`
+- US-057 `US-057_Gestion_Menaces_Threat_Intelligence.md`
+- US-058 `US-058_Zero_Trust_Architecture.md`
+- US-059 `US-059_Securite_DevSecOps_Integree.md`
+- US-060 `US-060_Resilience_Continuite_Securite.md`
+- US-061 `US-061_Optimisation_Performance_Multi_Niveaux.md`
+- US-062 `US-062_Auto_Scaling_Intelligent_Adapte.md`
+- US-063 `US-063_Optimisation_Base_Donnees_Avancee.md`
+- US-064 `US-064_Gestionnaire_Charge_Avance.md`
+- US-065 `US-065_Optimisation_Reseau_Latence.md`
+- US-066 `US-066_Gestion_Memoire_Ressources.md` (chevauchement PMM/VMM)
+- US-067 `US-067_Systeme_Cache_Distribue_Intelligent.md`
+- US-068 `US-068_Optimisation_Algorithmes_Traitements.md`
+- US-069 `US-069_Monitoring_Performance_Temps_Reel.md`
+- US-070 `US-070_Optimisation_Stockage_IO.md`
+- US-071 `US-071_Test_Charge_Stress_Automatise.md`
+- US-072 `US-072_Optimisation_Energetique_Green_IT.md`
+- US-073 `US-073_Orchestration_Workload_Intelligente.md`
+- US-074 `US-074_Optimisation_Continue_Adaptee.md`
+- US-075 `US-075_Benchmark_Comparaison_Performance.md`
 
-**Technologies** : C, Assembleur x86, IPC, Microkernel  
-**Dépendances** : Aucune (fondamentale)
+Pas de fichiers `US-076` … `US-120`.
 
-#### ✅ **US-002 : Gestionnaire de Ressources Intelligent**
-**Fichier** : `US-002_Gestionnaire_Ressources_Intelligent.md`  
-**Complexité** : Élevée | **Effort** : 20 j-h | **Risque** : Moyen
+## Structure d'un fichier US
 
-Gestionnaire de ressources basé sur l'IA avec :
-- Prédiction des besoins en ressources
-- Optimisation automatique des allocations
-- Apprentissage des patterns d'usage
-- Efficacité énergétique intelligente
+Métadonnées (id, phase, effort) → « En tant que / Je veux / Afin de » → spec technique → critères d'acceptation → tests imaginés. Les critères (NLU 90 %, 1000 nœuds P2P, TFLite, etc.) **ne s'appliquent pas** au prototype.
 
-**Technologies** : IA/ML, Algorithmes d'optimisation, Gestion mémoire  
-**Dépendances** : US-001
+## Ancienne légende (obsolète)
 
-#### ✅ **US-003 : Système de Sécurité Adaptatif**
-**Fichier** : `US-003_Systeme_Securite_Adaptatif.md`  
-**Complexité** : Très Élevée | **Effort** : 22 j-h | **Risque** : Élevé
-
-Système de sécurité intelligent avec :
-- Détection de menaces basée sur l'IA
-- Réponse automatique aux attaques
-- Apprentissage continu des nouvelles menaces
-- Forensique automatisée
-
-**Technologies** : Cybersécurité, IA/ML, Détection d'anomalies  
-**Dépendances** : US-001, US-002
-
-### 🧠 Phase 2 - AI Core
-
-#### ✅ **US-016 : Moteur IA Local TensorFlow Lite**
-**Fichier** : `US-016_Moteur_IA_Local.md`  
-**Complexité** : Très Élevée | **Effort** : 22 j-h | **Risque** : Élevé
-
-Intégration native de TensorFlow Lite avec :
-- Moteur d'inférence optimisé
-- Support des accélérateurs hardware
-- Cache intelligent des résultats
-- Sécurité et isolation des modèles
-
-**Technologies** : TensorFlow Lite, Optimisation hardware, Cache intelligent  
-**Dépendances** : US-001, US-002
-
-## User Stories à Développer
-
-### 🏗️ Phase 1 - Foundation (Restantes)
-
-#### ✅ **US-004 : Framework de plugins modulaires**
-**Fichier** : `US-004_Framework_Plugins_Modulaires.md`  
-**Complexité** : Élevée | **Effort** : 20 j-h | **Risque** : Moyen
-
-#### ✅ **US-005 : Système de logging distribué**
-**Fichier** : `US-005_Systeme_Logging_Distribue.md`  
-**Complexité** : Élevée | **Effort** : 18 j-h | **Risque** : Moyen
-
-#### ✅ **US-006 : Gestionnaire de configuration dynamique**
-**Fichier** : `US-006_Gestionnaire_Configuration_Dynamique.md`  
-**Complexité** : Moyenne | **Effort** : 15 j-h | **Risque** : Faible
-- **US-007** : Système de monitoring temps réel
-- **US-008** : Framework de tests automatisés
-- **US-009** : Système de mise à jour incrémentale
-- **US-010** : Gestionnaire de pilotes modulaires
-- **US-011** : Système de virtualisation léger
-- **US-012** : Framework d'APIs unifiées
-- **US-013** : Système de backup intelligent
-- **US-014** : Gestionnaire de performance adaptatif
-- **US-015** : Système de documentation automatique
-
-### 🧠 Phase 2 - AI Core (Restantes)
-
-- **US-017** : Système de compréhension du langage naturel
-- **US-018** : Gestionnaire de modèles IA distribués
-- **US-019** : Système d'apprentissage fédéré
-- **US-020** : Orchestrateur cloud-edge
-- **US-021** : Moteur de recommandations intelligent
-- **US-022** : Système de personnalisation adaptatif
-- **US-023** : Analyseur de sentiment en temps réel
-- **US-024** : Générateur de contenu automatique
-- **US-025** : Système de traduction universelle
-- **US-026** : Reconnaissance vocale avancée
-- **US-027** : Synthèse vocale naturelle
-- **US-028** : Vision par ordinateur intégrée
-- **US-029** : Prédicteur de pannes intelligent
-- **US-030** : Optimiseur de workflow automatique
-
-### 🌐 Phase 3 - Web Runtime
-
-- **US-031** : Navigateur-OS intégré
-- **US-032** : Gestionnaire d'applications web natives
-- **US-033** : Système de fichiers web
-- **US-034** : Moteur de rendu optimisé
-- **US-035** : Support PWA avancé
-- **US-036** : Synchronisation cloud intelligente
-- **US-037** : Gestionnaire d'extensions web
-- **US-038** : Système de notifications unifiées
-- **US-039** : Intégration APIs web modernes
-- **US-040** : Optimiseur de performance web
-- **US-041** : Système de cache web intelligent
-- **US-042** : Gestionnaire de sessions web
-- **US-043** : Système de sécurité web avancé
-- **US-044** : Intégration WebAssembly
-- **US-045** : Système de développement web intégré
-
-### 💬 Phase 4 - PromptMessage
-
-- **US-046** : Conception du langage PromptMessage
-- **US-047** : Compilateur PromptMessage
-- **US-048** : Interpréteur PromptMessage
-- **US-049** : Débogueur PromptMessage
-- **US-050** : IDE PromptMessage intégré
-- **US-051** : Système de packages PromptMessage
-- **US-052** : Optimiseur de code PromptMessage
-- **US-053** : Système de versioning PromptMessage
-- **US-054** : Documentation automatique PromptMessage
-- **US-055** : Tests automatisés PromptMessage
-- **US-056** : Intégration IA PromptMessage
-- **US-057** : Marketplace PromptMessage
-- **US-058** : Système de collaboration PromptMessage
-- **US-059** : Analyseur de performance PromptMessage
-- **US-060** : Convertisseur de langages PromptMessage
-
-### 🔗 Phase 5 - P2P Network
-
-- **US-061** : Protocole P2P MOHHOS
-- **US-062** : Découverte de nœuds intelligente
-- **US-063** : Routage adaptatif
-- **US-064** : Consensus distribué
-- **US-065** : Réplication de données
-- **US-066** : Chiffrement P2P
-- **US-067** : Équilibrage de charge P2P
-- **US-068** : Tolérance aux pannes P2P
-- **US-069** : Monitoring réseau P2P
-- **US-070** : Cache distribué
-- **US-071** : Système de réputation P2P
-- **US-072** : Optimisation bande passante
-- **US-073** : Gestion de la latence P2P
-- **US-074** : Sécurité réseau P2P
-- **US-075** : Analytics réseau P2P
-
-### 📱 Phase 6 - Multi-Platform
-
-- **US-076** : Adaptation noyau ARM
-- **US-077** : Interface mobile native
-- **US-078** : Gestionnaire tactile avancé
-- **US-079** : Optimisation batterie mobile
-- **US-080** : Support IoT intégré
-- **US-081** : Adaptation écrans variables
-- **US-082** : Gestionnaire capteurs
-- **US-083** : Synchronisation multi-appareils
-- **US-084** : Continuité cross-platform
-- **US-085** : Optimisation performance mobile
-- **US-086** : Gestion connectivité adaptative
-- **US-087** : Interface TV/Console
-- **US-088** : Support réalité augmentée
-- **US-089** : Administration unifiée
-- **US-090** : Déploiement multi-platform
-
-### 🤝 Phase 7 - Collaborative
-
-- **US-091** : Système de points MOHHOS
-- **US-092** : Marketplace de ressources
-- **US-093** : Système de réputation
-- **US-094** : Partage de ressources P2P
-- **US-095** : Économie collaborative
-- **US-096** : Système de contrats intelligents
-- **US-097** : Gouvernance communautaire
-- **US-098** : Système de vote distribué
-- **US-099** : Audit transparent
-- **US-100** : Mécanismes d'incitation
-- **US-101** : Protection anti-fraude
-- **US-102** : Système de dispute
-- **US-103** : Confidentialité avancée
-- **US-104** : Analytics économiques
-- **US-105** : Intégration monétaire
-
-### 🚀 Phase 8 - Production
-
-- **US-106** : Optimisation performances globales
-- **US-107** : Système de monitoring production
-- **US-108** : Déploiement continu
-- **US-109** : Gestion des versions production
-- **US-110** : Système de rollback automatique
-- **US-111** : Analytics d'usage
-- **US-112** : Optimisation énergétique
-- **US-113** : Système d'alertes intelligent
-- **US-114** : Backup et recovery
-- **US-115** : Maintenance prédictive
-- **US-116** : Support utilisateur automatisé
-- **US-117** : Système de feedback
-- **US-118** : Optimisation continue
-- **US-119** : Certification et compliance
-- **US-120** : Roadmap évolutive
-
-## Guide d'Utilisation
-
-### Pour les Développeurs
-
-1. **Lecture Séquentielle** : Commencer par les US de la Phase 1
-2. **Respect des Dépendances** : Vérifier les prérequis avant implémentation
-3. **Tests d'Acceptation** : Implémenter tous les tests spécifiés
-4. **Documentation** : Maintenir la documentation à jour
-
-### Pour les Chefs de Projet
-
-1. **Planification** : Utiliser les estimations pour le planning
-2. **Suivi des Risques** : Monitorer les risques identifiés
-3. **Validation** : Vérifier les critères d'acceptation
-4. **Coordination** : Gérer les dépendances entre équipes
-
-### Pour les Architectes
-
-1. **Cohérence** : Vérifier la cohérence des APIs
-2. **Performance** : Valider les objectifs de performance
-3. **Sécurité** : Réviser les aspects sécurité
-4. **Évolutivité** : Assurer la compatibilité future
-
-## Conventions de Nommage
-
-### Fichiers
-- Format : `US-XXX_Titre_Sans_Espaces.md`
-- Numérotation : 001-120 selon l'ordre des phases
-- Titre : Descriptif et concis
-
-### Sections
-- **Informations Générales** : Métadonnées de l'US
-- **Description Utilisateur** : Besoin métier
-- **Contexte Technique** : Analyse technique
-- **Spécifications** : Détails d'implémentation
-- **Critères d'Acceptation** : Conditions de validation
-- **Tests** : Procédures de test
-- **Métriques** : Indicateurs de succès
-
-## Contribution
-
-Pour contribuer aux spécifications :
-
-1. **Format** : Respecter la structure standardisée
-2. **Détail** : Fournir des spécifications complètes
-3. **Cohérence** : Maintenir la cohérence avec l'architecture globale
-4. **Validation** : Faire réviser par l'équipe architecture
-
-## Statut des Fichiers
-
-- ✅ **Complété** : Spécifications détaillées disponibles
-- 🚧 **En Cours** : Développement en cours
-- 📋 **Planifié** : À développer selon la roadmap
-
----
-
-**Total** : 120 User Stories | **Complétées** : 4 | **Restantes** : 116  
-**Effort Total Estimé** : 1,640 jours-homme  
-**Durée Projet** : ~6.5 ans avec équipe de 10 développeurs
-
+« Complétées : 4 / Restantes : 116 » comptait mal les fichiers et prenait ✅ pour « implémenté ». Remplacé par le tableau de chevauchement et l'inventaire ci-dessus.

--- a/US/individual_us/US-001_Architecture_Microkernel.md
+++ b/US/individual_us/US-001_Architecture_Microkernel.md
@@ -1,5 +1,7 @@
 # US-001 : Migration vers Architecture Microkernel
 
+> **AI-OS :** spec uniquement. Le noyau est monolithique. Backlog réel : [../ai_os_us.md](../ai_os_us.md).
+
 ## Informations Générales
 
 **ID** : US-001  

--- a/US/individual_us/US-002_Gestionnaire_Ressources_Intelligent.md
+++ b/US/individual_us/US-002_Gestionnaire_Ressources_Intelligent.md
@@ -1,5 +1,7 @@
 # US-002 : Gestionnaire de Ressources Intelligent
 
+> **AI-OS :** chevauchement PMM / VMM / heap / `SYS_MEMINFO` seulement — pas de gestionnaire IA. Voir [../ai_os_us.md](../ai_os_us.md) AOS-002.
+
 ## Informations Générales
 
 **ID** : US-002  

--- a/US/individual_us/US-007_Systeme_Monitoring_Temps_Reel.md
+++ b/US/individual_us/US-007_Systeme_Monitoring_Temps_Reel.md
@@ -1,5 +1,7 @@
 # US-007 : Système de Monitoring Temps Réel
 
+> **AI-OS :** `ps` / `mem` / `uptime` / `SYS_TICKS` seulement. Voir [../ai_os_us.md](../ai_os_us.md).
+
 ## Informations Générales
 
 **ID** : US-007  

--- a/US/individual_us/US-008_Framework_Tests_Automatises.md
+++ b/US/individual_us/US-008_Framework_Tests_Automatises.md
@@ -1,5 +1,7 @@
 # US-008 : Framework de Tests Automatisés
 
+> **AI-OS :** chevauchement Unity 144 + `make qemu-smoke` + GitHub Actions. Pas de tests integration/system/performance/robustness, pas de framework « intelligent ». Voir AOS-012 dans [../ai_os_us.md](../ai_os_us.md).
+
 ## Informations Générales
 
 **ID** : US-008  

--- a/US/individual_us/US-010_Gestionnaire_Pilotes_Modulaires.md
+++ b/US/individual_us/US-010_Gestionnaire_Pilotes_Modulaires.md
@@ -1,5 +1,7 @@
 # US-010 : Gestionnaire de Pilotes Modulaires
 
+> **AI-OS :** PIC / PIT / PS/2 / ATA PIO seulement, pas de framework de drivers. Voir [../ai_os_us.md](../ai_os_us.md).
+
 ## Informations Générales
 
 **ID** : US-010  

--- a/US/individual_us/US-012_Framework_APIs_Unifiees.md
+++ b/US/individual_us/US-012_Framework_APIs_Unifiees.md
@@ -1,5 +1,7 @@
 # US-012 : Framework d'APIs Unifiées
 
+> **AI-OS :** `include/os_syscalls.h` (23 appels). Pas d'API unifiée MOHHOS. Voir AOS-006 dans [../ai_os_us.md](../ai_os_us.md).
+
 ## Informations Générales
 
 **ID** : US-012  

--- a/US/individual_us/US-016_Moteur_IA_Local.md
+++ b/US/individual_us/US-016_Moteur_IA_Local.md
@@ -1,5 +1,7 @@
 # US-016 : Moteur IA Local TensorFlow Lite
 
+> **AI-OS :** chevauchement GPT-2 124M freestanding (`SYS_GPT2_GENERATE`), **pas** TensorFlow Lite. Voir AOS-010 dans [../ai_os_us.md](../ai_os_us.md).
+
 ## Informations Générales
 
 **ID** : US-016  

--- a/US/individual_us/US-017_Systeme_Comprehension_Langage_Naturel.md
+++ b/US/individual_us/US-017_Systeme_Comprehension_Langage_Naturel.md
@@ -1,5 +1,7 @@
 # US-017 : Système de Compréhension du Langage Naturel
 
+> **AI-OS :** pas de NLU. Encodeur BPE + complétion 12 jetons. Voir AOS-010 / AOS-011 dans [../ai_os_us.md](../ai_os_us.md).
+
 ## Informations Générales
 
 **ID** : US-017  

--- a/US/individual_us/US-021_Assistant_IA_Integre.md
+++ b/US/individual_us/US-021_Assistant_IA_Integre.md
@@ -1,5 +1,7 @@
 # US-021 : Assistant IA Intégré au Système
 
+> **AI-OS :** builtin shell `ai <texte>` synchrone et borné, pas un assistant proactif système. Voir AOS-010 dans [../ai_os_us.md](../ai_os_us.md).
+
 ## Informations Générales
 
 **ID** : US-021  

--- a/US/individual_us/US-066_Gestion_Memoire_Ressources.md
+++ b/US/individual_us/US-066_Gestion_Memoire_Ressources.md
@@ -1,5 +1,7 @@
 # US-066 : Gestion Mémoire et Ressources
 
+> **AI-OS :** PMM / VMM / heap / `SYS_MEMINFO` seulement. Voir AOS-002 dans [../ai_os_us.md](../ai_os_us.md).
+
 ## Description
 En tant que développeur système, je veux un gestionnaire avancé de mémoire et ressources qui optimise l'allocation, détecte les fuites, gère la fragmentation et applique des stratégies de nettoyage intelligent, afin de maintenir des performances stables et une utilisation efficace des ressources système de MOHHOS.
 

--- a/US/mohhos_us_phase1_foundation.md
+++ b/US/mohhos_us_phase1_foundation.md
@@ -1,6 +1,6 @@
 # MOHHOS - Phase 1 Foundation - User Stories Détaillées
 
-> **État réel (août 2026).** Phase **non commencée dans le code** : le noyau reste monolithique (`kernel/kernel.c`). Spécifications conservées. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+> **État réel (août 2026).** Phase **non commencée dans le code** : le noyau reste monolithique (`kernel/kernel.c`). Ce n'est pas la suite du prototype (voir [ai_os_us.md](ai_os_us.md)). Specs conservées. Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
 
 ## Vue d'Ensemble de la Phase 1
 

--- a/US/mohhos_us_phase2_ai_core.md
+++ b/US/mohhos_us_phase2_ai_core.md
@@ -1,6 +1,6 @@
 # MOHHOS - Phase 2 AI Core - User Stories Détaillées
 
-> **État réel (août 2026).** Phase **non implémentée**. L’IA actuelle est `userspace/fake_ai.c` (mots-clés), pas TensorFlow Lite. Spécifications conservées. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+> **État réel (août 2026).** Phase **non implémentée** (pas de TensorFlow Lite, pas de NLU, pas d'apprentissage fédéré). L'IA du prototype est un **GPT-2 124M freestanding** optionnel (`SYS_GPT2_GENERATE`, commande `ai`) ; `fake_ai` / `ai_assistant` sont des binaires historiques. Suite proche : [ai_os_us.md](ai_os_us.md). Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
 
 ## Vue d'Ensemble de la Phase 2
 

--- a/US/mohhos_us_phase3_web_runtime.md
+++ b/US/mohhos_us_phase3_web_runtime.md
@@ -1,6 +1,6 @@
 # MOHHOS - Phase 3 Web Runtime - User Stories Détaillées
 
-> **État réel (août 2026).** Phase **non implémentée** (pas de navigateur-OS). Spécifications conservées. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+> **État réel (août 2026).** Phase **non implémentée** (pas de navigateur-OS). Hors suite proche du prototype ([ai_os_us.md](ai_os_us.md)). Specs conservées. Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
 
 ## Vue d'Ensemble de la Phase 3
 

--- a/US/mohhos_us_phases_4_8_synthese.md
+++ b/US/mohhos_us_phases_4_8_synthese.md
@@ -1,6 +1,6 @@
 # MOHHOS - Phases 4-8 - Synthèse des User Stories
 
-> **État réel (août 2026).** Phases 4 à 8 **non implémentées** (PromptMessage, P2P, multi-plateforme, économie, production). Synthèse de conception conservée. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+> **État réel (août 2026).** Phases 4 à 8 **non implémentées** (PromptMessage, P2P, multi-plateforme, économie, production). Hors suite proche ([ai_os_us.md](ai_os_us.md)). Synthèse conservée. Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
 
 ## Vue d'Ensemble des Phases Avancées
 

--- a/US/mohhos_user_stories_master.md
+++ b/US/mohhos_user_stories_master.md
@@ -1,6 +1,7 @@
 # MOHHOS - Plan de Développement par User Stories
 
-> **État réel (août 2026).** Document de **planification**. AI-OS n’a pas encore migré vers MOHHOS (pas de microkernel, pas de TensorFlow Lite, pas de P2P). Les US ci-dessous restent valides comme backlog. Code actuel : [docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+> **État réel (août 2026).** Document de **vision / planification MOHHOS**, pas le backlog du prototype. Le code i386 (shell Ring 3, overlay ATA, GPT-2 optionnel) est décrit dans [ai_os_us.md](ai_os_us.md) et [docs/ETAT_REEL.md](../docs/ETAT_REEL.md).  
+> Les titres US-001…US-120 ci-dessous **divergent** souvent des fichiers `individual_us/` (numéros 023-025 en double ; US-031+ des fichiers ≠ navigateur-OS du maître). Ne pas traiter cette liste comme un sprint board.
 
 ## Vue d'Ensemble du Projet
 

--- a/US/recherche_technologies_mohhos.md
+++ b/US/recherche_technologies_mohhos.md
@@ -1,6 +1,6 @@
 # Recherche Approfondie - Technologies pour MOHHOS
 
-> **État réel (août 2026).** Veille / spécification. Ces technologies (TFLite, P2P, navigateur-OS, …) **ne sont pas** dans le dépôt AI-OS actuel. Voir [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+> **État réel (août 2026).** Veille / spécification MOHHOS. TFLite, P2P, navigateur-OS, etc. **ne sont pas** dans le dépôt. Prototype : [ai_os_us.md](ai_os_us.md) et [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
 
 ## Vue d'Ensemble du Projet MOHHOS
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,10 +1,10 @@
 # État réel d'AI-OS
 
 **Date de constat :** 13 août 2026  
-**Code de référence :** branche de travail overlay persisté sur IDE (snapshot ATA PIO)
+**Code de référence :** prototype i386 (overlay ATA, spawn/yield/exec coopératifs, GPT-2 top-k borné)  
 **Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
 
-Les rapports, TODO et user stories plus anciens restent utiles (pistes de debug, extraits de code, spécifications). Ils ne décrivent plus forcément le comportement actuel. En cas de contradiction, **ce fichier prime**.
+Les rapports, TODO et user stories **MOHHOS** restent utiles (pistes, extraits, vision). Ils ne décrivent pas le hobby OS actuel. Backlog aligné sur le code : [US/ai_os_us.md](../US/ai_os_us.md). En cas de contradiction, **ce fichier prime**.
 
 ## Synthèse
 
@@ -14,7 +14,7 @@ AI-OS est un **prototype de noyau pédagogique i386 32-bit**. Il boote sous QEMU
 |---|---|
 | Hobby OS minimal (boot -> shell sous QEMU) | ~60-70 % |
 | Inference GPT-2 locale de démonstration | Fonctionnelle avec checkpoint externe, contexte et sortie bornés |
-| Vision MOHHOS (120 US, 8 phases) | ~1-2 % (spécifications ; ne décrit pas le moteur GPT-2 actuel) |
+| Vision MOHHOS (120 US, 8 phases) | Specs seulement ; backlog réel : [US/ai_os_us.md](../US/ai_os_us.md) |
 
 Ce n'est **pas** un système d'exploitation utilisable au quotidien (pas de FS disque général, pas de réseau, pas d'interface graphique native, pas de vrais pilotes hors QEMU/i8042/ATA PIO).
 
@@ -118,7 +118,7 @@ Malgré la roadmap README v7/v8 et le dossier `US/` :
 - Interface graphique du OS (seul QEMU affiche du VGA texte)
 - Architecture microkernel, IPC, plugins
 - Réseau P2P, multi-plateforme, économie collaborative
-- Les 120 User Stories MOHHOS : **spécifications**, pas d'implémentation (sauf recouvrement accidentel avec le noyau actuel : mémoire, tests unitaires partiels)
+- Les User Stories MOHHOS : **spécifications**, pas d'implémentation. Recouvrement partiel (PMM, Unity, GPT-2, commande `ai`) : [US/individual_us/INDEX.md](../US/individual_us/INDEX.md). Suite proche du prototype : [US/ai_os_us.md](../US/ai_os_us.md)
 
 Le préemptif "à chaque tick" est volontairement **limité** : après le premier passage au shell, le timer n'appelle plus `schedule()` sauf `g_reschedule_needed` (premier saut vers le shell). `spawn`, `yield` et `exec` basculent depuis le syscall, sans round-robin IRQ0 (stabilité clavier).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,10 +7,11 @@ Depuis la racine du dépôt : `make deps` (script [`scripts/bootstrap-dev.sh`](.
 ## Lire en premier
 
 1. [ETAT_REEL.md](ETAT_REEL.md) - **état actuel du code**, y compris GPT-2 local et limites vérifiées
-2. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
-3. [kv_cache_performance_report.md](kv_cache_performance_report.md) - cache KV, reprise du shell et mesures de latence
-4. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
-5. [../README.md](../README.md) - compilation, tests, architecture des sources
+2. [../US/ai_os_us.md](../US/ai_os_us.md) - user stories du prototype (fait + suite)
+3. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
+4. [kv_cache_performance_report.md](kv_cache_performance_report.md) - cache KV, reprise du shell et mesures de latence
+5. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
+6. [../README.md](../README.md) - compilation, tests, architecture des sources
 
 Les autres fichiers de ce dossier sont conservés : rapports de debug, chronologie des correctifs clavier, spécifications d'étapes. Beaucoup décrivent un état **intermédiaire** (shell simulé dans le kernel, crash timer, clavier mort). Ils ne sont pas effacés.
 
@@ -19,6 +20,7 @@ Les autres fichiers de ce dossier sont conservés : rapports de debug, chronolog
 | Fichier | Contenu |
 |---|---|
 | [ETAT_REEL.md](ETAT_REEL.md) | État fonctionnel, GPT-2 local et limites vérifiées |
+| [../US/ai_os_us.md](../US/ai_os_us.md) | User stories du prototype (AOS-001…012 faits, suite AOS-020…025) |
 | [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) | Préparation des artefacts, construction et démarrage d'une ISO GPT-2 hors ligne |
 | [kv_cache_performance_report.md](kv_cache_performance_report.md) | Cache KV, SSE2, test de reprise du shell et mesures de latence |
 | [baremetal_llm_architecture.md](baremetal_llm_architecture.md) | Architecture de référence et évolutions envisagées pour un LLM bare-metal |
@@ -76,6 +78,10 @@ Le blocage restant (EOI IRQ0 après `schedule()` / PIC qui masque IRQ1) est docu
 
 Les captures QEMU et les exports Word ont été retirés du dépôt (la source reste les fichiers `.md`). Les scripts `tests/scripts/test_gpt2_shell_recovery.py` et `tests/scripts/benchmark_gpt2_kv_latency.py` sont les contrôles QEMU correspondants ; ils requièrent les poids locaux sous `models/`.
 
-## Vision MOHHOS (hors code actuel)
+## User stories
 
-Dossier [../US/](../US/README.md) : 120 user stories et phases Foundation -> Production. Ce sont des **spécifications cibles**, pas l'état du dépôt. Légende dans [../US/individual_us/INDEX.md](../US/individual_us/INDEX.md).
+- [../US/ai_os_us.md](../US/ai_os_us.md) — backlog du **prototype** (fait + suite proche)
+- [../US/README.md](../US/README.md) — deux couches : AI-OS vs vision MOHHOS
+- [../US/individual_us/INDEX.md](../US/individual_us/INDEX.md) — specs MOHHOS, chevauchements, IDs dupliqués
+
+Les 8 phases MOHHOS restent des **spécifications**. Elles ne décrivent pas GPT-2, l'overlay ATA ni `spawn`/`exec`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -49,17 +49,18 @@
 - [x] Optimiser la communication kernel/userspace (syscalls GETS/EXEC fonctionnels)
 
 ### Reste ouvert (hors périmètre "shell qui démarre")
-- [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (VFS RAM + table processus simulée)
-- [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + `task.c` + PIT + PMM)
+- [x] Commandes listées dans `help` branchées dans `execute_builtin_command` (overlay noyau + initrd ; `procsim.c` n'alimente plus `ps`/`kill`)
+- [x] `ls` / `cat` / `ps` / `kill` / `uptime` / `mem` : syscalls noyau (initrd + overlay + `task.c` + PIT + PMM)
 - [x] Overlay noyau RAM : `mkdir` / `rm` / `cp` (fichier et dossier via `SYS_COPY`) / `mv` (fichier et dossier via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`) / `touch` / `echo >` visibles par `ls`/`cat` (initrd toujours read-only)
 - [x] Overlay persisté : snapshot ATA PIO LBA28 sur disque IDE QEMU (`write` survit à un reboot) ; pas un FS général
 - [x] `spawn` / `yield` coopératifs (cadre syscall user ; pas de round-robin IRQ0)
 - [x] `exec` bloquant : parent `TASK_WAITING`, enfant reveille via `SYS_EXIT` (plus de `int $0x30` noyau)
-- [ ] Préemption round-robin continue (aujourd'hui limitée pour la stabilité)
-- [ ] Réseau, vrai moteur IA - voir roadmap README / dossier `US/`
+- [ ] Préemption round-robin continue (aujourd'hui limitée pour la stabilité clavier)
+- [ ] Quantification / GGUF / latence &lt; 1 s ; BPE `\p{L}` ; FS disque général ; réseau / OpenAI effectif — [US/ai_os_us.md](../US/ai_os_us.md) AOS-020…025
+- [ ] Dossiers `tests/integration` `system` `performance` `robustness` encore vides
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)
-- [x] Tests complets du système corrigé (`make test-all` : tests unitaires kernel + shell + ramfs)
+- [x] Tests complets du système corrigé (`make test-all` : 144 Unity ; `make qemu-smoke`)
 - [x] Validation du fonctionnement en mode utilisateur (QEMU GTK + `sendkey`)
 - [x] Commit et push des corrections sur GitHub
 - [x] Documentation des corrections apportées ([ETAT_REEL.md](ETAT_REEL.md))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Les 120 US MOHHOS (microkernel, TensorFlow Lite, P2P, PromptMessage…) étaient encore présentées comme le backlog, avec un index qui prenait ✅ pour « implémenté », des IDs 023/024/025 en double, et la phase 2 qui disait que l’IA actuelle était `fake_ai`.

Ce changement sépare deux couches :

1. **Prototype** — [`US/ai_os_us.md`](US/ai_os_us.md) : `AOS-001`…`AOS-012` (boot, overlay ATA, spawn/exec, GPT-2 top-k, Unity 144) et la suite proche `AOS-020`…`AOS-025` (GGUF, BPE unicode, FS disque, tests d’intégration, réseau).
2. **Vision MOHHOS** — specs conservées, index corrigé (chevauchements réels seulement : PMM, CI, GPT-2, commande `ai`).

README, ETAT_REEL, todo et `docs/README.md` pointent vers le backlog AOS. Pas de changement de code.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

