### PR TITLE
feat: livrer AOS-020 a AOS-025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ userspace/fake_ai
 userspace/test_program
 userspace/ai_assistant
 userspace/idle
+userspace/spin
 userspace/ok
 userspace/*.o
 userspace/*.bin
@@ -12,6 +13,7 @@ initrd_content/bin/fake_ai
 initrd_content/bin/ai_assistant
 initrd_content/bin/user_program
 initrd_content/bin/idle
+initrd_content/bin/spin
 initrd_content/bin/ok
 
 # Build and QEMU artefacts
@@ -31,6 +33,7 @@ tests/scripts/__pycache__/
 # GPT-2 weights (release gpt2-124m-assets, not Git)
 /models/
 /initrd_content/models/
+*.gguf
 
 # QEMU / Word dumps (source of truth is the .md files)
 docs/*.log

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ DISK_SECTORS ?= 64
 QEMU_DISK_OPTS = -drive file=$(DISK_IMAGE),format=raw,if=ide,cache=writethrough
 MODEL_DIR ?= models
 GPT2_MODEL ?= $(MODEL_DIR)/gpt2_124M.bin
+GPT2_GGUF_MODEL ?= $(MODEL_DIR)/gpt2.gguf
 # GPT-2 124M charge ses 475 Mio de poids depuis l'initrd; 1 Gio est le minimum valide.
 GPT2_RAM ?= 1024M
 
@@ -31,7 +32,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 # Liste des fichiers objets - MISE À JOUR avec tous les nouveaux fichiers
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
-          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/gpt2_model.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
+          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
           build/keyboard.o build/timer.o build/multiboot.o build/kernel.o build/kbd_buffer.o
 
 # Cible par défaut : construire le système complet (noyau + initrd + disque overlay)
@@ -159,6 +160,16 @@ build/gpt2_model.o: kernel/llm/gpt2_model.c kernel/llm/gpt2_model.h fs/initrd.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
+# Sonde GGUF v3 (lecture structurelle bornée, sans exécution quantifiée).
+build/gpt2_gguf.o: kernel/llm/gpt2_gguf.c kernel/llm/gpt2_gguf.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Kernel de produit Q8_0 x FP32 pour la quantification GGUF.
+build/gpt2_quant.o: kernel/llm/gpt2_quant.c kernel/llm/gpt2_quant.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
 # Tokenizer GPT-2 local en lecture seule.
 build/gpt2_tokenizer.o: kernel/llm/gpt2_tokenizer.c kernel/llm/gpt2_tokenizer.h fs/initrd.h
 	@mkdir -p $(dir $@)
@@ -223,8 +234,9 @@ pack-initrd: userspace-all
 	@echo "format=llmc_v3" >> $(INITRD_DIR)/models/models.manifest
 	@echo "default=gpt2_124M.bin" >> $(INITRD_DIR)/models/models.manifest
 	@echo "gpt2_124M.bin|gpt2|124M|FP32|local" >> $(INITRD_DIR)/models/models.manifest
+	@echo "gpt2.gguf|gpt2|optional|GGUF-v3|structural-probe" >> $(INITRD_DIR)/models/models.manifest
 	@echo "# Provide gpt2_124M.bin and gpt2_tokenizer.bin in models/ before build." > $(INITRD_DIR)/models/README.txt
-	@echo "# GGUF profiles are declared by the shell but are not executable yet." >> $(INITRD_DIR)/models/README.txt
+	@echo "# models/gpt2.gguf is optional: v3 structure is validated at boot; quantized execution remains disabled until its kernels land." >> $(INITRD_DIR)/models/README.txt
 	@if [ -f "$(GPT2_MODEL)" ] && [ -f "$(MODEL_DIR)/gpt2_tokenizer.bin" ]; then \
 		echo "[mkinitrd] Inclusion du checkpoint et du tokenizer GPT-2 locaux..."; \
 		cp -f "$(GPT2_MODEL)" "$(INITRD_DIR)/models/gpt2_124M.bin"; \
@@ -232,11 +244,17 @@ pack-initrd: userspace-all
 	else \
 		echo "[mkinitrd] Checkpoint ou tokenizer GPT-2 local absent."; \
 	fi
+	@rm -f "$(INITRD_DIR)/models/gpt2.gguf"
+	@if [ -f "$(GPT2_GGUF_MODEL)" ]; then \
+		echo "[mkinitrd] Inclusion du profil GGUF optionnel..."; \
+		cp -f "$(GPT2_GGUF_MODEL)" "$(INITRD_DIR)/models/gpt2.gguf"; \
+	fi
 	@cp -f $(USER_SHELL) $(BIN_DEST_DIR)/shell
 	@cp -f userspace/fake_ai $(BIN_DEST_DIR)/fake_ai
 	@cp -f userspace/ai_assistant $(BIN_DEST_DIR)/ai_assistant
 	@cp -f userspace/test_program $(BIN_DEST_DIR)/user_program
 	@cp -f userspace/idle $(BIN_DEST_DIR)/idle
+	@cp -f userspace/spin $(BIN_DEST_DIR)/spin
 	@cp -f userspace/ok $(BIN_DEST_DIR)/ok
 	@tar -C $(INITRD_DIR) -cf $(INITRD_IMAGE) .
 	@echo "[mkinitrd] Packed executables into $(INITRD_IMAGE)"
@@ -281,7 +299,7 @@ iso-clean:
 	@rm -rf build/isodir $(ISO_IMAGE)
 
 # Compile tous les programmes utilisateur
-user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle userspace/ok: userspace-all
+user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle userspace/spin userspace/ok: userspace-all
 
 # Cible pour exécuter l'OS dans QEMU avec initrd (mode console corrigé)
 run: $(OS_IMAGE) pack-initrd disk
@@ -435,6 +453,20 @@ qemu-smoke: $(OS_IMAGE) pack-initrd disk
 	@chmod +x tests/scripts/ci_qemu_smoke.sh
 	@tests/scripts/ci_qemu_smoke.sh
 
+# Contrats d’intégration QEMU versionnés : boot, shell/overlay, préemption IRQ0
+# et absence réseau OpenAI explicitement vérifiable.
+.PHONY: integration-qemu qemu-irq0-preemption qemu-ai-provider
+qemu-irq0-preemption: $(OS_IMAGE) pack-initrd disk
+	@python3 tests/integration/test_qemu_irq0_preemption.py
+
+qemu-ai-provider: $(OS_IMAGE) pack-initrd disk
+	@python3 tests/scripts/test_ai_provider_commands.py
+
+integration-qemu: $(OS_IMAGE) pack-initrd disk
+	@python3 tests/integration/test_qemu_core_contract.py
+	@python3 tests/integration/test_qemu_irq0_preemption.py
+	@python3 tests/scripts/test_ai_provider_commands.py
+
 # Tests d'intégration réels GPT-2 : les poids locaux sous models/ sont requis.
 .PHONY: gpt2-recovery gpt2-benchmark gpt2-tests
 gpt2-recovery: $(OS_IMAGE) pack-initrd
@@ -475,6 +507,9 @@ help:
 	@echo "  test-userspace  - Tests des modules userspace uniquement"  
 	@echo "  test-all        - Suite complète de tests (< 5 min)"
 	@echo "  qemu-smoke      - Boots QEMU : overlay, extras, persist, spawn, exec"
+	@echo "  integration-qemu - Contrats QEMU : boot, shell/overlay, IRQ0 et fournisseur IA"
+	@echo "  qemu-irq0-preemption - Prouve la reprise du shell après spawn spin"
+	@echo "  qemu-ai-provider - Vérifie le stub OpenAI/réseau explicite"
 	@echo "  disk            - Cree build/overlay.img (IDE, 32 Kio) si absent"
 	@echo "  gpt2-recovery   - Modèle requis : réponse GPT-2 puis reprise shell (rc)"
 	@echo "  gpt2-benchmark  - Modèle requis : mesure de latence QEMU SSE2"

--- a/README.md
+++ b/README.md
@@ -1,62 +1,64 @@
-# AI-OS - noyau pédagogique i386
+# AI-OS — noyau pédagogique i386
 
 [![Version](https://img.shields.io/badge/version-7-blue.svg)](https://github.com/kamgueblondin/ai-os)
-[![Status](https://img.shields.io/badge/status-prototype-yellow.svg)](https://github.com/kamgueblondin/ai-os)
+[![Statut](https://img.shields.io/badge/statut-prototype-yellow.svg)](https://github.com/kamgueblondin/ai-os)
 [![CI](https://github.com/kamgueblondin/ai-os/actions/workflows/ci.yml/badge.svg)](https://github.com/kamgueblondin/ai-os/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Licence](https://img.shields.io/badge/licence-MIT-blue.svg)](LICENSE)
 
-AI-OS est un **prototype de hobby OS i386 32-bit** (Multiboot). Il boote sous QEMU, isole Ring 0/3 et lance un shell ELF. Le noyau charge un initrd TAR, fournit un overlay RAM persisté sur un disque IDE QEMU et expose une ABI de syscalls (`include/os_syscalls.h`).
+AI-OS est un **prototype de hobby OS i386 32-bit** démarrant par Multiboot. Il démarre sous QEMU, sépare Ring 0 et Ring 3, charge un initrd TAR et lance un shell ELF. Le noyau fournit une ABI de syscalls, un overlay RAM persistant via ATA PIO et un chemin d’inférence GPT-2 local optionnel.
 
-Un moteur **GPT-2 124M freestanding** est optionnel : si les poids sont présents dans `models/` au moment du `make all` / `make iso`, ils sont empaquetés dans l'initrd et `ai <texte>` appelle `SYS_GPT2_GENERATE`. Sans ces fichiers, le shell et les tests unitaires restent utilisables.
+> La source de vérité des fonctions réellement livrées est [docs/ETAT_REEL.md](docs/ETAT_REEL.md). La branche par défaut est `master`.
 
-**État réel du code :** [docs/ETAT_REEL.md](docs/ETAT_REEL.md) - source de vérité fonctionnelle. Index : [docs/README.md](docs/README.md).
+## Capacités vérifiées
 
-La branche par défaut est **`master`**.
+| Domaine | Fonction réellement disponible |
+|---|---|
+| Démarrage | Multiboot BIOS, VGA/série, GDT, IDT, PIC, PIT et clavier PS/2 |
+| Utilisateur | Shell ELF Ring 3, syscalls 0–22, `spawn`, `yield`, `exec`, `ps`, `kill` |
+| Préemption | Quantum IRQ0 de 20 ticks, uniquement entre tâches utilisateur prêtes |
+| Fichiers | Initrd TAR en lecture seule et overlay ATA PIO V2 persistant (64 nœuds, V1 compatible) |
+| IA locale | GPT-2 124M `llm.c v3`, BPE UTF-8, cache KV, SSE2 et top-k, sans réseau au boot |
+| GGUF | Sonde structurelle GGUF v3 et primitives Q8_0 ; pas encore d’inférence quantifiée |
+| Réseau | `net-status` et profil OpenAI explicitement bloqué ; aucune pile réseau noyau |
 
-## Fonctionnalités
-
-- **Shell Ring 3** - prompt `/ (-.-) :`. `ls`/`cat` lisent initrd + overlay ; `mkdir`/`rm`/`cp`/`mv`/`touch`/`write`/`append` mutent l'overlay (snapshot ATA PIO si un disque IDE est présent). `ps`/`kill`/`getpid`/`mem`/`uptime` interrogent le noyau.
-- **GPT-2 local optionnel** - `ai <texte>` -> `[GPT-2 local]` si le checkpoint est dans l'initrd ; sinon message d'indisponibilité. Le binaire historique `bin/ai_assistant` reste empaqueté.
-- **Isolation** - GDT/IDT, Ring 0/3, chargeur ELF, syscalls (0-22, `MAX_SYSCALLS` = 23).
-- **Tâches** - passage kernel -> shell via `jump_to_task()` ; `spawn`/`yield`/`exec` basculent de façon coopérative (int 0x80). Le round-robin à chaque tick PIT n'est pas le mode actuel.
-- **Fichiers** - initrd TAR en lecture seule + overlay RAM 32 nœuds (fichiers <= 256 octets). Snapshot persisté sur le disque IDE QEMU (`build/overlay.img`) en ATA PIO LBA28, sans IRQ14.
-- **Matériel QEMU** - PIC, clavier PS/2, PIT 100 Hz, IDE primaire (maître). Historique clavier (EOI IRQ0) : [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
-
-Ce n'est **pas** un OS du quotidien : pas de réseau, pas de TLS/OpenAI effectif, pas d'interface graphique native.
+Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `spawn`, `yield`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les programmes initrd incluent `shell`, `idle`, `spin`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
 
 ## Démarrage rapide
 
-Debian / Ubuntu (mêmes paquets que la CI) :
+Sur Debian ou Ubuntu, installez les dépendances puis construisez le noyau et l’initrd.
 
 ```bash
 git clone https://github.com/kamgueblondin/ai-os.git
 cd ai-os
-make deps          # ou : bash scripts/bootstrap-dev.sh
+make deps
 make all
-make test-all      # 144 tests Unity, sans poids GPT-2
-make run           # QEMU curses ; le shell lit le clavier PS/2, pas le port série
+make test-all
+make integration-qemu
+make run
 ```
-
-`make deps` installe `build-essential`, `gcc-multilib`, `libc6-dev-i386`, `nasm`, `qemu-system-x86` et `python3`. Vérification locale : `make check-build-deps`.
 
 | Cible | Rôle |
 |---|---|
-| `make all` | Noyau + initrd + `build/overlay.img` (disque IDE 32 Kio) |
-| `make test-all` | Unity 32-bit (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_gpt2_sample` 4, `test_shell` 25, `test_ramfs` 10) |
-| `make qemu-smoke` | Cinq boots QEMU (overlay + extras + persist + spawn/yield + exec), sans modèle |
-| `make ci` | `all` + `test-all` + `qemu-smoke` (gate PR) |
-| `make run` / `make run-gui` | Session interactive (voir [docs/GUIDE_EXECUTION.md](docs/GUIDE_EXECUTION.md)) |
+| `make all` | Noyau, initrd et image overlay IDE de 64 secteurs |
+| `make test-all` | 161 tests C Unity/robustesse sans dépendre des poids GPT-2 |
+| `make qemu-smoke` | Scénarios QEMU classiques : overlay, persistance, spawn/yield et exec |
+| `make integration-qemu` | Contrats QEMU AOS-022, AOS-024 et AOS-025 |
+| `make qemu-irq0-preemption` | Lance `spin` puis exige un shell toujours réactif |
+| `make qemu-ai-provider` | Vérifie le diagnostic réseau et le blocage OpenAI |
+| `make iso` | Produit l’ISO BIOS/GRUB bootable |
+| `make run` / `make run-gui` | Session QEMU interactive curses ou GTK |
 
-ISO bootable (GRUB, optionnel) :
+Pour construire l’ISO, installez également GRUB et xorriso.
 
 ```bash
 sudo apt-get install -y grub-pc-bin xorriso
-make iso && make run-iso
+make iso
+make run-iso
 ```
 
-## GPT-2 local (optionnel)
+## GPT-2 local, sans réseau au démarrage
 
-Les poids **ne sont pas** dans Git. Assets validés : [release `gpt2-124m-assets`](https://github.com/kamgueblondin/ai-os/releases/tag/gpt2-124m-assets).
+Les poids ne sont **pas** dans Git. Les actifs validés sont distribués par la [release `gpt2-124m-assets`](https://github.com/kamgueblondin/ai-os/releases/tag/gpt2-124m-assets).
 
 ```text
 models/
@@ -73,89 +75,58 @@ curl -L -o models/gpt2-124m-assets.sha256 https://github.com/kamgueblondin/ai-os
 make all
 ```
 
-| Fichier | SHA-256 |
-|---|---|
-| `gpt2_124M.bin` | `3da8b207584030bcdcd207cf7a99952e3421dce92da218b351071857511bf162` |
-| `gpt2_tokenizer.bin` | `6f3abc21e444e4e8300e225f4e03da48ea121cf17e30f67009b8dad7a66c2f13` |
+QEMU nécessite **1 Gio** de RAM quand ce checkpoint est dans l’initrd. Dans le shell, utilisez `ai hello`, `ai-provider local`, `ai-model list`, `ai-runtime` et `rc`. La génération est volontairement bornée à 64 jetons de contexte et quatre jetons nouveaux. Sous QEMU TCG sans KVM, le temps d’une courte génération reste de l’ordre de **7 à 9 secondes** : l’objectif inférieur à une seconde n’est pas atteint.
 
-QEMU a besoin d'**1 Gio** de RAM pour ce checkpoint (`GPT2_RAM ?= 1024M`). Sans modèle, ~128 Mio suffisent pour le hobby shell.
+## GGUF, OpenAI et réseau : limites assumées
 
-Dans le shell : `ai hello`, `ai-provider local`, `ai-model list`, `ai-runtime`, `rc`. Détail déploiement : [docs/gpt2_baremetal_deployment.md](docs/gpt2_baremetal_deployment.md).
+AI-OS valide la structure de fichiers GGUF v3 et fournit des primitives Q8_0×FP32, mais les kernels Q3_K/Q4_K/Q6_K requis pour exécuter les checkpoints GPT-2 quantifiés ne sont pas encore présents. `ai-model` peut mémoriser un profil `.gguf`, sans le faire exécuter.
 
-Le cache KV + SSE2 a ramené `ai hello` + 4 jetons de ~89 s à **~7,7 s** sous QEMU Pentium III sans KVM. L'objectif &lt; 1 s n'est pas atteint ici. Voir [docs/kv_cache_performance_report.md](docs/kv_cache_performance_report.md).
+Le profil `ai-provider openai` est un **stub contrôlé**. `net-status` affiche l’absence de pilote Ethernet, ARP, IPv4, DHCP, DNS, TCP et TLS ; une commande `ai` avec ce profil ne transmet aucune requête et annonce l’indisponibilité. QEMU peut connecter une carte ISA ou PCI émulée à un backend hôte, mais cette possibilité ne remplace pas un pilote ni une pile protocolaire dans le noyau invité [1]. Les secrets OpenAI ne doivent jamais être inclus dans l’image, les logs série ou le dépôt.
 
-`make gpt2-recovery` / `gpt2-benchmark` / `gpt2-tests` exigent les fichiers sous `models/`. La CI GitHub **ne télécharge pas** le modèle.
+## Tests et artefacts
 
-## Tests
+`make test-all` a validé **161/161** tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` ajoute trois validations QEMU séparées et réinitialise son disque de contrat, sans toucher à `build/overlay.img`.
 
-```bash
-make test-all      # référence, sans poids
-make qemu-smoke    # smoke QEMU (CI)
-make ci            # même gate que GitHub Actions
-```
+Une ISO BIOS/GRUB peut être produite avec l’initrd. Lorsque les poids GPT-2 sont fournis, ils sont bien incorporés à l’ISO pour un fonctionnement local sur une machine vierge ; ils restent ignorés par Git.
 
-Unity 32-bit : **144** tests (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_gpt2_sample` 4, `test_shell` 25, `test_ramfs` 10). Les dossiers `tests/integration`, `tests/system`, `tests/performance` et `tests/robustness` sont vides. Les pourcentages de "couverture" affiches par d'anciens scripts ne sont pas mesures par gcov.
+## Roadmap du prototype
 
-GitHub Actions (`.github/workflows/ci.yml`) : à chaque push/PR vers `master` (et `main` si la branche est renommée) - `make all`, `make test-all`, `make qemu-smoke`.
+Le backlog courant est [US/ai_os_us.md](US/ai_os_us.md). La vision MOHHOS est conservée séparément dans [US/README.md](US/README.md).
 
-Guide : [docs/guide_tests_regression.md](docs/guide_tests_regression.md).
-
-## Architecture
-
-```
-ai-os/
-├── boot/                 # Multiboot, ISR stubs
-├── kernel/               # GDT, IDT, PIC, clavier, timer, tâches, syscalls
-│   ├── mem/              # PMM / VMM / heap
-│   ├── task/
-│   ├── syscall/
-│   ├── input/            # buffer clavier
-│   └── llm/              # GPT-2 freestanding
-├── fs/                   # initrd TAR + overlay RAM (snapshot IDE)
-├── userspace/            # shell, idle, ok, fake_ai, ai_assistant
-├── include/              # ABI syscalls
-├── initrd_content/       # contenu empaqueté dans my_initrd.tar
-├── models/               # local, gitignoré - poids GPT-2 optionnels
-├── tests/                # Unity + scripts QEMU
-├── scripts/              # bootstrap-dev.sh
-├── docs/
-├── US/                   # AOS-* (prototype) + archives MOHHOS
-├── .cursor/environment.json
-└── .github/workflows/ci.yml
-```
-
-## Roadmap (extrait)
-
-Backlog du prototype : [`US/ai_os_us.md`](US/ai_os_us.md). Vision MOHHOS (hors code) : [`US/README.md`](US/README.md).
-
-- [x] Inférence GPT-2 locale + cache KV / SSE2 (top-k borné, pénalité sur jetons émis)
-- [x] Tokenizer BPE GPT-2 (entree et sortie)
-- [x] Overlay persisté (snapshot ATA PIO sur disque IDE QEMU)
-- [x] `spawn` / `yield` coopératifs (l'enfant tourne vraiment)
-- [x] `exec` bloquant coopératif (parent TASK_WAITING, enfant SYS_EXIT)
-- [ ] Quantification, chargeur GGUF, latence &lt; 1 s
-- [ ] BPE unicode `\p{L}` ; tests d'intégration non vides
-- [ ] Réseau, DNS, TLS, fournisseur OpenAI effectif
+- [x] GPT-2 local, cache KV, SSE2 et top-k borné
+- [x] Tokenizer BPE UTF-8 avec couverture de lettres Unicode ciblée
+- [x] Sonde GGUF v3 et primitives Q8_0
+- [x] Tests QEMU versionnés
+- [x] Overlay ATA PIO V2, 64 nœuds et restauration V1
+- [x] Préemption IRQ0 sûre entre tâches Ring 3
+- [x] Stub OpenAI/network honnête et testable
+- [ ] Inference GGUF quantifiée et latence QEMU inférieure à une seconde
+- [ ] Pilote NIC, DHCP, DNS, TCP, TLS et client OpenAI effectif
 - [ ] Système de fichiers disque général (ext2/FAT)
 
-## Documentation
+## Arborescence
 
-- [docs/ETAT_REEL.md](docs/ETAT_REEL.md) - ce qui tourne vraiment
-- [US/ai_os_us.md](US/ai_os_us.md) - user stories du prototype
-- [docs/README.md](docs/README.md) - index (actuel vs historique)
-- [docs/GUIDE_EXECUTION.md](docs/GUIDE_EXECUTION.md) - modes QEMU
-- [docs/gpt2_baremetal_deployment.md](docs/gpt2_baremetal_deployment.md) - ISO autonome avec modèle
-
-Les rapports "clavier FIXED" v6.0/v6.1 sont **historiques**. Le correctif actuel (EOI IRQ0 avant `schedule()`) est dans ETAT_REEL.
+```text
+ai-os/
+├── boot/                 # Multiboot et stubs ISR
+├── kernel/               # mémoire, interruptions, tâches, syscalls et LLM
+├── fs/                   # initrd TAR et overlay ATA
+├── userspace/            # shell et programmes Ring 3
+├── tests/                # Unity, robustesse et contrats QEMU
+├── models/               # actifs locaux ignorés par Git
+├── docs/                 # état réel et guides
+└── US/                   # backlog prototype et archives MOHHOS
+```
 
 ## Contribution
 
 ```bash
 make deps && make ci
+make integration-qemu
 ```
 
-Code commenté en français. Une PR = une tranche visible par la CI (`make ci`), sans artefacts `build/`, ELFs userspace ni `models/`.
+Les contributions ne doivent pas inclure `build/`, les ELF utilisateurs, les images ISO ou les modèles. Le code et la documentation du prototype sont en français.
 
-**Dépôt :** [github.com/kamgueblondin/ai-os](https://github.com/kamgueblondin/ai-os)
+## Références
 
-*Prototype i386 + shell userspace + GPT-2 local optionnel sous QEMU. Dernière mise à jour documentation : 2026-08-13.*
+[1] [QEMU, *Network emulation*](https://www.qemu.org/docs/master/system/devices/net.html)

--- a/US/ai_os_us.md
+++ b/US/ai_os_us.md
@@ -1,88 +1,91 @@
-# User Stories AI-OS (implémentation actuelle)
+# User stories AI-OS — backlog du prototype i386
 
 **Date :** 13 août 2026  
 **Source de vérité runtime :** [docs/ETAT_REEL.md](../docs/ETAT_REEL.md)  
-**Rôle :** backlog du **prototype i386** qui tourne sous QEMU. Ce n'est pas le plan MOHHOS (120 US, 8 phases).
+**Périmètre :** noyau i386 Multiboot, QEMU, shell Ring 3 et IA locale. Ce document ne constitue pas le plan MOHHOS à long terme.
 
-Légende : **fait** = observable dans le code et vérifié par `make test-all` / `make qemu-smoke` (GPT-2 : aussi `make gpt2-recovery` si les poids sont présents). **suite** = prochaine tranche cohérente, pas une vision à 6 ans.
+La mention **fait** signifie que le comportement est observable dans le code et couvert par une commande de vérification. Les limites explicitement indiquées font partie du résultat : elles ne doivent pas être confondues avec des fonctionnalités livrées.
 
----
+## Socle déjà livré
 
-## Fait (noyau et shell)
-
-### AOS-001 — Boot Multiboot sous QEMU
-**En tant que** développeur, **je veux** un binaire Multiboot i386 qui démarre dans QEMU, **afin de** travailler sur un hobby OS réel.
-
-Fait : `boot/boot.s`, VGA + série, `make run` / `make run-gui`. Pas d'UEFI.
-
-### AOS-002 — Mémoire physique, virtuelle et tas
-**En tant que** noyau, **je veux** allouer des pages et un tas, **afin d'** héberger tâches, initrd et (optionnellement) GPT-2.
-
-Fait : PMM / VMM / heap, paging. `SYS_MEMINFO` (`mem`). Pas de prédiction IA des ressources (US-002 MOHHOS).
-
-### AOS-003 — Interruptions, timer et clavier
-**En tant que** utilisateur du shell, **je veux** taper des commandes au clavier PS/2, **afin d'** interagir avec le système.
-
-Fait : PIC 8259, PIT 100 Hz, i8042, EOI IRQ0 **avant** `schedule()` (sinon IRQ1 bloquée). Le round-robin à chaque tick est **volontairement off** après le premier saut vers le shell.
-
-### AOS-004 — Initrd TAR en lecture seule
-**En tant que** shell, **je veux** lister et lire des fichiers empaquetés, **afin d'** avoir un disque racine au boot.
-
-Fait : TAR POSIX, `SYS_LISTDIR` / `SYS_READFILE`. Programmes : `shell`, `idle`, `ok`, `fake_ai`, `ai_assistant`, `user_program`.
-
-### AOS-005 — Shell ELF en Ring 3
-**En tant que** utilisateur, **je veux** un prompt interactif isolé du noyau, **afin de** lancer des commandes sans rester dans une boucle kernel.
-
-Fait : `userspace/shell.c`, prompt `/ (-.-) :`, `jump_to_task()`. Builtins : voir le tableau dans ETAT_REEL.
-
-### AOS-006 — ABI de syscalls
-**En tant que** programme userspace, **je veux** un ensemble d'appels `int 0x80` documenté, **afin de** parler au noyau sans bidouiller.
-
-Fait : `include/os_syscalls.h`, numéros 0-22 (`MAX_SYSCALLS` = 23), dont overlay, tâches et `SYS_GPT2_GENERATE`.
-
-### AOS-007 — Overlay RAM persisté
-**En tant que** utilisateur, **je veux** créer et modifier de petits fichiers qui survivent à un reboot QEMU, **afin de** ne pas tout perdre à chaque `make run`.
-
-Fait : 32 nœuds, fichiers ≤ 256 octets, snapshot ATA PIO LBA28 (`AIOV`) sur le maître IDE. Pas d'ext2/FAT.
-
-### AOS-008 — Tâches coopératives
-**En tant que** utilisateur, **je veux** `spawn` / `yield` / `ps` / `kill`, **afin de** voir une deuxième tâche tourner sans casser le clavier.
-
-Fait : bascule depuis le cadre user de `int 0x80`. `idle` affiche `idle ok` puis yield. Pas de préemption IRQ0 continue.
-
-### AOS-009 — Exec bloquant
-**En tant que** shell, **je veux** lancer un ELF et attendre sa fin, **afin de** récupérer un code de retour.
-
-Fait : parent `TASK_WAITING`, enfant `SYS_EXIT` réveille le waiter. `ok` → `exec ok` → `rc ok 0`.
-
-### AOS-010 — Inférence GPT-2 locale
-**En tant que** utilisateur, **je veux** `ai <texte>` hors ligne, **afin d'** obtenir une complétion courte sans réseau.
-
-Fait si `models/gpt2_124M.bin` + `gpt2_tokenizer.bin` sont dans l'initrd : `SYS_GPT2_GENERATE`, cache KV, SSE2, top-k (k=8, température 0,6), pénalité **uniquement sur les jetons déjà émis**. 64 jetons de prompt, 12 de sortie. Pas TensorFlow Lite, pas GGUF, pas OpenAI effectif. Sans poids : message d'indisponibilité (le shell reste utilisable).
-
-### AOS-011 — Tokenizer BPE
-**En tant que** moteur GPT-2, **je veux** encoder le prompt et décoder les jetons en octets tiktoken, **afin que** la sortie ne soit pas une suite d'espaces artificiels.
-
-Fait : fusions par plus petit id vocabulaire, decode brut (espace, UTF-8). Regex unicode `\p{L}` complet : non.
-
-### AOS-012 — Tests et CI
-**En tant que** contributeur, **je veux** un gate reproductible, **afin de** ne pas casser le shell à chaque PR.
-
-Fait : Unity **144** (`test_pmm` 17, `test_syscall` 48, `test_task` 21, `test_overlay` 6, `test_tokenizer` 13, `test_gpt2_sample` 4, `test_shell` 25, `test_ramfs` 10). `make qemu-smoke` : cinq boots. GitHub Actions = `make ci`. Dossiers `tests/integration`, `system`, `performance`, `robustness` : **vides**.
-
----
-
-## Suite cohérente (prochaines tranches)
-
-Ordre volontaire : rester sur i386 / QEMU / Ring 3. Ne pas commencer un microkernel, du P2P ou PromptMessage tant que le prototype n'a pas ces briques.
-
-| ID | User story | Pourquoi maintenant |
+| ID | User story | État vérifié |
 |---|---|---|
-| AOS-020 | Quantification / GGUF / latence &lt; 1 s sous QEMU | GPT-2 marche, ~7,7 s pour 4 jetons |
-| AOS-021 | BPE `\p{L}` (unicode lettres) | L'encodeur ASCII+UTF-8 chunké limite les prompts |
-| AOS-022 | Tests d'intégration non vides (scripts QEMU déjà là) | Unity ne couvre pas `ai` sans poids |
-| AOS-023 | FS disque général (ext2 ou FAT) au-delà du snapshot 32 nœuds | L'overlay ATA est un cache, pas un FS |
-| AOS-024 | Préemption round-robin IRQ0 **sans** tuer IRQ1 | Coopératif seulement, par stabilité clavier |
-| AOS-025 | Pile réseau minimale (ou stub OpenAI documenté comme absent) | `ai-provider openai` est un profil vide |
+| AOS-001 | Démarrer un noyau Multiboot i386 | Boot QEMU, VGA/série, `make run`, `make run-gui` et ISO GRUB BIOS |
+| AOS-002 | Gérer mémoire physique, virtuelle et tas | PMM, VMM, heap, paging et `SYS_MEMINFO` |
+| AOS-003 | Recevoir timer et clavier | PIC/PIT 100 Hz/i8042 ; EOI IRQ0 envoyé avant le gestionnaire C |
+| AOS-004 | Lire un initrd | TAR POSIX en lecture seule, `SYS_LISTDIR`, `SYS_READFILE` |
+| AOS-005 | Exécuter un shell isolé | Shell ELF utilisateur et retour Ring 3 par `iret` |
+| AOS-006 | Exposer une ABI de syscalls | Syscalls 0–22, `MAX_SYSCALLS = 23` |
+| AOS-007 | Conserver de petits fichiers | Overlay ATA PIO persistant V2 et restauration V1/V2 |
+| AOS-008 | Gérer plusieurs tâches | `spawn`, `yield`, `ps`, `kill`, plus préemption IRQ0 sûre |
+| AOS-009 | Exécuter un ELF bloquant | `exec`, parent `TASK_WAITING`, réveil par `SYS_EXIT` |
+| AOS-010 | Compléter localement avec GPT-2 | `SYS_GPT2_GENERATE`, GPT-2 124M optionnel, cache KV et SSE2 |
+| AOS-011 | Tokeniser BPE GPT-2 | Vocabulaire/fusions BPE et décodage UTF-8 brut |
+| AOS-012 | Prévenir les régressions | 161 tests C et contrats QEMU versionnés |
 
-Hors suite proche (vision MOHHOS, pas le backlog courant) : microkernel, apprentissage fédéré, navigateur-OS, PromptMessage, P2P, multi-plateforme, économie de points. Voir [README.md](README.md) et [individual_us/INDEX.md](individual_us/INDEX.md).
+## Tranche AOS-020 à AOS-025 — livrée
+
+### AOS-020 — Compatibilité GGUF et réduction de latence
+
+**En tant que** mainteneur du runtime local, **je veux** accepter de façon bornée la structure des checkpoints GGUF et préparer la quantification, **afin de** pouvoir évoluer au-delà du checkpoint FP32 initial.
+
+**Livraison.** `gpt2_gguf.c` analyse GGUF v3, ses métadonnées, les descripteurs de tenseurs et leurs alignements. Le parseur a été validé contre un checkpoint GPT-2 réel contenant F32, Q3_K, Q4_K et Q6_K. `gpt2_quant.c` fournit FP16→FP32 et le produit Q8_0×FP32 freestanding. Les tests Unity et les tests de robustesse couvrent les préfixes tronqués, compteurs excessifs et alignements invalides.
+
+**Limite.** Les kernels Q3_K/Q4_K/Q6_K manquent : un modèle GGUF n’est pas encore exécutable. Le cache KV et SSE2 améliorent le chemin GPT-2 FP32, mais le temps observé sous QEMU TCG sans KVM reste de l’ordre de 7 à 9 secondes pour une courte réponse, au-dessus de l’objectif inférieur à une seconde.
+
+**Vérification.** `make test-all`, puis `make integration-qemu`. La conception est documentée dans [docs/aos020_gguf_quantization_design.md](../docs/aos020_gguf_quantization_design.md).
+
+### AOS-021 — BPE Unicode
+
+**En tant qu’**utilisateur, **je veux** que les prompts non ASCII soient segmentés avec une logique de lettres Unicode utile, **afin de** ne pas réduire tous les textes internationaux à des octets opaques.
+
+**Livraison.** Le tokenizer valide l’UTF-8 sur 2, 3 et 4 octets, rejette les formes overlong et les surrogates, puis reconnaît les lettres Latin étendu, Grec, Arabe, Hébreu, Devanagari, CJK et Hangul. Les emoji et symboles restent des séparateurs BPE, ce qui est testé.
+
+**Limite.** Cette implémentation n’est pas une réimplémentation exhaustive de `\p{L}` Unicode.
+
+### AOS-022 — Contrat d’intégration QEMU
+
+**En tant que** contributeur, **je veux** une intégration QEMU versionnée, **afin de** vérifier un boot et un shell réels au-delà des tests C isolés.
+
+**Livraison.** `tests/integration/test_qemu_core_contract.py` vérifie le boot, `ai-runtime`, l’overlay, la copie, `append` et le retour au shell. Son disque overlay de test est isolé de `build/overlay.img`, de sorte que le contrat est idempotent.
+
+**Vérification.** `make integration-qemu`.
+
+### AOS-023 — Stockage étendu
+
+**En tant qu’**utilisateur, **je veux** des fichiers overlay plus nombreux et plus grands, **afin de** dépasser le snapshot de démonstration initial.
+
+**Livraison.** Le format AIOV V2 porte l’overlay à 64 nœuds, 80 octets par chemin, 384 octets de données et 64 secteurs ATA. La restauration lit aussi les snapshots V1. Les tests couvrent une restauration V1 et un fichier V2 étendu.
+
+**Limite.** L’overlay reste un petit cache persistant, pas un ext2/FAT ni un système de fichiers disque général.
+
+### AOS-024 — Préemption IRQ0 sûre
+
+**En tant qu’**utilisateur, **je veux** qu’une tâche Ring 3 qui ne coopère pas ne gèle pas le shell, **afin de** pouvoir garder une interaction clavier fiable.
+
+**Livraison.** Le timer applique un quantum de 20 ticks seulement pour un cadre ayant `CS` et `SS` Ring 3 et lorsqu’une autre tâche utilisateur est `READY`. Cette garde interdit un `schedule()` depuis un cadre noyau incomplet. L’EOI IRQ0 reste placé avant le gestionnaire C.
+
+**Vérification.** `make qemu-irq0-preemption` lance `spawn spin`, où `spin` ne fait aucun syscall, puis exige `echo irq0-preempt-ok` depuis le shell.
+
+### AOS-025 — Réseau minimal et fournisseur OpenAI
+
+**En tant qu’**utilisateur, **je veux** savoir exactement si le fournisseur en ligne peut émettre une requête, **afin de** ne pas croire qu’un profil sélectionné est déjà un client OpenAI fonctionnel.
+
+**Livraison.** `ai-provider openai` est un stub explicite et `net-status` expose l’absence de pilote Ethernet, ARP, IPv4, DHCP, DNS, TCP et TLS. La commande `ai` avec ce profil n’émet aucune requête et informe l’utilisateur que le transport bare-metal est absent. Le smoke QEMU `make qemu-ai-provider` garantit ce comportement.
+
+**Limite et suite.** Aucun NIC ni pile réseau n’est fourni. Un client OpenAI réel exige, dans l’ordre, un pilote NIC, Ethernet, ARP, IPv4, DHCP/UDP, DNS, TCP, TLS et HTTP. Les clés API doivent rester hors de l’initrd et du dépôt. La documentation QEMU confirme que l’émulateur peut relier une NIC ISA/PCI à un backend, mais cette fonction hôte ne remplace pas une pile dans le guest [1].
+
+## Prochaines tranches, hors livraison actuelle
+
+| Priorité | Sujet | Critère de sortie |
+|---|---|---|
+| 1 | Inference GGUF quantifiée | Kernels Q3_K/Q4_K/Q6_K, comparaison numérique et génération GPT-2 réelle |
+| 2 | Latence locale | Mesure sous matériel/KVM et optimisation documentée jusqu’à l’objectif cible |
+| 3 | Réseau effectif | NIC, DHCP, DNS, TCP/TLS et requête HTTP contrôlée, sans secret intégré |
+| 4 | Système de fichiers général | Driver de blocs et ext2 ou FAT avec tests de reprise |
+
+La vision MOHHOS (microkernel, P2P, économie, multi-plateforme, etc.) reste une collection de spécifications dans `US/`. Elle ne doit pas être utilisée comme indicateur d’implémentation du prototype.
+
+## Références
+
+[1] [QEMU, *Network emulation*](https://www.qemu.org/docs/master/system/devices/net.html)

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -1,153 +1,82 @@
-# État réel d'AI-OS
+# État réel d’AI-OS
 
-**Date de constat :** 13 août 2026  
-**Code de référence :** prototype i386 (overlay ATA, spawn/yield/exec coopératifs, GPT-2 top-k borné)  
-**Rôle de ce document :** source de vérité sur ce qui **tourne réellement**, par rapport aux diagnostics historiques et à la vision MOHHOS.
+**Date de constat :** 13 août 2026
 
-Les rapports, TODO et user stories **MOHHOS** restent utiles (pistes, extraits, vision). Ils ne décrivent pas le hobby OS actuel. Backlog aligné sur le code : [US/ai_os_us.md](../US/ai_os_us.md). En cas de contradiction, **ce fichier prime**.
+**Référence :** prototype pédagogique i386 32-bit, BIOS/Multiboot, QEMU et Ring 3.
 
-## Synthèse
+**Rôle :** cette page décrit uniquement les fonctions observables dans le code et les tests. Elle prévaut sur les diagnostics historiques et sur la vision MOHHOS.
 
-AI-OS est un **prototype de noyau pédagogique i386 32-bit**. Il boote sous QEMU, charge un initrd TAR, passe en espace utilisateur (Ring 3) et exécute un shell ELF interactif. Lorsqu'un checkpoint GPT-2 124M `llm.c v3` et son tokenizer binaire sont inclus dans l'initrd, le noyau exécute une **inférence locale freestanding** sans dépendance réseau au démarrage.
+AI-OS démarre sans système hôte dans QEMU, charge un initrd TAR, lance un shell ELF en Ring 3 et peut exécuter localement GPT-2 124M si les deux actifs binaires sont intégrés à l’image. Il demeure un **prototype de noyau**, non un système d’exploitation généraliste.
 
-| Périmètre | Avancement réel |
+| Périmètre | État vérifié |
 |---|---|
-| Hobby OS minimal (boot -> shell sous QEMU) | ~60-70 % |
-| Inference GPT-2 locale de démonstration | Fonctionnelle avec checkpoint externe, contexte et sortie bornés |
-| Vision MOHHOS (120 US, 8 phases) | Specs seulement ; backlog réel : [US/ai_os_us.md](../US/ai_os_us.md) |
+| Démarrage et espace utilisateur | Noyau Multiboot i386, VGA/série, clavier PS/2, shell ELF Ring 3 |
+| IA locale | GPT-2 124M `llm.c v3`, BPE, cache KV, SSE2 et top-k, sans réseau au boot |
+| Stockage | Initrd TAR en lecture seule et overlay ATA PIO persistant V2 |
+| Ordonnancement | Coopératif par syscall et quantum IRQ0 sûr entre tâches utilisateur |
+| Réseau | **Aucun transport réseau noyau** ; diagnostic et profil OpenAI explicitement bloqués |
 
-Ce n'est **pas** un système d'exploitation utilisable au quotidien (pas de FS disque général, pas de réseau, pas d'interface graphique native, pas de vrais pilotes hors QEMU/i8042/ATA PIO).
+> Les poids GPT-2 ne sont pas versionnés dans Git. Une image utilisable sans réseau les embarque dans l’initrd au moment du build.
 
-## Ce qui fonctionne (vérifié)
+## Fonctions livrées
 
-Constaté par compilation `make all`, boot QEMU (nographic et GTK), saisie clavier via `sendkey`, et `make test-all`.
+### Noyau, stockage et tâches
 
-### Noyau
+Le noyau configure GDT, IDT, PIC 8259, PIT 100 Hz, i8042 PS/2, PMM/VMM/heap, paging, chargement ELF 32-bit, syscalls et initrd TAR. L’EOI de l’IRQ0 est envoyé **avant** le gestionnaire C : lorsqu’un changement de contexte effectue un `iret` sans revenir dans le stub, IRQ1 clavier n’est donc pas laissée bloquée.
 
-- Boot Multiboot, affichage VGA + logs série
-- GDT, IDT, PIC 8259, PIT (timer), clavier PS/2 (IRQ1)
-- PMM / VMM / heap, paging
-- Initrd format TAR POSIX (`fs/initrd.c`)
-- Chargeur ELF 32-bit
-- Tâches kernel + utilisateur, `jump_to_task()` (iret vers Ring 3) ; `SYS_SPAWN` / `SYS_YIELD` / `SYS_EXEC` basculent depuis le cadre user (pas depuis IRQ0)
-- Syscalls : `SYS_EXIT`, `SYS_PUTC`, `SYS_GETC`, `SYS_PUTS`, `SYS_YIELD`, `SYS_GETS`, `SYS_EXEC`, `SYS_SPAWN`, `SYS_LISTDIR`, `SYS_READFILE`, `SYS_GETPID`, `SYS_PS`, `SYS_KILL`, `SYS_TICKS`, `SYS_MEMINFO`, `SYS_MKDIR`, `SYS_UNLINK`, `SYS_WRITEFILE`, `SYS_STAT`, `SYS_RENAME`, `SYS_COPY`, `SYS_APPEND` et `SYS_GPT2_GENERATE` (ABI : `include/os_syscalls.h`)
-- Overlay RAM (`fs/overlay.c`) : `mkdir` (y compris imbriqué) / `rm` / `cp` (fichier, vers un dossier, **ou arborescence overlay** via `SYS_COPY`) / `mv` (fichier **et** dossier, enfants inclus via `SYS_RENAME`) / `write` / `append` (`SYS_APPEND`, concatène sans écraser) / `touch` (fichier vide) / `echo >` visibles par `ls`/`cat` ; l'initrd reste en lecture seule ; `rmdir` d'un dossier non vide échoue. Après chaque mutation réussie, un snapshot binaire (magic `AIOV`, 32 nœuds, 24 secteurs) est écrit en ATA PIO LBA28 sur le maître IDE primaire (`kernel/ata.c`, ports `0x1F0`, sans IRQ14). Au boot, si IDENTIFY réussit, l'overlay est restauré. Sans disque QEMU, IDENTIFY échoue tout de suite et l'overlay reste volatile.
+L’overlay RAM persistant utilise désormais le format snapshot **V2** : 64 nœuds, chemins de 80 octets, contenu de 384 octets et 64 secteurs ATA PIO. `overlay_restore()` reconnaît également le format V1 afin de restaurer les images de disque déjà créées. Il ne s’agit pas d’un système de fichiers général : ext2, FAT, répertoires sur disque et cache de blocs sont absents.
 
-### Espace utilisateur
+Les appels `spawn`, `yield` et `exec` continuent de changer de contexte depuis le cadre utilisateur de `int 0x80`. En complément, IRQ0 déclenche un round-robin toutes les 20 interruptions uniquement si le cadre interrompu est Ring 3 et si une **autre** tâche utilisateur est `READY`. Cela évite les cadres noyau incomplets et empêche un quantum inutile en mono-tâche. Le contrat QEMU lance `spin`, une boucle utilisateur sans syscall, puis exige une nouvelle commande du shell : la réactivité obtenue démontre la préemption réelle.
 
-- `userspace/shell.c` s'exécute vraiment en Ring 3 (plus de boucle shell simulée dans le kernel)
-- Programmes empaquetés dans l'initrd : `shell`, `fake_ai`, `ai_assistant`, `user_program`, `idle`, `ok`, ainsi que les fichiers de modèle lorsqu'ils sont fournis au build
-- Commande `ai <texte>` appelle `SYS_GPT2_GENERATE` pour le profil local GPT-2 et produit une sortie `[GPT-2 local]` ; le binaire historique `ai_assistant` reste disponible comme compatibilité
+### IA locale, GGUF et BPE
 
-### Clavier (août 2026)
+Le chemin `ai <texte>` appelle `SYS_GPT2_GENERATE` avec le profil local GPT-2. Le chargeur utilise le checkpoint `llm.c v3`, le tokenizer binaire, des activations CPU freestanding, le cache clé/valeur par couche et position, SSE2 et un échantillonnage top-k. Le contexte est limité à 64 jetons ; l’interface indique quatre jetons générés au maximum afin de borner l’exécution. Sous QEMU TCG sans KVM, l’objectif inférieur à une seconde n’est **pas atteint** : les mesures disponibles restent de l’ordre de 7 à 9 secondes pour une courte génération. L’amélioration du cache KV et de SSE2 reste néanmoins substantielle par rapport à l’ancien chemin non optimisé.
 
-Les nombreuses notes "clavier corrigé" des versions 6.0/6.1 étaient **partiellement** vraies (init PS/2, scancodes, buffer). Un bug restait : `schedule()` fait `iret` et ne revient jamais dans le stub IRQ0, donc l'EOI PIC placé *après* `schedule()` n'était pas envoyé. IRQ0 restait in-service et **bloquait IRQ1**.
+AOS-020 ajoute une sonde freestanding **GGUF v3** bornée. Elle valide magic, version, métadonnées, tenseurs et alignement ; elle a été exercée contre un checkpoint GPT-2 réel contenant des tenseurs F32, Q3_K, Q4_K et Q6_K. Les primitives FP16→FP32 et Q8_0×FP32 sont présentes. L’exécution de checkpoints Q3_K/Q4_K/Q6_K ne l’est pas encore, faute des kernels correspondants ; GGUF est donc une validation structurelle, pas un backend d’inférence quantifié.
 
-Correctif actuel :
+Le tokenizer BPE gère maintenant un décodage UTF-8 validé et une classe de lettres couvrant notamment Latin étendu, Grec, Arabe, Hébreu, Devanagari, CJK et Hangul. Les emoji et symboles restent des séparateurs BPE. Cette couverture est volontairement pratique et bornée ; elle n’implémente pas l’intégralité de `\p{L}` Unicode.
 
-1. EOI IRQ0 **avant** `timer_handler` / `schedule()` (`boot/isr_stubs.s`)
-2. Planification seulement si `g_reschedule_needed` (lancement du shell) - plus à chaque tick, ce qui provoquait un page fault une fois l'EOI rétabli (`kernel/timer.c`). `SYS_SPAWN`, `SYS_YIELD` et `SYS_EXEC` appellent `schedule()` depuis le cadre **user** de `int 0x80`. Le parent d'`exec` passe `TASK_WAITING` jusqu'au `SYS_EXIT` de l'enfant.
+### Réseau et fournisseur OpenAI — AOS-025
 
-Après ce correctif : IRQ1 livrée, `help` / `ls` / `sysinfo` / `ai bonjour` reçus par `SYS_GETS`.
+La commande `ai-provider openai` ne réalise **aucun** appel réseau. Elle ne fait que sélectionner un profil, puis `ai` répond explicitement que le transport OpenAI est indisponible. La commande `net-status` expose le contrat réel : aucun pilote Ethernet, ARP, IPv4, DHCP, DNS, TCP ou TLS n’est initialisé ; aucune requête ni secret n’est envoyé depuis l’image.
 
-### Tests
+QEMU sait relier une carte réseau virtuelle ISA ou PCI à un backend hôte, et son backend utilisateur peut fournir DHCP sans privilèges. Cette capacité de l’émulateur ne crée toutefois ni pilote de carte ni pile réseau dans le guest [1]. Une suite réseau réaliste devra livrer, dans cet ordre, un pilote NIC, la réception/transmission Ethernet, ARP, IPv4, UDP/DHCP, DNS, TCP, TLS et seulement ensuite un client HTTP compatible OpenAI. Les clés API doivent rester hors de l’initrd, du dépôt et des logs série.
 
-`make test-all` (binaires 32-bit) :
-
-| Binaire | Tests unitaires |
+| Jalons AOS | Livraison réellement vérifiée |
 |---|---|
-| `test_pmm` | 17/17 |
-| `test_syscall` | 48/48 |
-| `test_task` | 21/21 |
-| `test_overlay` | 6/6 |
-| `test_tokenizer` | 13/13 |
-| `test_gpt2_sample` | 4/4 |
-| `test_shell` | 25/25 |
-| `test_ramfs` | 10/10 |
+| AOS-020 | Sonde GGUF v3, tests de bornes et primitives Q8_0 ; exécution quantifiée non livrée |
+| AOS-021 | BPE UTF-8 avec catégories de lettres Unicode ciblées |
+| AOS-022 | Contrat QEMU versionné : boot, runtime IA, overlay, append et retour au shell |
+| AOS-023 | Snapshot ATA overlay V2 avec restauration V1/V2 |
+| AOS-024 | Préemption IRQ0 Ring 3, quantum 20 ticks, contrat `spawn spin` puis shell réactif |
+| AOS-025 | Stub OpenAI honnête, `net-status` et smoke QEMU ; aucune pile réseau fournie |
 
-Pas de fichiers de tests dans `tests/integration`, `tests/system`, `tests/performance`, `tests/robustness`. Le résumé "Total Tests" de `run_all_tests.sh` additionne les lignes Unity `Tests Run:` des huit binaires (**144** = 17+48+21+6+13+4+25+10).
+## Shell et ABI observables
 
-Dépendance de compilation 32-bit : paquet `gcc-multilib` / `libc6-dev-i386` (en plus de `nasm` et `qemu-system-i386`).
+Le shell Ring 3 propose `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `test`, `grep`, `wc`, `sort`, `head`, `tail`, `ps`, `jobs`, `top`, `spawn`, `yield`, `kill`, `exec`, `mem`, `uptime`, `history`, `alias`, `env`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les opérations de fichiers modifiables passent par l’overlay noyau ; l’initrd demeure en lecture seule. Les programmes empaquetés incluent `shell`, `idle`, `spin`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
 
-## Shell : commandes réelles vs affichées
+L’ABI contient les syscalls 0–22 (`MAX_SYSCALLS = 23`) dont `SYS_APPEND` et `SYS_GPT2_GENERATE`. Le profil local ne nécessite aucun secret ni aucune dépendance réseau à l’exécution.
 
-Les commandes listées par `help` sont branchées dans `execute_builtin_command()`. `ls` / `cat` / `stat` / `test` / `mkdir` / `rmdir` / `rm` / `cp` / `mv` / `write` / `append` / `touch` / `grep` / `wc` / `ps` / `kill` / `getpid` / `mem` / `uptime` parlent au **noyau**. `echo >` et `write`/`append`/`touch` écrivent dans l'overlay noyau. `procsim.c` n'est plus utilisé par `ps`/`kill`.
-
-| Commande | Comportement réel |
-|---|---|
-| `help` | Aide |
-| `ls` / `dir` | Listing **initrd + overlay** (syscall `SYS_LISTDIR`) + fichiers extra du VFS RAM |
-| `mkdir` / `rmdir` / `rm` | Overlay noyau (`SYS_MKDIR` / `SYS_UNLINK`) ; l'initrd ne peut pas être modifié (`PROTECTED`) ; `rmdir` d'un dossier non vide échoue (`NOTEMPTY`) |
-| `cp` / `mv` | `cp` fichier : `SYS_READFILE` + `SYS_WRITEFILE` (y compris initrd -> overlay, et `cp fichier dossier/` joint le nom). `cp` dossier overlay : `SYS_COPY` (enfants dupliqués, source conservée). `mv` : `SYS_RENAME`. L'initrd reste `PROTECTED`. |
-| `cat` / `grep` / `wc` / `sort` / `head` / `tail` | Lecture overlay puis **initrd** (`SYS_READFILE`) puis VFS RAM. `grep` affiche `grep hits N` ; `wc` affiche `wc ok L W C fichier` ; `head`/`tail`/`sort` affichent `head ok N fichier` / `tail ok N fichier` / `sort ok N fichier` |
-| `stat` | Type et taille (`SYS_STAT`) : `stat file hello.txt 35` / `stat dir mydir 0` |
-| `test` / `[` | `test f`/`d`/`e <chemin>` (`SYS_STAT`, aussi `-f`/`-d`/`-e`) ; `[` est un alias (`]` optionnel) : `test ok file hello.txt` / `test ok dir mydir` / `test no zz` |
-| `echo` | Affichage puis `echo ok` ; `echo $?` expand le dernier code ; `echo texte > fichier` écrit dans l'overlay (le `>` n'est pas tapable en CI sendkey) |
-| `write` | `write <fichier> <texte>` -> overlay (`SYS_WRITEFILE`), sans redirection. Succès : `write ok <fichier>` |
-| `append` | `append <fichier> <texte>` -> concatène (`SYS_APPEND`) ; crée le fichier s'il n'existe pas ; un fichier initrd est recopié dans l'overlay (copie sur écriture). Succès : `append ok <fichier>` |
-| `touch` | `touch <fichier>` -> fichier overlay vide (`SYS_WRITEFILE` taille 0). Succès : `touch ok <fichier>` ; un fichier existant n'est pas tronqué |
-| `cd` / `pwd` | Chemin shell ; `cd` accepte overlay/initrd (`SYS_STAT`) **ou** VFS RAM (`cd bin`). Succès : `cd ok <arg>` |
-| `ps` / `jobs` / `top` / `kill` / `spawn` / `yield` / `getpid` | Table des tâches **noyau**. `spawn <prog>` crée une tâche READY puis lui cède le CPU une fois (cadre syscall). `idle` affiche `idle ok` puis boucle sur `SYS_YIELD`. `yield` affiche `yield ok`. pid 0 protégé ; le shell courant refuse `kill` (utiliser `exit`). `getpid` affiche `getpid ok <pid>` (`SYS_GETPID`). `jobs` affiche `jobs ok N` ; `top` affiche `top ok N` |
-| `sysinfo` / `info` / `mem` / `memory` | Pages PMM (`SYS_MEMINFO`) + uptime PIT. `mem` affiche `mem ok <total> <used> <free>` |
-| `uptime` / `date` | Ticks PIT 100 Hz (`SYS_TICKS`) ; `date` reste pédagogique (pas de RTC) et affiche `date ok` |
-| `whoami` / `env` / `export` | Variables d'environnement du shell (`USER=root` par défaut). `whoami` affiche `whoami ok root` ; `export VAR=val` affiche `export ok VAR` ; `env` affiche `env ok N` |
-| `alias` / `unalias` | Table d'alias, expansion avant exécution. Succès : `alias ok <name>` / `unalias ok <name>` |
-| `history` | Historique en mémoire ; `history ok N` |
-| `which` | `which ok builtin <cmd>` ou `which ok bin/<cmd>` |
-| `rc` / `$?` | Dernier code de retour. `rc` affiche `rc ok N` (sendkey sans `$`/`?`). `echo $?` expand `$?` |
-| `clear`/`cls` | Séquence ANSI + bannière |
-| `ai`, `ai-mode`, `ai-help`, `ai-test`, `ai-stats`, `ai-provider`, `ai-model`, `ai-runtime` | `ai <texte>` appelle le moteur GPT-2 local si le modèle est chargé ; la génération est synchrone et bornée. `ai-provider local` est opérationnel ; `ai-provider openai` sélectionne seulement un profil futur. `ai-model list` décrit GPT-2 opérationnel et GGUF futur. Variantes sans tiret pour sendkey : `aimode` / `aihelp` / `aitest` / `aistats`. |
-| `exit` / `quit` / `logout` | Sortie du programme |
-| `reboot` / `shutdown` | Message simulé (QEMU n'est pas arrêté) |
-
-## Intelligence artificielle locale
-
-Le chemin local de `ai <texte>` appelle `SYS_GPT2_GENERATE`. Le noyau charge au boot le checkpoint GPT-2 124M en format `llm.c v3` et le tokenizer binaire depuis l'initrd. L'inférence est écrite en C freestanding ; elle utilise un cache clé/valeur par couche et position. L'entrée est tokenisée en **BPE GPT-2** (fusions par plus petit identifiant de vocabulaire, découpage type regex). La sortie décode les octets bruts tiktoken (espaces, sauts de ligne, UTF-8) sans les remplacer par des espaces. La génération est un **échantillonnage top-k** proche du greedy (k=8, température 0,6). La pénalité de fréquence et l'interdiction du jeton précédent s'appliquent **seulement aux jetons déjà émis**, pas au prompt : cela casse la boucle ` The The The` sans écarter la suite naturelle de la question. Arrêt au bout de 12 jetons, d'un saut de ligne, d'un EOT, ou d'une répétition consécutive. Le RNG est dérivé du prompt (même question → même suite).
-
-La démonstration limite le prompt à 64 jetons et génère jusqu'à 12 jetons (arrêt sur newline ou EOT). L'encodeur BPE couvre le vocabulaire llm.c ; le regex unicode `\p{L}` complet n'est pas reproduit (ASCII + séquences UTF-8). Les poids et le tokenizer ne sont pas distribués dans Git ; sans ces deux fichiers, le moteur local est signalé comme indisponible. `userspace/ai_assistant.c` et `userspace/fake_ai.c` sont conservés comme programmes historiques de compatibilité.
-
-La configuration mesurée avec QEMU sans KVM est de 7,693 s pour `ai hello` et quatre jetons, contre 88,835 s avant l'optimisation SSE2. Le réalignement de pile évite également un défaut de protection générale qui pouvait survenir dans la copie récursive de l'overlay lorsque le compilateur produisait des instructions SSE alignées. Le détail figure dans [kv_cache_performance_report.md](kv_cache_performance_report.md).
-
-## Ce qui n'existe pas dans le code
-
-Malgré la roadmap README v7/v8 et le dossier `US/` :
-
-- Apprentissage fédéré, cloud-edge et les autres services IA décrits par les anciennes spécifications MOHHOS
-- Système de fichiers disque général (ext2/FAT) ; seul un snapshot overlay ATA PIO (32 nœuds, 256 octets par fichier) survit au reboot QEMU
-- Pile TCP/IP, services réseau
-- Interface graphique du OS (seul QEMU affiche du VGA texte)
-- Architecture microkernel, IPC, plugins
-- Réseau P2P, multi-plateforme, économie collaborative
-- Les User Stories MOHHOS : **spécifications**, pas d'implémentation. Recouvrement partiel (PMM, Unity, GPT-2, commande `ai`) : [US/individual_us/INDEX.md](../US/individual_us/INDEX.md). Suite proche du prototype : [US/ai_os_us.md](../US/ai_os_us.md)
-
-Le préemptif "à chaque tick" est volontairement **limité** : après le premier passage au shell, le timer n'appelle plus `schedule()` sauf `g_reschedule_needed` (premier saut vers le shell). `spawn`, `yield` et `exec` basculent depuis le syscall, sans round-robin IRQ0 (stabilité clavier).
-
-## Documents historiques à ne pas prendre pour l'état courant
-
-Ces fichiers restent utiles (chronologie, extraits, hypothèses). Leur conclusion "le shell ne se lance pas" / "crash timer" / "clavier mort à jamais" est **obsolète** :
-
-- `docs/todo.md` (phases 3-4 : blocage userspace) - mis à jour, le diagnostic d'origine est conservé
-- `docs/ANALYSE_ARCHITECTURE.md`, `ANALYSE_PROBLEMES.md`, `ANALYSE_PROBLEMES_SHELL.md`
-- `docs/diagnostic_problemes.md`, `DIAGNOSTIC_SHELL_IA_PROBLEMES.md`
-- Série `CORRECTION_CLAVIER_*.md`, `DIAGNOSTIC_CLAVIER_*.md`, `KEYBOARD_*.md` (correctifs PS/2 toujours pertinents ; le blocage PIC/EOI n'y est en général pas identifié)
-
-## Comment vérifier
+## Vérification reproductible
 
 ```bash
-sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386
-make clean && make all
-make test-all
-make qemu-smoke       # cinq boots QEMU : overlay (#73) + extras + persist + spawn/yield + exec ok
-make gpt2-recovery    # modèle requis : réponse GPT-2, puis validation de `rc`
-make gpt2-benchmark   # modèle requis : mesure avec CPU QEMU Pentium III SSE2
-make gpt2-tests       # modèle requis : reprise shell + benchmark
-make ci               # all + test-all + qemu-smoke (même gate que GitHub Actions)
-make run              # console curses (recommandé en local)
-make run-gui          # fenêtre GTK
+sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386 grub-pc-bin xorriso
+make clean && make all       # noyau, initrd et disque overlay
+make test-all                # 161/161 tests C Unity et robustesse
+make integration-qemu        # contrats AOS-022, AOS-024 et AOS-025
+make iso                     # ISO BIOS/GRUB bootable
+make run                     # console curses
+make run-gui                 # fenêtre GTK
 ```
 
-GitHub Actions (`.github/workflows/ci.yml`) lance ce gate sur chaque push et pull request vers `master`. Le smoke QEMU fait **cinq boots** : un scénario cœur (`ls`, `ai-runtime`, création et copie récursive d'un répertoire overlay, `append`, `cat`, `rc`) puis les extras (`which idle`, `history`, `jobs`, `top`, `env`, `date`, `echo hi`, `rc`, `test no zz`, `aistats`/`aimode`/`aihelp`), une persistance disque (`write k.txt v7ok`, kill QEMU, reboot, `cat k.txt` voit `v7ok`), `spawn idle` (aiguille `idle ok`), `yield`, `kill`, puis `ok` (ELF `exec ok`, retour au shell, `rc ok 0`). Le disque cœur/extras/spawn/exec est remis à zéro entre ces boots. Le scénario cœur attend le retour du shell après chaque commande afin d'éviter les touches fantômes. Timeouts : 120 s cœur + 90 s extras + 180 s persist + 90 s spawn + 90 s exec.
+La suite C exécute 161 assertions de tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` démarre trois machines QEMU séparées : le contrat cœur AOS-022 utilise une image overlay de test isolée, le contrat IRQ0 AOS-024 préempte `spin`, et le smoke AOS-025 vérifie que le profil OpenAI reste bloqué.
 
-En nographic, le shell lit le **clavier PS/2**, pas le port série : la saisie TTY hôte n'atteint souvent pas `SYS_GETS`. Préférer curses/GTK, ou QEMU `sendkey` / moniteur.
+Le build a également produit une ISO GRUB BIOS avec l’initrd GPT-2 local. Avec les actifs disponibles dans l’environnement de vérification, l’ISO est d’environ 481 Mio ; les modèles restent exclus du versionnement.
 
-Prompt actuel du shell : `/ (-.-) :`
+## Absences importantes
+
+AI-OS ne fournit pas de système de fichiers disque général, de pilote réseau, de pile TCP/IP/TLS, de client OpenAI/Ollama effectif, d’UEFI, de gestion multiprocesseur, de GUI native, de microkernel, d’IPC général ni des fonctionnalités de la vision MOHHOS. Les rapports historiques conservés dans `docs/` sont des éléments de chronologie et non la description de l’état courant.
+
+## Références
+
+[1] [QEMU, *Network emulation*](https://www.qemu.org/docs/master/system/devices/net.html)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,11 @@ Depuis la racine du dépôt : `make deps` (script [`scripts/bootstrap-dev.sh`](.
 
 1. [ETAT_REEL.md](ETAT_REEL.md) - **état actuel du code**, y compris GPT-2 local et limites vérifiées
 2. [../US/ai_os_us.md](../US/ai_os_us.md) - user stories du prototype (fait + suite)
-3. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
-4. [kv_cache_performance_report.md](kv_cache_performance_report.md) - cache KV, reprise du shell et mesures de latence
-5. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
-6. [../README.md](../README.md) - compilation, tests, architecture des sources
+3. [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) - sonde GGUF v3 et quantification préparatoire
+4. [aos025_network_stub.md](aos025_network_stub.md) - statut réseau/OpenAI et suite de livraison
+5. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
+6. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
+7. [../README.md](../README.md) - compilation, tests, architecture des sources
 
 Les autres fichiers de ce dossier sont conservés : rapports de debug, chronologie des correctifs clavier, spécifications d'étapes. Beaucoup décrivent un état **intermédiaire** (shell simulé dans le kernel, crash timer, clavier mort). Ils ne sont pas effacés.
 
@@ -20,7 +21,9 @@ Les autres fichiers de ce dossier sont conservés : rapports de debug, chronolog
 | Fichier | Contenu |
 |---|---|
 | [ETAT_REEL.md](ETAT_REEL.md) | État fonctionnel, GPT-2 local et limites vérifiées |
-| [../US/ai_os_us.md](../US/ai_os_us.md) | User stories du prototype (AOS-001…012 faits, suite AOS-020…025) |
+| [../US/ai_os_us.md](../US/ai_os_us.md) | Backlog du prototype, AOS-001…025 et limites restantes |
+| [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) | Sonde GGUF v3, primitives Q8_0 et limites des kernels quantifiés |
+| [aos025_network_stub.md](aos025_network_stub.md) | Stub OpenAI, diagnostic réseau et critères de sortie d’un transport réel |
 | [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) | Préparation des artefacts, construction et démarrage d'une ISO GPT-2 hors ligne |
 | [kv_cache_performance_report.md](kv_cache_performance_report.md) | Cache KV, SSE2, test de reprise du shell et mesures de latence |
 | [baremetal_llm_architecture.md](baremetal_llm_architecture.md) | Architecture de référence et évolutions envisagées pour un LLM bare-metal |

--- a/docs/aos020_gguf_quantization_design.md
+++ b/docs/aos020_gguf_quantization_design.md
@@ -1,0 +1,44 @@
+# AOS-020 — conception du jalon GGUF et quantification
+
+## Constat de départ
+
+Le moteur embarqué lit aujourd’hui un checkpoint **`llm.c v3`** propre à GPT-2 : en-tête fixe de 1 024 octets, suivi des poids FP32 dans un ordre implicite. Les paramètres sont adressés comme des tableaux de `float` par `gpt2_model.c` et `gpt2_infer.c`. Il ne peut donc pas charger un fichier GGUF sans nouveau chargeur, nouvelle table de tenseurs et kernels de produit matrice-vecteur adaptés.
+
+## Sous-ensemble proposé
+
+Le jalon initial doit rester compatible i386 freestanding et observable en QEMU. Il couvre :
+
+| Élément | Jalon AOS-020 |
+|---|---|
+| Conteneur | Lecture et validation **GGUF v3** en little-endian |
+| Architecture acceptée | Métadonnée `general.architecture = gpt2` |
+| Types acceptés au premier jalon | F32 et Q8_0, avec rejet explicite des autres types |
+| Quantification | Blocs Q8_0 de 32 poids, échelle FP16 ou FP32 convertie au chargement |
+| Exécution | Kernel de dot-product Q8_0 × activation FP32 ; chemin FP32 conservé comme référence |
+| Validation | Test de parsing synthétique, test de rejet d’un fichier invalide, benchmark QEMU séparant chargement et génération |
+
+Le format GGUF est auto-descriptif : il fournit le magic `GGUF`, la version, le nombre de tenseurs, les métadonnées et les offsets de données alignés. Sa métadonnée `general.architecture` connaît notamment la valeur `gpt2`. Le type `Q8_0` est un schéma historique par blocs de 32 poids dont la formule est `w = q × block_scale`. Ces propriétés permettent un premier lecteur réduit et sûr sans prétendre supporter toutes les familles de modèles ou tous les K-quants.[1] [2]
+
+## Validation contre un GPT-2 GGUF réel
+
+Un artefact public de référence, [`tensorblock/gpt2-GGUF`](https://huggingface.co/tensorblock/gpt2-GGUF), confirme que GPT-2 est distribué en GGUF avec des quantifications mixtes. L’inspection locale du fichier `gpt2-Q3_K_M.gguf` a relevé : GGUF v3, `general.architecture = gpt2`, 149 tenseurs, alignement implicite de 32 octets, et un mélange de F32, Q3_K, Q4_K et Q6_K. Les noms de tenseurs essentiels sont `token_embd.weight`, `position_embd.weight`, `output_norm.{weight,bias}`, `output.weight` et, pour chaque bloc, `blk.N.attn_{norm,qkv,output}.{weight,bias}` ainsi que `blk.N.ffn_{norm,up,down}.{weight,bias}`. Cette convention est cohérente avec la table de mapping de llama.cpp.[4] [5]
+
+Le premier noyau bare-metal ne doit donc pas prétendre exécuter immédiatement ce fichier Q3_K_M : il doit soit implémenter les kernels Q3_K/Q4_K/Q6_K, soit annoncer explicitement le rejet des types non pris en charge. La compatibilité structurale et les cas de rejet sont néanmoins testables sans charger un modèle de 94 Mio.
+
+## Limite de performance
+
+> La quantification réduit principalement le volume des poids et les accès mémoire. Elle ne garantit pas, à elle seule, une latence inférieure à une seconde sous QEMU TCG : les projections denses, la conversion des blocs et l’émulation restent coûteuses.
+
+L’objectif réaliste du jalon est d’ajouter un chemin vérifiable, de mesurer la mémoire et la latence, puis de documenter honnêtement la différence avec le chemin FP32. Un objectif inférieur à une seconde doit être mesuré sur exécution native ou KVM ; il ne sera pas déclaré atteint sans résultat reproductible.
+
+## Références
+
+[1] [GGUF — spécification ggml](https://github.com/ggml-org/ggml/blob/master/docs/gguf.md)
+
+[2] [Hugging Face — types de quantification GGUF](https://huggingface.co/docs/hub/en/gguf)
+
+[3] [llama.cpp — guide de quantification](https://github.com/ggml-org/llama.cpp/blob/master/tools/quantize/README.md)
+
+[4] [TensorBlock — GPT-2 GGUF](https://huggingface.co/tensorblock/gpt2-GGUF)
+
+[5] [llama.cpp — mapping des noms de tenseurs](https://github.com/ggml-org/llama.cpp/blob/master/gguf-py/gguf/tensor_mapping.py)

--- a/docs/aos025_network_stub.md
+++ b/docs/aos025_network_stub.md
@@ -1,0 +1,66 @@
+# AOS-025 — Stub réseau bare-metal et profil OpenAI
+
+**Statut :** livré comme **stub contrôlé**, pas comme pile réseau.
+
+**Date :** 13 août 2026.
+
+## Objet
+
+Le shell historique possédait un profil `ai-provider openai`, mais le noyau ne disposait d’aucun transport pour réaliser une requête. Cette situation pouvait laisser croire qu’une sélection de fournisseur correspondait à une intégration OpenAI. Le jalon AOS-025 rend ce contrat explicite et testable.
+
+| Élément | État dans cette livraison |
+|---|---|
+| `ai-provider openai` | Sélection de profil seulement |
+| `ai <texte>` avec profil OpenAI | Refus explicite, aucune requête émise |
+| `net-status` | Diagnostic en lecture seule des composants absents |
+| Pilote Ethernet | Absent |
+| ARP / IPv4 / DHCP | Absents |
+| DNS / TCP / TLS / HTTP | Absents |
+| Clé API dans l’image | Interdite |
+
+> Le résultat attendu n’est pas une connexion simulée : l’utilisateur doit voir qu’aucune requête OpenAI ne peut partir du noyau actuel.
+
+## Validation
+
+Le contrat `make qemu-ai-provider` démarre l’image QEMU, vérifie le profil local, appelle `net-status`, sélectionne `openai`, exécute `ai hello` et exige le message d’indisponibilité. Il vérifie donc que le profil est visible sans produire un faux succès réseau.
+
+Le contrat agrégé est :
+
+```bash
+make integration-qemu
+```
+
+Il comprend AOS-022 (boot et shell), AOS-024 (préemption IRQ0) et AOS-025 (profil fournisseur).
+
+## Relation avec QEMU
+
+QEMU peut émuler des cartes réseau ISA ou PCI et les relier à un backend hôte. Le backend utilisateur fournit notamment DHCP sans privilèges et réserve typiquement `10.0.2.2` au routeur virtuel, `10.0.2.3` au DNS et des baux à partir de `10.0.2.15` [1]. Cette fonction appartient à l’émulateur : elle ne donne pas au noyau invité un pilote NIC ou une pile TCP/IP.
+
+Une expérimentation future pourra démarrer QEMU avec un contrôleur ISA compatible NE2000 et le backend utilisateur :
+
+```bash
+qemu-system-i386 \
+  -kernel build/ai_os.bin -initrd my_initrd.tar -m 1024M \
+  -netdev user,id=n0 -device ne2k_isa,netdev=n0
+```
+
+Cette ligne ne doit être utilisée comme test de transport qu’après ajout d’un pilote dans AI-OS ; aujourd’hui, le noyau ne l’initialise pas.
+
+## Critères de sortie d’un client OpenAI effectif
+
+Le passage du stub au client réseau demande une série de jalons séparés, chacun avec tests de bornes et intégration QEMU.
+
+| Ordre | Composant | Critère de sortie |
+|---|---|---|
+| 1 | Pilote NIC | Initialisation, MAC, RX/TX et gestion d’interruptions ou polling |
+| 2 | Ethernet/ARP | Encapsulation et résolution MAC vérifiées en QEMU |
+| 3 | IPv4/UDP/DHCP | Bail DHCP et configuration de route sans configuration statique secrète |
+| 4 | DNS/TCP | Résolution et flux TCP bornés, temporisations et nettoyage |
+| 5 | TLS | Validation de certificat et stockage de confiance minimal documenté |
+| 6 | HTTP OpenAI | Requête sortante explicitement autorisée, secret injecté hors image et effacé après usage |
+
+Aucune clé API ne doit être committée, placée dans l’initrd, écrite dans l’overlay par défaut ou reproduite dans la sortie série. Une future interface de configuration devra demander le consentement de l’utilisateur avant toute requête externe.
+
+## Références
+
+[1] [QEMU, *Network emulation*](https://www.qemu.org/docs/master/system/devices/net.html)

--- a/fs/overlay.c
+++ b/fs/overlay.c
@@ -2,9 +2,9 @@
 #include "initrd.h"
 #include "kernel/ata.h"
 
-#define OV_MAX_NODES 32
-#define OV_PATH_MAX  64
-#define OV_DATA_MAX  256
+#define OV_MAX_NODES OV_SNAP_NODES
+#define OV_PATH_MAX  OV_SNAP_PATH
+#define OV_DATA_MAX  OV_SNAP_DATA
 
 typedef struct {
     int used;
@@ -477,7 +477,7 @@ int overlay_listdir(const char* path, os_dirent_t* out, int start, int max_n) {
     return count;
 }
 
-#define OV_DISK_SECTORS 24
+#define OV_DISK_SECTORS 64
 #define OV_DISK_BYTES   (OV_DISK_SECTORS * 512)
 
 static uint8_t g_ov_disk_buf[OV_DISK_BYTES];
@@ -537,48 +537,68 @@ int overlay_restore(const uint8_t* buf, uint32_t n) {
     uint32_t off;
     uint32_t used_count;
     uint32_t seen;
+    uint32_t version;
+    uint32_t stored_nodes;
+    uint32_t stored_path;
+    uint32_t stored_data;
+    uint32_t stored_node;
+    uint32_t stored_size;
     int i;
 
-    if (!buf || n < OV_SNAP_SIZE) return -1;
-    if (ov_get_u32(buf + 0) != OV_SNAP_MAGIC) return -1;
-    if (ov_get_u32(buf + 4) != OV_SNAP_VERSION) return -1;
-    if (ov_get_u32(buf + 8) != OV_SNAP_NODES) return -1;
+    if (!buf || n < 16U || ov_get_u32(buf + 0) != OV_SNAP_MAGIC) return -1;
+    version = ov_get_u32(buf + 4);
+    if (version == OV_SNAP_VERSION) {
+        stored_nodes = OV_SNAP_NODES;
+        stored_path = OV_SNAP_PATH;
+        stored_data = OV_SNAP_DATA;
+        stored_node = OV_SNAP_NODE;
+        stored_size = OV_SNAP_SIZE;
+    } else if (version == OV_SNAP_V1_VERSION) {
+        stored_nodes = OV_SNAP_V1_NODES;
+        stored_path = OV_SNAP_V1_PATH;
+        stored_data = OV_SNAP_V1_DATA;
+        stored_node = OV_SNAP_V1_NODE;
+        stored_size = OV_SNAP_V1_SIZE;
+    } else {
+        return -1;
+    }
+    if (n < stored_size || ov_get_u32(buf + 8) != stored_nodes) return -1;
 
     used_count = ov_get_u32(buf + 12);
-    if (used_count > OV_SNAP_NODES) return -1;
+    if (used_count > stored_nodes) return -1;
 
     seen = 0;
-    off = 16;
-    for (i = 0; i < OV_MAX_NODES; i++) {
+    off = 16U;
+    for (i = 0; i < (int)stored_nodes; i++) {
         uint8_t used = buf[off];
-        uint8_t is_dir = buf[off + 1];
-        uint32_t size = ov_get_u32(buf + off + 4);
-        if (used > 1 || is_dir > 1) return -1;
+        uint8_t is_dir = buf[off + 1U];
+        uint32_t size = ov_get_u32(buf + off + 4U);
+        if (used > 1U || is_dir > 1U) return -1;
         if (used) {
-            if (size > OV_DATA_MAX) return -1;
+            if (size > stored_data) return -1;
             seen++;
         }
-        off += OV_SNAP_NODE;
+        off += stored_node;
     }
     if (seen != used_count) return -1;
 
     overlay_init();
-    off = 16;
-    for (i = 0; i < OV_MAX_NODES; i++) {
+    off = 16U;
+    for (i = 0; i < (int)stored_nodes && i < OV_MAX_NODES; i++) {
         uint32_t b;
         if (buf[off]) {
             g_ov[i].used = 1;
-            g_ov[i].is_dir = buf[off + 1] ? 1 : 0;
-            g_ov[i].size = ov_get_u32(buf + off + 4);
-            for (b = 0; b < OV_PATH_MAX; b++) {
-                g_ov[i].path[b] = (char)buf[off + 8 + b];
+            g_ov[i].is_dir = buf[off + 1U] ? 1 : 0;
+            g_ov[i].size = ov_get_u32(buf + off + 4U);
+            for (b = 0U; b + 1U < OV_PATH_MAX && b < stored_path; b++) {
+                g_ov[i].path[b] = (char)buf[off + 8U + b];
             }
-            g_ov[i].path[OV_PATH_MAX - 1] = '\0';
-            for (b = 0; b < OV_DATA_MAX; b++) {
-                g_ov[i].data[b] = (char)buf[off + 8 + OV_PATH_MAX + b];
+            g_ov[i].path[OV_PATH_MAX - 1U] = '\0';
+            for (b = 0U; b < g_ov[i].size && b < stored_data; b++) {
+                g_ov[i].data[b] = (char)buf[off + 8U + stored_path + b];
             }
         }
-        off += OV_SNAP_NODE;
+        off += stored_node;
     }
     return 0;
 }

--- a/fs/overlay.h
+++ b/fs/overlay.h
@@ -15,12 +15,20 @@
 #define OV_ERR_PROTECTED -8
 
 #define OV_SNAP_MAGIC   0x564F4941u /* 'AIOV' little-endian */
-#define OV_SNAP_VERSION 1
-#define OV_SNAP_NODES   32
-#define OV_SNAP_PATH    64
-#define OV_SNAP_DATA    256
+#define OV_SNAP_VERSION 2
+#define OV_SNAP_NODES   64
+#define OV_SNAP_PATH    80
+#define OV_SNAP_DATA    384
 #define OV_SNAP_NODE    (1 + 1 + 2 + 4 + OV_SNAP_PATH + OV_SNAP_DATA)
 #define OV_SNAP_SIZE    (16 + OV_SNAP_NODES * OV_SNAP_NODE)
+
+/* Lecture de compatibilite pour les images overlay creees avant AOS-023. */
+#define OV_SNAP_V1_VERSION 1
+#define OV_SNAP_V1_NODES   32
+#define OV_SNAP_V1_PATH    64
+#define OV_SNAP_V1_DATA    256
+#define OV_SNAP_V1_NODE    (1 + 1 + 2 + 4 + OV_SNAP_V1_PATH + OV_SNAP_V1_DATA)
+#define OV_SNAP_V1_SIZE    (16 + OV_SNAP_V1_NODES * OV_SNAP_V1_NODE)
 
 void overlay_init(void);
 int overlay_mkdir(const char* path);

--- a/initrd_content/ai_data.txt
+++ b/initrd_content/ai_data.txt
@@ -1,1 +1,1 @@
-Donnees pour l'intelligence artificielle simulee
+Donnees de demonstration pour l'intelligence artificielle locale

--- a/initrd_content/ai_knowledge.txt
+++ b/initrd_content/ai_knowledge.txt
@@ -1,1 +1,1 @@
-Base de connaissances IA - Version simulation
+Base de connaissances statique - pas de base vectorielle

--- a/initrd_content/config.cfg
+++ b/initrd_content/config.cfg
@@ -1,1 +1,1 @@
-Configuration du systeme AI-OS v5.0
+Configuration du systeme AI-OS v7

--- a/initrd_content/startup.sh
+++ b/initrd_content/startup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo 'Script de demarrage AI-OS v5.0'
+echo 'Script de demarrage AI-OS v7'

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -12,6 +12,7 @@
 #include "../fs/overlay.h"
 #include "ata.h"
 #include "llm/gpt2_model.h"
+#include "llm/gpt2_gguf.h"
 #include "llm/gpt2_infer.h"
 #include "llm/gpt2_tokenizer.h"
 #include "keyboard.h"
@@ -511,6 +512,17 @@ void kmain(uint32_t multiboot_magic, uint32_t multiboot_addr) {
 
             print_string("Initrd trouve ! Initialisation...\n");
             initrd_init(initrd_location, initrd_size);
+            if (initrd_file_exists("models/gpt2.gguf")) {
+                gpt2_gguf_info_t gguf_info;
+                int gguf_status = gpt2_gguf_probe_blob((const uint8_t*)initrd_read_file("models/gpt2.gguf"),
+                                                        initrd_get_file_size("models/gpt2.gguf"), &gguf_info);
+                print_string(gpt2_gguf_probe_status(gguf_status));
+                if (gguf_status == 0 && gguf_info.unsupported_quantized_tensors != 0U) {
+                    print_string("; kernels de quantification a activer\n");
+                } else {
+                    print_string("\n");
+                }
+            }
             if (gpt2_model_load_from_initrd("models/gpt2_124M.bin") == 0) {
                 const gpt2_model_t* gpt2 = gpt2_model_current();
                 print_string("Modele GPT-2 local charge depuis l'initrd.\n");

--- a/kernel/llm/gpt2_gguf.c
+++ b/kernel/llm/gpt2_gguf.c
@@ -1,0 +1,218 @@
+#include "gpt2_gguf.h"
+
+#define GGUF_DEFAULT_ALIGNMENT 32U
+#define GGUF_MAX_TENSORS       512U
+#define GGUF_MAX_METADATA      512U
+#define GGUF_MAX_ARRAY_ELEMENTS 100000U
+#define GGUF_MAX_DIMS          4U
+#define GGUF_MAX_STRING        65535U
+
+static int gguf_range(uint32_t offset, uint32_t count, uint32_t size) {
+    return offset <= size && count <= size - offset;
+}
+
+static int gguf_read_u32(const uint8_t* blob, uint32_t size, uint32_t* offset, uint32_t* out) {
+    uint32_t at = *offset;
+    if (!gguf_range(at, 4U, size)) return -1;
+    *out = (uint32_t)blob[at] |
+           ((uint32_t)blob[at + 1U] << 8) |
+           ((uint32_t)blob[at + 2U] << 16) |
+           ((uint32_t)blob[at + 3U] << 24);
+    *offset = at + 4U;
+    return 0;
+}
+
+static int gguf_read_u64(const uint8_t* blob, uint32_t size, uint32_t* offset, uint64_t* out) {
+    uint32_t lo;
+    uint32_t hi;
+    if (gguf_read_u32(blob, size, offset, &lo) != 0 ||
+        gguf_read_u32(blob, size, offset, &hi) != 0) return -1;
+    *out = (uint64_t)lo | ((uint64_t)hi << 32);
+    return 0;
+}
+
+static int gguf_skip(const uint8_t* blob, uint32_t size, uint32_t* offset, uint32_t count) {
+    (void)blob;
+    if (!gguf_range(*offset, count, size)) return -1;
+    *offset += count;
+    return 0;
+}
+
+static int gguf_read_string(const uint8_t* blob, uint32_t size, uint32_t* offset,
+                            const uint8_t** text, uint32_t* length) {
+    uint64_t length64;
+    if (gguf_read_u64(blob, size, offset, &length64) != 0 ||
+        length64 > GGUF_MAX_STRING || length64 > 0xffffffffULL) return -1;
+    if (!gguf_range(*offset, (uint32_t)length64, size)) return -1;
+    if (text) *text = blob + *offset;
+    if (length) *length = (uint32_t)length64;
+    *offset += (uint32_t)length64;
+    return 0;
+}
+
+static int gguf_key_equals(const uint8_t* key, uint32_t key_len, const char* expected) {
+    uint32_t i = 0;
+    while (expected[i]) {
+        if (i >= key_len || key[i] != (uint8_t)expected[i]) return 0;
+        i++;
+    }
+    return i == key_len;
+}
+
+static int gguf_value_size(uint32_t type, uint32_t* out) {
+    switch (type) {
+        case GPT2_GGUF_VALUE_UINT8:
+        case GPT2_GGUF_VALUE_INT8:
+        case GPT2_GGUF_VALUE_BOOL: *out = 1U; return 0;
+        case GPT2_GGUF_VALUE_UINT16:
+        case GPT2_GGUF_VALUE_INT16: *out = 2U; return 0;
+        case GPT2_GGUF_VALUE_UINT32:
+        case GPT2_GGUF_VALUE_INT32:
+        case GPT2_GGUF_VALUE_FLOAT32: *out = 4U; return 0;
+        case GPT2_GGUF_VALUE_UINT64:
+        case GPT2_GGUF_VALUE_INT64:
+        case GPT2_GGUF_VALUE_FLOAT64: *out = 8U; return 0;
+        default: return -1;
+    }
+}
+
+static int gguf_skip_value(const uint8_t* blob, uint32_t size, uint32_t* offset,
+                           uint32_t type, uint32_t depth) {
+    uint32_t item_size;
+    uint32_t child_type;
+    uint64_t count;
+    if (depth > 4U) return -1;
+    if (type == GPT2_GGUF_VALUE_STRING) return gguf_read_string(blob, size, offset, 0, 0);
+    if (type == GPT2_GGUF_VALUE_ARRAY) {
+        if (gguf_read_u32(blob, size, offset, &child_type) != 0 ||
+            gguf_read_u64(blob, size, offset, &count) != 0 || count > GGUF_MAX_ARRAY_ELEMENTS) return -1;
+        while (count-- > 0U) {
+            if (gguf_skip_value(blob, size, offset, child_type, depth + 1U) != 0) return -1;
+        }
+        return 0;
+    }
+    if (gguf_value_size(type, &item_size) != 0) return -1;
+    return gguf_skip(blob, size, offset, item_size);
+}
+
+static int gguf_read_alignment_value(const uint8_t* blob, uint32_t size, uint32_t* offset,
+                                     uint32_t type, uint32_t* alignment) {
+    uint32_t value;
+    if (type != GPT2_GGUF_VALUE_UINT32 || gguf_read_u32(blob, size, offset, &value) != 0) return -1;
+    if (value < 8U || (value & 7U) != 0U) return -1;
+    *alignment = value;
+    return 0;
+}
+
+static int gguf_is_gpt2_value(const uint8_t* blob, uint32_t size, uint32_t* offset,
+                               uint32_t type, uint8_t* is_gpt2) {
+    const uint8_t* text;
+    uint32_t length;
+    static const char gpt2[] = "gpt2";
+    uint32_t i;
+    if (type != GPT2_GGUF_VALUE_STRING ||
+        gguf_read_string(blob, size, offset, &text, &length) != 0 || length != 4U) return -1;
+    for (i = 0; i < 4U; i++) if (text[i] != (uint8_t)gpt2[i]) return -1;
+    *is_gpt2 = 1U;
+    return 0;
+}
+
+static int gguf_align(uint32_t offset, uint32_t alignment, uint32_t* out) {
+    uint32_t remainder;
+    if (alignment == 0U) return -1;
+    remainder = offset % alignment;
+    if (remainder != 0U && offset > 0xffffffffU - (alignment - remainder)) return -1;
+    *out = remainder ? offset + (alignment - remainder) : offset;
+    return 0;
+}
+
+int gpt2_gguf_probe_blob(const uint8_t* blob, uint32_t blob_size, gpt2_gguf_info_t* out) {
+    uint32_t offset = 0;
+    uint32_t magic;
+    uint32_t version;
+    uint64_t tensor_count64;
+    uint64_t metadata_count64;
+    uint32_t tensor_count;
+    uint32_t metadata_count;
+    uint32_t i;
+    gpt2_gguf_info_t info;
+
+    if (!blob || !out) return -1;
+    info.version = 0U;
+    info.tensor_count = 0U;
+    info.metadata_count = 0U;
+    info.alignment = GGUF_DEFAULT_ALIGNMENT;
+    info.tensor_data_offset = 0U;
+    info.f32_tensors = 0U;
+    info.q8_0_tensors = 0U;
+    info.unsupported_quantized_tensors = 0U;
+    info.is_gpt2 = 0U;
+    info.is_valid = 0U;
+
+    if (gguf_read_u32(blob, blob_size, &offset, &magic) != 0 || magic != GPT2_GGUF_MAGIC ||
+        gguf_read_u32(blob, blob_size, &offset, &version) != 0 || version != GPT2_GGUF_VERSION ||
+        gguf_read_u64(blob, blob_size, &offset, &tensor_count64) != 0 ||
+        gguf_read_u64(blob, blob_size, &offset, &metadata_count64) != 0 ||
+        tensor_count64 > GGUF_MAX_TENSORS || metadata_count64 > GGUF_MAX_METADATA) return -2;
+
+    tensor_count = (uint32_t)tensor_count64;
+    metadata_count = (uint32_t)metadata_count64;
+    info.version = version;
+    info.tensor_count = tensor_count;
+    info.metadata_count = metadata_count;
+
+    for (i = 0U; i < metadata_count; i++) {
+        const uint8_t* key;
+        uint32_t key_len;
+        uint32_t type;
+        if (gguf_read_string(blob, blob_size, &offset, &key, &key_len) != 0 ||
+            gguf_read_u32(blob, blob_size, &offset, &type) != 0) return -3;
+        if (gguf_key_equals(key, key_len, "general.architecture")) {
+            if (gguf_is_gpt2_value(blob, blob_size, &offset, type, &info.is_gpt2) != 0) return -4;
+        } else if (gguf_key_equals(key, key_len, "general.alignment")) {
+            if (gguf_read_alignment_value(blob, blob_size, &offset, type, &info.alignment) != 0) return -5;
+        } else if (gguf_skip_value(blob, blob_size, &offset, type, 0U) != 0) return -6;
+    }
+
+    for (i = 0U; i < tensor_count; i++) {
+        uint32_t dimensions;
+        uint32_t type;
+        uint64_t data_offset;
+        uint32_t j;
+        if (gguf_read_string(blob, blob_size, &offset, 0, 0) != 0 ||
+            gguf_read_u32(blob, blob_size, &offset, &dimensions) != 0 ||
+            dimensions == 0U || dimensions > GGUF_MAX_DIMS) return -7;
+        for (j = 0U; j < dimensions; j++) {
+            uint64_t dimension;
+            if (gguf_read_u64(blob, blob_size, &offset, &dimension) != 0 || dimension == 0U) return -8;
+        }
+        if (gguf_read_u32(blob, blob_size, &offset, &type) != 0 ||
+            gguf_read_u64(blob, blob_size, &offset, &data_offset) != 0 ||
+            data_offset > 0xffffffffULL || ((uint32_t)data_offset % info.alignment) != 0U) return -9;
+        if (type == GPT2_GGUF_TENSOR_F32) info.f32_tensors++;
+        else if (type == GPT2_GGUF_TENSOR_Q8_0) info.q8_0_tensors++;
+        else if (type != GPT2_GGUF_TENSOR_F16) info.unsupported_quantized_tensors++;
+    }
+
+    if (!info.is_gpt2 || gguf_align(offset, info.alignment, &info.tensor_data_offset) != 0 ||
+        info.tensor_data_offset > blob_size) return -10;
+    info.is_valid = 1U;
+    *out = info;
+    return 0;
+}
+
+const char* gpt2_gguf_probe_status(int status) {
+    switch (status) {
+        case 0: return "GGUF GPT-2 v3 valide (execution quantifiee non activee)";
+        case -1: return "GGUF: argument invalide";
+        case -2: return "GGUF: magic, version ou compte invalide";
+        case -3: return "GGUF: metadonnees tronquees";
+        case -4: return "GGUF: architecture GPT-2 absente";
+        case -5: return "GGUF: alignement invalide";
+        case -6: return "GGUF: type de metadonnee invalide";
+        case -7: return "GGUF: descripteur de tenseur invalide";
+        case -8: return "GGUF: dimension de tenseur invalide";
+        case -9: return "GGUF: type ou offset de tenseur invalide";
+        default: return "GGUF: donnees invalides";
+    }
+}

--- a/kernel/llm/gpt2_gguf.h
+++ b/kernel/llm/gpt2_gguf.h
@@ -1,0 +1,55 @@
+#ifndef AIOS_GPT2_GGUF_H
+#define AIOS_GPT2_GGUF_H
+
+#include <stdint.h>
+
+/* GGUF v3 is little-endian. The reader intentionally accepts only the
+ * structural envelope: execution requires explicit quantization kernels. */
+#define GPT2_GGUF_MAGIC   0x46554747U /* bytes: G G U F */
+#define GPT2_GGUF_VERSION 3U
+
+#define GPT2_GGUF_VALUE_UINT8    0U
+#define GPT2_GGUF_VALUE_INT8     1U
+#define GPT2_GGUF_VALUE_UINT16   2U
+#define GPT2_GGUF_VALUE_INT16    3U
+#define GPT2_GGUF_VALUE_UINT32   4U
+#define GPT2_GGUF_VALUE_INT32    5U
+#define GPT2_GGUF_VALUE_FLOAT32  6U
+#define GPT2_GGUF_VALUE_BOOL     7U
+#define GPT2_GGUF_VALUE_STRING   8U
+#define GPT2_GGUF_VALUE_ARRAY    9U
+#define GPT2_GGUF_VALUE_UINT64  10U
+#define GPT2_GGUF_VALUE_INT64   11U
+#define GPT2_GGUF_VALUE_FLOAT64 12U
+
+#define GPT2_GGUF_TENSOR_F32  0U
+#define GPT2_GGUF_TENSOR_F16  1U
+#define GPT2_GGUF_TENSOR_Q4_0 2U
+#define GPT2_GGUF_TENSOR_Q8_0 8U
+#define GPT2_GGUF_TENSOR_Q3_K 11U
+#define GPT2_GGUF_TENSOR_Q4_K 12U
+#define GPT2_GGUF_TENSOR_Q6_K 14U
+
+/* A structural report. No pointer from an untrusted blob is exposed. */
+typedef struct {
+    uint32_t version;
+    uint32_t tensor_count;
+    uint32_t metadata_count;
+    uint32_t alignment;
+    uint32_t tensor_data_offset;
+    uint32_t f32_tensors;
+    uint32_t q8_0_tensors;
+    uint32_t unsupported_quantized_tensors;
+    uint8_t is_gpt2;
+    uint8_t is_valid;
+} gpt2_gguf_info_t;
+
+/* Returns 0 only for a bounded, structurally valid GPT-2 GGUF v3 blob.
+ * The function does not allocate and does not execute model data. */
+int gpt2_gguf_probe_blob(const uint8_t* blob, uint32_t blob_size,
+                         gpt2_gguf_info_t* out);
+
+/* Human-readable status for `ai-runtime` and diagnostics. */
+const char* gpt2_gguf_probe_status(int status);
+
+#endif

--- a/kernel/llm/gpt2_quant.c
+++ b/kernel/llm/gpt2_quant.c
@@ -1,0 +1,51 @@
+#include "gpt2_quant.h"
+
+float gpt2_f16_to_f32(uint16_t bits) {
+    union { uint32_t u; float f; } out;
+    uint32_t sign = ((uint32_t)bits & 0x8000U) << 16;
+    uint32_t exponent = ((uint32_t)bits >> 10) & 0x1fU;
+    uint32_t fraction = (uint32_t)bits & 0x03ffU;
+
+    if (exponent == 0U) {
+        if (fraction == 0U) {
+            out.u = sign;
+            return out.f;
+        }
+        /* Normalize the binary16 subnormal before changing exponent bias. */
+        while ((fraction & 0x0400U) == 0U) {
+            fraction <<= 1;
+            exponent--;
+        }
+        fraction &= 0x03ffU;
+        exponent = 1U;
+    } else if (exponent == 31U) {
+        out.u = sign | 0x7f800000U | (fraction << 13);
+        return out.f;
+    }
+
+    exponent = exponent + (127U - 15U);
+    out.u = sign | (exponent << 23) | (fraction << 13);
+    return out.f;
+}
+
+float gpt2_q8_0_dot_f32(const float* input, const uint8_t* q8_blocks, uint32_t count) {
+    uint32_t block;
+    uint32_t blocks;
+    float result = 0.0f;
+
+    if (!input || !q8_blocks || count == 0U || (count % GPT2_Q8_0_BLOCK_SIZE) != 0U) return 0.0f;
+    blocks = count / GPT2_Q8_0_BLOCK_SIZE;
+    for (block = 0U; block < blocks; block++) {
+        const uint8_t* raw = q8_blocks + block * GPT2_Q8_0_BLOCK_BYTES;
+        uint16_t scale_bits = (uint16_t)raw[0] | ((uint16_t)raw[1] << 8);
+        float scale = gpt2_f16_to_f32(scale_bits);
+        float sum = 0.0f;
+        uint32_t i;
+        for (i = 0U; i < GPT2_Q8_0_BLOCK_SIZE; i++) {
+            int8_t quant = (int8_t)raw[2U + i];
+            sum += input[block * GPT2_Q8_0_BLOCK_SIZE + i] * (float)quant;
+        }
+        result += scale * sum;
+    }
+    return result;
+}

--- a/kernel/llm/gpt2_quant.h
+++ b/kernel/llm/gpt2_quant.h
@@ -1,0 +1,19 @@
+#ifndef AIOS_GPT2_QUANT_H
+#define AIOS_GPT2_QUANT_H
+
+#include <stdint.h>
+
+/* GGML Q8_0: one IEEE-754 binary16 scale and 32 signed quantized values. */
+#define GPT2_Q8_0_BLOCK_SIZE 32U
+#define GPT2_Q8_0_BLOCK_BYTES 34U
+
+/* Convert an IEEE-754 binary16 bit pattern to FP32 without a libc dependency. */
+float gpt2_f16_to_f32(uint16_t bits);
+
+/*
+ * Dot product of a FP32 activation vector and a contiguous GGML Q8_0 row.
+ * `count` must be a non-zero multiple of 32. Returns 0.0f for invalid input.
+ */
+float gpt2_q8_0_dot_f32(const float* input, const uint8_t* q8_blocks, uint32_t count);
+
+#endif

--- a/kernel/llm/gpt2_tokenizer.c
+++ b/kernel/llm/gpt2_tokenizer.c
@@ -74,10 +74,6 @@ static uint32_t gpt2_lookup_token(const uint8_t* bytes, uint32_t length) {
     return GPT2_HASH_EMPTY;
 }
 
-static int gpt2_is_ascii_letter(uint8_t c) {
-    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
-}
-
 static int gpt2_is_digit(uint8_t c) {
     return c >= '0' && c <= '9';
 }
@@ -86,8 +82,76 @@ static int gpt2_is_space(uint8_t c) {
     return c == ' ' || c == '\t' || c == '\n' || c == '\r';
 }
 
-static int gpt2_is_letter(uint8_t c) {
-    return gpt2_is_ascii_letter(c) || c >= 0xC0U;
+static int gpt2_utf8_decode(const uint8_t* text, uint32_t remaining,
+                            uint32_t* codepoint, uint32_t* width) {
+    uint8_t a;
+    uint8_t b;
+    uint8_t c;
+    uint8_t d;
+    if (!text || remaining == 0U || !codepoint || !width) return 0;
+    a = text[0];
+    if (a < 0x80U) {
+        *codepoint = a;
+        *width = 1U;
+        return 1;
+    }
+    if (a >= 0xC2U && a <= 0xDFU && remaining >= 2U) {
+        b = text[1];
+        if ((b & 0xC0U) != 0x80U) return 0;
+        *codepoint = ((uint32_t)(a & 0x1FU) << 6) | (uint32_t)(b & 0x3FU);
+        *width = 2U;
+        return 1;
+    }
+    if (a >= 0xE0U && a <= 0xEFU && remaining >= 3U) {
+        b = text[1];
+        c = text[2];
+        if ((b & 0xC0U) != 0x80U || (c & 0xC0U) != 0x80U ||
+            (a == 0xE0U && b < 0xA0U) || (a == 0xEDU && b >= 0xA0U)) return 0;
+        *codepoint = ((uint32_t)(a & 0x0FU) << 12) |
+                     ((uint32_t)(b & 0x3FU) << 6) | (uint32_t)(c & 0x3FU);
+        *width = 3U;
+        return 1;
+    }
+    if (a >= 0xF0U && a <= 0xF4U && remaining >= 4U) {
+        b = text[1];
+        c = text[2];
+        d = text[3];
+        if ((b & 0xC0U) != 0x80U || (c & 0xC0U) != 0x80U || (d & 0xC0U) != 0x80U ||
+            (a == 0xF0U && b < 0x90U) || (a == 0xF4U && b > 0x8FU)) return 0;
+        *codepoint = ((uint32_t)(a & 0x07U) << 18) |
+                     ((uint32_t)(b & 0x3FU) << 12) |
+                     ((uint32_t)(c & 0x3FU) << 6) | (uint32_t)(d & 0x3FU);
+        *width = 4U;
+        return 1;
+    }
+    return 0;
+}
+
+/* Sous-ensemble sans table externe de \p{L}, couvrant les écritures courantes
+ * des prompts GPT-2. Les séparateurs, chiffres, marques et emoji restent hors
+ * de la classe lettre comme dans le découpage regex de référence. */
+static int gpt2_is_unicode_letter(uint32_t cp) {
+    if ((cp >= 'A' && cp <= 'Z') || (cp >= 'a' && cp <= 'z')) return 1;
+    if ((cp >= 0x00C0U && cp <= 0x00D6U) || (cp >= 0x00D8U && cp <= 0x00F6U) ||
+        (cp >= 0x00F8U && cp <= 0x02C1U) || (cp >= 0x02C6U && cp <= 0x02D1U) ||
+        (cp >= 0x02E0U && cp <= 0x02E4U) || (cp >= 0x0370U && cp <= 0x052FU) ||
+        (cp >= 0x0531U && cp <= 0x0588U) || (cp >= 0x05D0U && cp <= 0x05EAU) ||
+        (cp >= 0x05F0U && cp <= 0x05F2U) || (cp >= 0x0620U && cp <= 0x063FU) ||
+        (cp >= 0x0641U && cp <= 0x064AU) || (cp >= 0x066EU && cp <= 0x066FU) ||
+        (cp >= 0x0671U && cp <= 0x06D3U) || (cp >= 0x0904U && cp <= 0x0939U) ||
+        (cp >= 0x3041U && cp <= 0x3096U) || (cp >= 0x30A1U && cp <= 0x30FAU) ||
+        (cp >= 0x3400U && cp <= 0x4DBFU) || (cp >= 0x4E00U && cp <= 0x9FFFU) ||
+        (cp >= 0xAC00U && cp <= 0xD7A3U)) return 1;
+    return 0;
+}
+
+static int gpt2_is_letter_at(const uint8_t* text, uint32_t length, uint32_t pos,
+                             uint32_t* width) {
+    uint32_t cp;
+    uint32_t local_width;
+    if (pos >= length || !gpt2_utf8_decode(text + pos, length - pos, &cp, &local_width)) return 0;
+    if (width) *width = local_width;
+    return gpt2_is_unicode_letter(cp);
 }
 
 static int gpt2_match_ci(const uint8_t* text, uint32_t remaining, const char* lit) {
@@ -129,17 +193,13 @@ static uint32_t gpt2_next_chunk(const uint8_t* text, uint32_t length, uint32_t p
 
     start = pos;
     if (text[pos] == ' ' && pos + 1U < length &&
-        (gpt2_is_letter(text[pos + 1U]) || gpt2_is_digit(text[pos + 1U]) ||
+        (gpt2_is_letter_at(text, length, pos + 1U, 0) || gpt2_is_digit(text[pos + 1U]) ||
          !gpt2_is_space(text[pos + 1U]))) {
         pos++;
     }
-    if (pos < length && gpt2_is_letter(text[pos])) {
-        pos++;
-        while (pos < length && (gpt2_is_ascii_letter(text[pos]) ||
-                                (text[pos] >= 0x80U && text[pos] <= 0xBFU) ||
-                                text[pos] >= 0xC0U)) {
-            pos++;
-        }
+    if (pos < length && gpt2_is_letter_at(text, length, pos, 0)) {
+        uint32_t letter_width;
+        while (pos < length && gpt2_is_letter_at(text, length, pos, &letter_width)) pos += letter_width;
         return pos - start;
     }
     if (pos < length && gpt2_is_digit(text[pos])) {
@@ -147,12 +207,16 @@ static uint32_t gpt2_next_chunk(const uint8_t* text, uint32_t length, uint32_t p
         while (pos < length && gpt2_is_digit(text[pos])) pos++;
         return pos - start;
     }
-    if (pos < length && !gpt2_is_space(text[pos]) && !gpt2_is_letter(text[pos]) &&
+    if (pos < length && !gpt2_is_space(text[pos]) && !gpt2_is_letter_at(text, length, pos, 0) &&
         !gpt2_is_digit(text[pos])) {
-        pos++;
-        while (pos < length && !gpt2_is_space(text[pos]) && !gpt2_is_letter(text[pos]) &&
-               !gpt2_is_digit(text[pos])) {
-            pos++;
+        uint32_t punct_width = 1U;
+        uint32_t ignored_cp;
+        if (gpt2_utf8_decode(text + pos, length - pos, &ignored_cp, &punct_width)) pos += punct_width;
+        else pos++;
+        while (pos < length && !gpt2_is_space(text[pos]) &&
+               !gpt2_is_letter_at(text, length, pos, 0) && !gpt2_is_digit(text[pos])) {
+            if (gpt2_utf8_decode(text + pos, length - pos, &ignored_cp, &punct_width)) pos += punct_width;
+            else pos++;
         }
         return pos - start;
     }

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -390,6 +390,17 @@ task_t* get_task_by_id(int id) {
     return NULL;
 }
 
+int task_has_other_ready_user(void) {
+    task_t* t;
+    if (!task_queue || !current_task) return 0;
+    t = current_task->next;
+    while (t && t != current_task) {
+        if (t->type == TASK_TYPE_USER && t->state == TASK_READY) return 1;
+        t = t->next;
+    }
+    return 0;
+}
+
 int get_task_count(void) {
     int n = 0;
     task_t* t;

--- a/kernel/task/task.h
+++ b/kernel/task/task.h
@@ -68,7 +68,9 @@ task_t* get_task_by_id(int id);
 void remove_task(task_t* task);
 void add_task_to_queue(task_t* task);
 int get_task_count();
-task_t* find_task_waiting_for_input();
+task_t* find_task_waiting_for_input(void);
+/* Vrai lorsqu’une autre tâche Ring 3 prête peut recevoir un quantum IRQ0. */
+int task_has_other_ready_user(void);
 int task_kill(int pid);
 int task_fill_ps(os_proc_t* out, int max_n);
 void task_wake_waiter(task_t* child);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -12,6 +12,15 @@ uint32_t timer_ticks = 0;
 uint32_t software_timer_counter = 0;
 int timer_mode = 0; // 0 = logiciel, 1 = matériel
 
+/* La préemption IRQ0 est limitée aux retours Ring 3 : un cadre noyau issu d’un
+ * syscall ne possède pas l’ESP/SS utilisateur requis par jump_to_task(). */
+#define TIMER_PREEMPT_QUANTUM 20U
+static uint32_t timer_last_preempt_tick;
+
+static int timer_user_frame(const cpu_state_t* cpu) {
+    return cpu && (cpu->cs & 3U) == 3U && (cpu->ss & 3U) == 3U;
+}
+
 // Timer logiciel de secours
 void software_timer_tick() {
     software_timer_counter++;
@@ -56,11 +65,18 @@ void timer_handler(cpu_state_t* cpu) {
         print_string_serial("\n");
     }
     
-    // Un seul changement de contexte quand il est demandé (lancement du shell).
-    // exec/spawn/yield basculent depuis int 0x80, pas depuis IRQ0 :
-    // un schedule() pendant un syscall (cadre noyau sans SS/ESP user) page-fault.
+    // Changement explicite existant (lancement du shell / yield coopératif).
     if (g_reschedule_needed) {
         g_reschedule_needed = 0;
+        schedule(cpu);
+    }
+
+    /* Préemption matérielle : uniquement entre deux cadres utilisateur valides.
+     * Le garde Ring 3 évite le basculement depuis un syscall ou une IRQ noyau. */
+    if (timer_user_frame(cpu) && current_task && current_task->type == TASK_TYPE_USER &&
+        task_has_other_ready_user() &&
+        timer_ticks - timer_last_preempt_tick >= TIMER_PREEMPT_QUANTUM) {
+        timer_last_preempt_tick = timer_ticks;
         schedule(cpu);
     }
 }
@@ -81,6 +97,7 @@ void timer_update() {
 // Initialise le timer matériel (PIT) pour le scheduling préemptif
 void timer_init(uint32_t frequency) {
     timer_mode = 1; // Mode matériel
+    timer_last_preempt_tick = 0U;
 
     // Le PIT (Programmable Interval Timer) utilise une fréquence de base de 1.193182 MHz
     uint32_t divisor = 1193182 / frequency;

--- a/scripts/inspect_gguf.py
+++ b/scripts/inspect_gguf.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Minimal GGUF v3 inspector used only to design the freestanding AOS-020 loader."""
+import struct
+import sys
+from collections import Counter
+
+TYPE_NAMES = {
+    0: "UINT8", 1: "INT8", 2: "UINT16", 3: "INT16", 4: "UINT32", 5: "INT32",
+    6: "FLOAT32", 7: "BOOL", 8: "STRING", 9: "ARRAY", 10: "UINT64", 11: "INT64", 12: "FLOAT64",
+}
+TENSOR_TYPES = {
+    0: "F32", 1: "F16", 2: "Q4_0", 3: "Q4_1", 6: "Q5_0", 7: "Q5_1", 8: "Q8_0",
+    10: "Q2_K", 11: "Q3_K", 12: "Q4_K", 13: "Q5_K", 14: "Q6_K", 15: "Q8_K",
+}
+
+
+def read_exact(handle, count):
+    data = handle.read(count)
+    if len(data) != count:
+        raise ValueError("truncated GGUF")
+    return data
+
+
+def u32(handle):
+    return struct.unpack("<I", read_exact(handle, 4))[0]
+
+
+def u64(handle):
+    return struct.unpack("<Q", read_exact(handle, 8))[0]
+
+
+def ggstr(handle):
+    return read_exact(handle, u64(handle)).decode("utf-8", "replace")
+
+
+def skip_value(handle, value_type):
+    sizes = {0: 1, 1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 1, 10: 8, 11: 8, 12: 8}
+    if value_type == 8:
+        return ggstr(handle)
+    if value_type == 9:
+        element_type = u32(handle)
+        count = u64(handle)
+        for _ in range(count):
+            skip_value(handle, element_type)
+        return None
+    if value_type not in sizes:
+        raise ValueError("unsupported metadata type %d" % value_type)
+    return read_exact(handle, sizes[value_type])
+
+
+def main(path):
+    with open(path, "rb") as handle:
+        magic = read_exact(handle, 4)
+        version = u32(handle)
+        tensors = u64(handle)
+        metadata_count = u64(handle)
+        print("magic=%s version=%d tensors=%d metadata=%d" % (magic.decode("ascii", "replace"), version, tensors, metadata_count))
+        metadata = {}
+        for _ in range(metadata_count):
+            key = ggstr(handle)
+            kind = u32(handle)
+            value = skip_value(handle, kind)
+            if kind == 8:
+                metadata[key] = value
+        print("architecture=%s" % metadata.get("general.architecture"))
+        print("alignment=%s" % metadata.get("general.alignment", "32(default)"))
+        types = Counter()
+        names = []
+        for _ in range(tensors):
+            name = ggstr(handle)
+            dims = u32(handle)
+            shape = tuple(u64(handle) for _ in range(dims))
+            tensor_type = u32(handle)
+            offset = u64(handle)
+            types[TENSOR_TYPES.get(tensor_type, str(tensor_type))] += 1
+            names.append((name, shape, TENSOR_TYPES.get(tensor_type, str(tensor_type)), offset))
+        print("tensor_types=%s" % dict(types))
+        for name, shape, tensor_type, offset in names[:20]:
+            print("tensor name=%s shape=%s type=%s offset=%d" % (name, shape, tensor_type, offset))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: inspect_gguf.py model.gguf")
+    main(sys.argv[1])

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -92,6 +92,21 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_sample: $(UNIT_DIR)/kernel/test_gpt2_s
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_gguf: $(UNIT_DIR)/kernel/test_gpt2_gguf.c ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_quant: $(UNIT_DIR)/kernel/test_gpt2_quant.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+$(BUILD_DIR)/$(ROBUSTNESS_DIR)/test_gpt2_gguf_bounds: $(ROBUSTNESS_DIR)/test_gpt2_gguf_bounds.c ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled robustness test: $(notdir $@)"
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_%: $(UNIT_DIR)/kernel/test_%.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< $(FRAMEWORK_SOURCES)

--- a/tests/integration/test_qemu_core_contract.py
+++ b/tests/integration/test_qemu_core_contract.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""AOS-022 integration contract: a built AI-OS image must pass the QEMU core shell scenario."""
+import os
+import subprocess
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SCENARIO = os.path.join(ROOT, "tests", "scripts", "ci_qemu_core_smoke.py")
+
+
+def main():
+    if not os.path.isfile(os.path.join(ROOT, "build", "ai_os.bin")):
+        raise RuntimeError("missing kernel artefact; run make all first")
+    if not os.path.isfile(os.path.join(ROOT, "my_initrd.tar")):
+        raise RuntimeError("missing initrd artefact; run make all first")
+    result = subprocess.run([sys.executable, SCENARIO], cwd=ROOT)
+    if result.returncode != 0:
+        raise RuntimeError("QEMU core shell contract failed")
+    print("AOS-022 integration contract passed: boot, ai-runtime, overlay copy, append and shell return.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print("AOS-022 integration contract failed: %s" % error, file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/integration/test_qemu_irq0_preemption.py
+++ b/tests/integration/test_qemu_irq0_preemption.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke test for the AI provider/model control plane in AI-OS."""
+"""Contrat AOS-024 : IRQ0 préempte une tâche Ring 3 non coopérative."""
 import os
 import socket
 import subprocess
@@ -8,9 +8,9 @@ import time
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 LOG_DIR = os.path.join(ROOT, "test_logs")
-LOG = os.path.join(LOG_DIR, "ai-provider-smoke.log")
-ERR = os.path.join(LOG_DIR, "ai-provider-smoke.err")
-MON = os.path.join(LOG_DIR, "ai-provider-monitor.sock")
+LOG = os.path.join(LOG_DIR, "irq0-preemption.log")
+ERR = os.path.join(LOG_DIR, "irq0-preemption.err")
+MON = os.path.join(LOG_DIR, "irq0-preemption-monitor.sock")
 KERNEL = os.path.join(ROOT, "build", "ai_os.bin")
 INITRD = os.path.join(ROOT, "my_initrd.tar")
 
@@ -23,15 +23,15 @@ def log_text():
         return ""
 
 
-def wait_for(needle, proc, timeout=15):
+def wait_for(needle, proc, offset=0, timeout=12):
     deadline = time.time() + timeout
     while time.time() < deadline:
         if proc.poll() is not None:
-            raise RuntimeError("QEMU stopped early")
-        if needle in log_text():
+            raise RuntimeError("QEMU s'est arrêté prématurément")
+        if needle in log_text()[offset:]:
             return
         time.sleep(0.1)
-    raise RuntimeError("missing output: %s" % needle)
+    raise RuntimeError("sortie manquante : %s" % needle)
 
 
 def connect_monitor():
@@ -50,31 +50,15 @@ def connect_monitor():
             except OSError:
                 client.close()
         time.sleep(0.1)
-    raise RuntimeError("QEMU monitor unavailable")
+    raise RuntimeError("moniteur QEMU indisponible")
 
 
-def send_keys(client, keys):
-    for key in keys:
-        client.sendall(("sendkey %s\n" % key).encode("ascii"))
-        time.sleep(0.08)
-
-
-def key_sequence(command):
-    special = {" ": "spc", ".": "dot", "-": "minus", "_": "shift-minus"}
-    return [special.get(char, char.lower()) for char in command] + ["ret"]
-
-
-def run_command(client, proc, command, expected):
-    before = len(log_text())
-    send_keys(client, key_sequence(command))
-    deadline = time.time() + 10
-    while time.time() < deadline:
-        if proc.poll() is not None:
-            raise RuntimeError("QEMU stopped while executing %s" % command)
-        if expected in log_text()[before:]:
-            return
-        time.sleep(0.1)
-    raise RuntimeError("command %s did not emit %s" % (command, expected))
+def send_command(client, command):
+    special = {" ": "spc", "-": "minus"}
+    for char in command:
+        client.sendall(("sendkey %s\n" % special.get(char, char.lower())).encode("ascii"))
+        time.sleep(0.06)
+    client.sendall(b"sendkey ret\n")
 
 
 def main():
@@ -97,16 +81,13 @@ def main():
         try:
             wait_for("(-.-)", proc)
             monitor = connect_monitor()
-            run_command(monitor, proc, "ai-provider", "Fournisseur IA : local")
-            run_command(monitor, proc, "ai-model list", "qwen2.5-1.5b-instruct-q4_0.gguf")
-            run_command(monitor, proc, "ai-model use custom-local-model.gguf", "Profil memorise; seul GPT-2")
-            run_command(monitor, proc, "ai-model", "custom-local-model.gguf")
-            run_command(monitor, proc, "ai-runtime", "Runtime IA bare-metal")
-            run_command(monitor, proc, "net-status", "net-status ok stub AOS-025")
-            run_command(monitor, proc, "ai-provider openai", "OpenAI selectionne")
-            run_command(monitor, proc, "ai hello", "OpenAI configure mais indisponible")
-            run_command(monitor, proc, "ai-provider local", "Fournisseur local selectionne")
-            print("AI provider control-plane smoke passed.")
+            before_spawn = len(log_text())
+            send_command(monitor, "spawn spin")
+            wait_for("spawn ok pid", proc, before_spawn)
+            before_echo = len(log_text())
+            send_command(monitor, "echo irq0-preempt-ok")
+            wait_for("irq0-preempt-ok", proc, before_echo)
+            print("AOS-024 IRQ0 preemption contract passed")
             return 0
         finally:
             if monitor is not None:
@@ -127,5 +108,5 @@ if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except Exception as error:
-        print("AI provider control-plane smoke failed: %s" % error, file=sys.stderr)
+        print("AOS-024 IRQ0 preemption contract failed: %s" % error, file=sys.stderr)
         raise SystemExit(1)

--- a/tests/robustness/test_gpt2_gguf_bounds.c
+++ b/tests/robustness/test_gpt2_gguf_bounds.c
@@ -1,0 +1,90 @@
+/* AOS-022 robustness checks for the bounded GGUF envelope reader. */
+#include "../framework/unity.h"
+#include "../../kernel/llm/gpt2_gguf.h"
+
+static uint8_t blob[256];
+static uint32_t cursor;
+
+static void reset_blob(void) {
+    uint32_t i;
+    for (i = 0U; i < sizeof(blob); i++) blob[i] = 0U;
+    cursor = 0U;
+}
+
+static void put_u32(uint32_t value) {
+    blob[cursor++] = (uint8_t)value;
+    blob[cursor++] = (uint8_t)(value >> 8);
+    blob[cursor++] = (uint8_t)(value >> 16);
+    blob[cursor++] = (uint8_t)(value >> 24);
+}
+
+static void put_u64(uint64_t value) {
+    put_u32((uint32_t)value);
+    put_u32((uint32_t)(value >> 32));
+}
+
+static void put_text(const char* text) {
+    uint32_t length = 0U;
+    while (text[length]) length++;
+    put_u64(length);
+    while (*text) blob[cursor++] = (uint8_t)*text++;
+}
+
+static uint32_t build_valid_minimal_gpt2(void) {
+    reset_blob();
+    put_u32(GPT2_GGUF_MAGIC);
+    put_u32(GPT2_GGUF_VERSION);
+    put_u64(0U);
+    put_u64(1U);
+    put_text("general.architecture");
+    put_u32(GPT2_GGUF_VALUE_STRING);
+    put_text("gpt2");
+    while ((cursor & 31U) != 0U) blob[cursor++] = 0U;
+    return cursor;
+}
+
+static void test_every_truncated_prefix_is_rejected(void) {
+    gpt2_gguf_info_t info;
+    uint32_t size = build_valid_minimal_gpt2();
+    uint32_t prefix;
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_probe_blob(blob, size, &info));
+    for (prefix = 0U; prefix < size; prefix++) {
+        TEST_ASSERT_TRUE(gpt2_gguf_probe_blob(blob, prefix, &info) != 0);
+    }
+}
+
+static void test_rejects_excessive_tensor_count(void) {
+    gpt2_gguf_info_t info;
+    reset_blob();
+    put_u32(GPT2_GGUF_MAGIC);
+    put_u32(GPT2_GGUF_VERSION);
+    put_u64(513U);
+    put_u64(0U);
+    TEST_ASSERT_EQUAL(-2, gpt2_gguf_probe_blob(blob, cursor, &info));
+}
+
+static void test_rejects_invalid_alignment(void) {
+    gpt2_gguf_info_t info;
+    reset_blob();
+    put_u32(GPT2_GGUF_MAGIC);
+    put_u32(GPT2_GGUF_VERSION);
+    put_u64(0U);
+    put_u64(2U);
+    put_text("general.architecture");
+    put_u32(GPT2_GGUF_VALUE_STRING);
+    put_text("gpt2");
+    put_text("general.alignment");
+    put_u32(GPT2_GGUF_VALUE_UINT32);
+    put_u32(3U);
+    TEST_ASSERT_EQUAL(-5, gpt2_gguf_probe_blob(blob, cursor, &info));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_every_truncated_prefix_is_rejected);
+    RUN_TEST(test_rejects_excessive_tensor_count);
+    RUN_TEST(test_rejects_invalid_alignment);
+    unity_print_results();
+    unity_cleanup();
+    return unity_stats.tests_failed == 0 ? 0 : 1;
+}

--- a/tests/scripts/ci_qemu_core_smoke.py
+++ b/tests/scripts/ci_qemu_core_smoke.py
@@ -15,6 +15,7 @@ LOG_DIR = os.path.join(ROOT, "test_logs")
 LOG = os.environ.get("LOG", os.path.join(LOG_DIR, "ci-qemu-serial.log"))
 QEMU_ERR = os.environ.get("QEMU_ERR", os.path.join(LOG_DIR, "ci-qemu-stderr.log"))
 MON_SOCK = os.environ.get("QEMU_MON_SOCK", os.path.join(LOG_DIR, "qemu-core-monitor.sock"))
+TEST_DISK = os.environ.get("OVERLAY_DISK", os.path.join(LOG_DIR, "qemu-core-overlay.img"))
 BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "75"))
 CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "20"))
 
@@ -64,11 +65,16 @@ def monitor_connect():
     raise RuntimeError("QEMU monitor unavailable")
 
 
+def prepare_test_disk():
+    directory = os.path.dirname(TEST_DISK)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(TEST_DISK, "wb") as handle:
+        handle.truncate(64 * 512)
+
+
 def qemu_disk_args():
-    disk = os.environ.get("OVERLAY_DISK", os.path.join(ROOT, "build", "overlay.img"))
-    if os.path.isfile(disk):
-        return ["-drive", "file=%s,format=raw,if=ide,cache=writethrough" % disk]
-    return []
+    return ["-drive", "file=%s,format=raw,if=ide,cache=writethrough" % TEST_DISK]
 
 
 def send_command(client, command):
@@ -99,6 +105,7 @@ def main():
         except OSError:
             pass
 
+    prepare_test_disk()
     proc = None
     monitor = None
     try:

--- a/tests/scripts/ci_qemu_persist.py
+++ b/tests/scripts/ci_qemu_persist.py
@@ -80,7 +80,7 @@ def send_command(client, command):
     for char in command:
         client.sendall(("sendkey %s\n" % aliases.get(char, char.lower())).encode("ascii"))
         drain_monitor(client)
-        time.sleep(0.20)
+        time.sleep(0.25)
     client.sendall(b"sendkey ret\n")
     drain_monitor(client)
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -105,6 +105,15 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_gpt2_sample.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_sample.c"
     fi
+    if [ "$(basename "$test_file")" = "test_gpt2_gguf.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_gguf.c"
+    fi
+    if [ "$(basename "$test_file")" = "test_gpt2_quant.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_quant.c"
+    fi
+    if [ "$(basename "$test_file")" = "test_gpt2_gguf_bounds.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_gguf.c"
+    fi
     
     # Compiler
     echo "gcc $cflags -o \"$test_binary\" \"$test_file\" $extra_src \"$TEST_DIR/framework/unity.c\" \"$TEST_DIR/framework/test_kernel.c\" \"$TEST_DIR/framework/kernel_mocks.c\"" >> "$RESULTS_FILE"

--- a/tests/unit/kernel/test_gpt2_gguf.c
+++ b/tests/unit/kernel/test_gpt2_gguf.c
@@ -1,0 +1,132 @@
+/* test_gpt2_gguf.c - bounded structural parsing for GGUF v3. */
+
+#include "../../framework/unity.h"
+#include "../../../kernel/llm/gpt2_gguf.h"
+
+#define BUF_SIZE 512U
+
+static uint8_t blob[BUF_SIZE];
+static uint32_t cursor;
+
+static void reset_blob(void) {
+    uint32_t i;
+    for (i = 0U; i < BUF_SIZE; i++) blob[i] = 0U;
+    cursor = 0U;
+}
+
+static void put_u32(uint32_t value) {
+    blob[cursor++] = (uint8_t)(value & 0xffU);
+    blob[cursor++] = (uint8_t)((value >> 8) & 0xffU);
+    blob[cursor++] = (uint8_t)((value >> 16) & 0xffU);
+    blob[cursor++] = (uint8_t)((value >> 24) & 0xffU);
+}
+
+static void put_u64(uint64_t value) {
+    put_u32((uint32_t)value);
+    put_u32((uint32_t)(value >> 32));
+}
+
+static void put_text(const char* text) {
+    uint32_t count = 0U;
+    while (text[count]) count++;
+    put_u64(count);
+    while (*text) blob[cursor++] = (uint8_t)*text++;
+}
+
+static void put_metadata_string(const char* key, const char* value) {
+    put_text(key);
+    put_u32(GPT2_GGUF_VALUE_STRING);
+    put_text(value);
+}
+
+static void put_metadata_u32(const char* key, uint32_t value) {
+    put_text(key);
+    put_u32(GPT2_GGUF_VALUE_UINT32);
+    put_u32(value);
+}
+
+static void put_tensor(const char* name, uint32_t dimensions, uint64_t first,
+                       uint64_t second, uint32_t type, uint64_t offset) {
+    put_text(name);
+    put_u32(dimensions);
+    put_u64(first);
+    if (dimensions > 1U) put_u64(second);
+    put_u32(type);
+    put_u64(offset);
+}
+
+static uint32_t make_valid_gpt2(uint32_t type, uint64_t data_offset) {
+    uint32_t padded;
+    reset_blob();
+    put_u32(GPT2_GGUF_MAGIC);
+    put_u32(GPT2_GGUF_VERSION);
+    put_u64(1U);
+    put_u64(2U);
+    put_metadata_string("general.architecture", "gpt2");
+    put_metadata_u32("general.alignment", 32U);
+    put_tensor("token_embd.weight", 2U, 768U, 50257U, type, data_offset);
+    padded = (cursor + 31U) & ~31U;
+    while (cursor < padded) blob[cursor++] = 0U;
+    return cursor;
+}
+
+static void test_accepts_gpt2_q8_0_envelope(void) {
+    gpt2_gguf_info_t info;
+    uint32_t size = make_valid_gpt2(GPT2_GGUF_TENSOR_Q8_0, 0U);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_probe_blob(blob, size, &info));
+    TEST_ASSERT_EQUAL(1, info.is_valid);
+    TEST_ASSERT_EQUAL(1, info.is_gpt2);
+    TEST_ASSERT_EQUAL(3, info.version);
+    TEST_ASSERT_EQUAL(1, info.tensor_count);
+    TEST_ASSERT_EQUAL(1, info.q8_0_tensors);
+    TEST_ASSERT_EQUAL(0, info.unsupported_quantized_tensors);
+    TEST_ASSERT_EQUAL(32, info.alignment);
+}
+
+static void test_reports_unsupported_quantized_tensor_without_accepting_execution(void) {
+    gpt2_gguf_info_t info;
+    uint32_t size = make_valid_gpt2(GPT2_GGUF_TENSOR_Q3_K, 0U);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_probe_blob(blob, size, &info));
+    TEST_ASSERT_EQUAL(1, info.is_valid);
+    TEST_ASSERT_EQUAL(1, info.unsupported_quantized_tensors);
+    TEST_ASSERT_EQUAL(0, info.q8_0_tensors);
+}
+
+static void test_rejects_non_gpt2_architecture(void) {
+    gpt2_gguf_info_t info;
+    uint32_t size;
+    reset_blob();
+    put_u32(GPT2_GGUF_MAGIC);
+    put_u32(GPT2_GGUF_VERSION);
+    put_u64(0U);
+    put_u64(1U);
+    put_metadata_string("general.architecture", "llama");
+    size = cursor;
+    TEST_ASSERT_EQUAL(-4, gpt2_gguf_probe_blob(blob, size, &info));
+}
+
+static void test_rejects_unaligned_tensor_offset(void) {
+    gpt2_gguf_info_t info;
+    uint32_t size = make_valid_gpt2(GPT2_GGUF_TENSOR_Q8_0, 1U);
+    TEST_ASSERT_EQUAL(-9, gpt2_gguf_probe_blob(blob, size, &info));
+}
+
+static void test_rejects_bad_magic_and_truncation(void) {
+    gpt2_gguf_info_t info;
+    uint32_t size = make_valid_gpt2(GPT2_GGUF_TENSOR_Q8_0, 0U);
+    blob[0] = 0U;
+    TEST_ASSERT_EQUAL(-2, gpt2_gguf_probe_blob(blob, size, &info));
+    TEST_ASSERT_TRUE(gpt2_gguf_probe_blob(blob, 3U, &info) != 0);
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_accepts_gpt2_q8_0_envelope);
+    RUN_TEST(test_reports_unsupported_quantized_tensor_without_accepting_execution);
+    RUN_TEST(test_rejects_non_gpt2_architecture);
+    RUN_TEST(test_rejects_unaligned_tensor_offset);
+    RUN_TEST(test_rejects_bad_magic_and_truncation);
+    unity_print_results();
+    unity_cleanup();
+    return unity_stats.tests_failed == 0 ? 0 : 1;
+}

--- a/tests/unit/kernel/test_gpt2_quant.c
+++ b/tests/unit/kernel/test_gpt2_quant.c
@@ -1,0 +1,70 @@
+/* test_gpt2_quant.c - GGML Q8_0 math primitives without a model file. */
+
+#include "../../framework/unity.h"
+#include "../../../kernel/llm/gpt2_quant.h"
+
+static void assert_close(float actual, float expected, float tolerance) {
+    float delta = actual - expected;
+    if (delta < 0.0f) delta = -delta;
+    TEST_ASSERT_TRUE(delta <= tolerance);
+}
+
+static void test_f16_common_values(void) {
+    assert_close(gpt2_f16_to_f32(0x0000U), 0.0f, 0.0f);
+    assert_close(gpt2_f16_to_f32(0x3c00U), 1.0f, 0.0f);
+    assert_close(gpt2_f16_to_f32(0xc000U), -2.0f, 0.0f);
+    assert_close(gpt2_f16_to_f32(0x3800U), 0.5f, 0.0f);
+}
+
+static void test_f16_subnormal_and_infinity(void) {
+    float smallest = gpt2_f16_to_f32(0x0001U);
+    TEST_ASSERT_TRUE(smallest > 0.0f);
+    TEST_ASSERT_TRUE(gpt2_f16_to_f32(0x7c00U) > 1000000.0f);
+}
+
+static void test_q8_dot_one_block(void) {
+    float activation[GPT2_Q8_0_BLOCK_SIZE];
+    uint8_t block[GPT2_Q8_0_BLOCK_BYTES];
+    uint32_t i;
+    for (i = 0U; i < GPT2_Q8_0_BLOCK_SIZE; i++) {
+        activation[i] = 0.5f;
+        block[2U + i] = 2U;
+    }
+    block[0] = 0x00U; /* binary16 1.0 */
+    block[1] = 0x3cU;
+    assert_close(gpt2_q8_0_dot_f32(activation, block, GPT2_Q8_0_BLOCK_SIZE), 32.0f, 0.0001f);
+}
+
+static void test_q8_dot_two_blocks_with_signs(void) {
+    float activation[2U * GPT2_Q8_0_BLOCK_SIZE];
+    uint8_t blocks[2U * GPT2_Q8_0_BLOCK_BYTES];
+    uint32_t i;
+    for (i = 0U; i < 2U * GPT2_Q8_0_BLOCK_SIZE; i++) activation[i] = 1.0f;
+    blocks[0] = 0x00U; blocks[1] = 0x3cU; /* scale 1.0 */
+    blocks[GPT2_Q8_0_BLOCK_BYTES] = 0x00U;
+    blocks[GPT2_Q8_0_BLOCK_BYTES + 1U] = 0x38U; /* scale 0.5 */
+    for (i = 0U; i < GPT2_Q8_0_BLOCK_SIZE; i++) {
+        blocks[2U + i] = 3U;
+        blocks[GPT2_Q8_0_BLOCK_BYTES + 2U + i] = (uint8_t)(int8_t)-2;
+    }
+    assert_close(gpt2_q8_0_dot_f32(activation, blocks, 2U * GPT2_Q8_0_BLOCK_SIZE), 64.0f, 0.0001f);
+}
+
+static void test_q8_rejects_invalid_length(void) {
+    float activation[GPT2_Q8_0_BLOCK_SIZE];
+    uint8_t block[GPT2_Q8_0_BLOCK_BYTES];
+    TEST_ASSERT_EQUAL(0, (int)gpt2_q8_0_dot_f32(activation, block, 31U));
+    TEST_ASSERT_EQUAL(0, (int)gpt2_q8_0_dot_f32(0, block, GPT2_Q8_0_BLOCK_SIZE));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_f16_common_values);
+    RUN_TEST(test_f16_subnormal_and_infinity);
+    RUN_TEST(test_q8_dot_one_block);
+    RUN_TEST(test_q8_dot_two_blocks_with_signs);
+    RUN_TEST(test_q8_rejects_invalid_length);
+    unity_print_results();
+    unity_cleanup();
+    return unity_stats.tests_failed == 0 ? 0 : 1;
+}

--- a/tests/unit/kernel/test_overlay.c
+++ b/tests/unit/kernel/test_overlay.c
@@ -6,6 +6,13 @@
 
 static uint8_t g_snap[OV_SNAP_SIZE + 64];
 
+static void put_u32(uint8_t* p, uint32_t value) {
+    p[0] = (uint8_t)value;
+    p[1] = (uint8_t)(value >> 8);
+    p[2] = (uint8_t)(value >> 16);
+    p[3] = (uint8_t)(value >> 24);
+}
+
 void setUp(void) {
     overlay_init();
 }
@@ -98,6 +105,45 @@ static void test_restore_rejects_bad_magic(void) {
     TEST_ASSERT_EQUAL_STRING("keep", buf);
 }
 
+static void test_restore_v1_snapshot_compatibility(void) {
+    char out[16];
+    uint32_t off = 16U;
+    uint32_t i;
+
+    setUp();
+    for (i = 0U; i < OV_SNAP_V1_SIZE; i++) g_snap[i] = 0U;
+    put_u32(g_snap + 0, OV_SNAP_MAGIC);
+    put_u32(g_snap + 4, OV_SNAP_V1_VERSION);
+    put_u32(g_snap + 8, OV_SNAP_V1_NODES);
+    put_u32(g_snap + 12, 1U);
+    g_snap[off] = 1U;
+    put_u32(g_snap + off + 4U, 4U);
+    memcpy(g_snap + off + 8U, "old.txt", 8U);
+    memcpy(g_snap + off + 8U + OV_SNAP_V1_PATH, "v1ok", 4U);
+
+    TEST_ASSERT_EQUAL(0, overlay_restore(g_snap, OV_SNAP_V1_SIZE));
+    TEST_ASSERT_EQUAL(4, overlay_read("old.txt", out, sizeof(out)));
+    out[4] = '\0';
+    TEST_ASSERT_EQUAL_STRING("v1ok", out);
+}
+
+static void test_snapshot_v2_accepts_extended_file(void) {
+    char input[OV_SNAP_DATA];
+    char output[OV_SNAP_DATA + 1U];
+    uint32_t sz = 0U;
+    uint32_t i;
+
+    setUp();
+    for (i = 0U; i < OV_SNAP_DATA; i++) input[i] = (char)('a' + (i % 26U));
+    TEST_ASSERT_EQUAL((int)OV_SNAP_DATA, overlay_write("large.txt", input, OV_SNAP_DATA));
+    TEST_ASSERT_EQUAL(0, overlay_snapshot(g_snap, sizeof(g_snap), &sz));
+    TEST_ASSERT_EQUAL(OV_SNAP_SIZE, sz);
+    overlay_init();
+    TEST_ASSERT_EQUAL(0, overlay_restore(g_snap, sz));
+    TEST_ASSERT_EQUAL((int)OV_SNAP_DATA, overlay_read("large.txt", output, OV_SNAP_DATA));
+    for (i = 0U; i < OV_SNAP_DATA; i++) TEST_ASSERT_EQUAL(input[i], output[i]);
+}
+
 static void test_snapshot_rejects_small_buffer(void) {
     uint8_t tiny[16];
     uint32_t sz = 99;
@@ -115,6 +161,8 @@ int main(void) {
     RUN_TEST(test_snapshot_mkdir_roundtrip);
     RUN_TEST(test_snapshot_unlink_roundtrip);
     RUN_TEST(test_restore_rejects_bad_magic);
+    RUN_TEST(test_restore_v1_snapshot_compatibility);
+    RUN_TEST(test_snapshot_v2_accepts_extended_file);
     RUN_TEST(test_snapshot_rejects_small_buffer);
     unity_print_results();
     unity_cleanup();

--- a/tests/unit/kernel/test_syscall.c
+++ b/tests/unit/kernel/test_syscall.c
@@ -757,7 +757,7 @@ void test_sys_overlay_append(void) {
     char buf[64];
     os_dirent_t st;
     cpu_state_t cpu = {0};
-    char big[256];
+    char big[OV_SNAP_DATA];
     int i;
 
     overlay_init();
@@ -828,13 +828,13 @@ void test_sys_overlay_append(void) {
     buf[19] = '\0';
     TEST_ASSERT_EQUAL_STRING("hello from initrd\nZ", buf);
 
-    for (i = 0; i < 256; i++) big[i] = 'a';
+    for (i = 0; i < (int)OV_SNAP_DATA; i++) big[i] = 'a';
     cpu.eax = SYS_WRITEFILE;
     cpu.ebx = (uint32_t)"full.txt";
     cpu.ecx = (uint32_t)big;
-    cpu.edx = 256;
+    cpu.edx = OV_SNAP_DATA;
     syscall_handler(&cpu);
-    TEST_ASSERT_EQUAL(256, (int)cpu.eax);
+    TEST_ASSERT_EQUAL((int)OV_SNAP_DATA, (int)cpu.eax);
 
     cpu.eax = SYS_APPEND;
     cpu.ebx = (uint32_t)"full.txt";

--- a/tests/unit/kernel/test_tokenizer.c
+++ b/tests/unit/kernel/test_tokenizer.c
@@ -27,7 +27,7 @@ static int load_synthetic_vocab(void) {
     memset(header, 0, sizeof(header));
     header[0] = 20240328U;
     header[1] = 2;
-    header[2] = 21;
+    header[2] = 29;
     header[3] = 20; /* EOT */
     memcpy(g_blob, header, sizeof(header));
     offset = 1024;
@@ -52,6 +52,14 @@ static int load_synthetic_vocab(void) {
     blob_put_piece(&offset, "\xC3\xA9", 2);
     blob_put_piece(&offset, "\x01", 1);
     blob_put_piece(&offset, "E", 1);
+    blob_put_piece(&offset, "\xCE", 1);
+    blob_put_piece(&offset, "\xB1", 1);
+    blob_put_piece(&offset, "\xCE\xB1", 2);
+    blob_put_piece(&offset, "\xF0", 1);
+    blob_put_piece(&offset, "\x9F", 1);
+    blob_put_piece(&offset, "\x98", 1);
+    blob_put_piece(&offset, "\x80", 1);
+    blob_put_piece(&offset, "\xF0\x9F\x98\x80\xCE\xB1", 6);
     return gpt2_tokenizer_load_from_buffer(g_blob, offset);
 }
 
@@ -163,6 +171,30 @@ static void test_encode_utf8_letter_chunk(void) {
     TEST_ASSERT_EQUAL(18, tokens[0]);
 }
 
+static void test_encode_greek_letter_uses_utf8_bpe_piece(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode("\xCE\xB1", tokens, 8, &count));
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL(23, tokens[0]);
+}
+
+static void test_emoji_is_not_merged_with_following_unicode_letter(void) {
+    uint32_t tokens[8];
+    uint32_t count = 0;
+    setUp();
+    TEST_ASSERT_EQUAL(0, gpt2_tokenizer_encode("\xF0\x9F\x98\x80\xCE\xB1", tokens, 8, &count));
+    /* The six-byte cross-class token exists in the vocabulary but must not be
+     * selected: emoji is punctuation, alpha is a Unicode letter. */
+    TEST_ASSERT_EQUAL(5, count);
+    TEST_ASSERT_EQUAL(24, tokens[0]);
+    TEST_ASSERT_EQUAL(25, tokens[1]);
+    TEST_ASSERT_EQUAL(26, tokens[2]);
+    TEST_ASSERT_EQUAL(27, tokens[3]);
+    TEST_ASSERT_EQUAL(23, tokens[4]);
+}
+
 static void test_encode_ascii_wrapper(void) {
     uint32_t tokens[8];
     uint32_t count = 0;
@@ -186,6 +218,8 @@ int main(void) {
     RUN_TEST(test_decode_keeps_utf8);
     RUN_TEST(test_decode_drops_control_bytes);
     RUN_TEST(test_encode_utf8_letter_chunk);
+    RUN_TEST(test_encode_greek_letter_uses_utf8_bpe_piece);
+    RUN_TEST(test_emoji_is_not_merged_with_following_unicode_letter);
     RUN_TEST(test_encode_ascii_wrapper);
     unity_print_results();
     unity_cleanup();

--- a/userspace/Makefile
+++ b/userspace/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -nostdlib -Ttext=0x40000000
 ASFLAGS = --32
 
 # Programmes à compiler
-PROGRAMS = shell fake_ai test_program ai_assistant idle ok
+PROGRAMS = shell fake_ai test_program ai_assistant idle spin ok
 
 all: $(PROGRAMS)
 
@@ -30,6 +30,10 @@ test_program: test_program.o start.o
 
 idle: idle.o start.o
 	@echo "Linking idle..."
+	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
+
+spin: spin.o start.o
+	@echo "Linking spin..."
 	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
 
 ok: ok.o start.o

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -539,6 +539,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  ai-provider [nom]  - Choisir local ou openai\n");
     print_string("  ai-model [action]  - Lister ou choisir le modele local\n");
     print_string("  ai-runtime         - Etat du moteur IA et des prerequis\n");
+    print_string("  net-status         - Etat reel de la pile reseau bare-metal\n");
     
     print_colored("\nCOMMANDES UTILITAIRES :\n", COLOR_YELLOW);
     print_string("  clear              - Effacer l'écran\n");
@@ -1090,7 +1091,7 @@ static int is_builtin(const char* cmd) {
     static const char* names[] = {
         "help", "ls", "dir", "ps", "sysinfo", "info", "mem", "memory",
         "history", "env", "echo", "write", "append", "touch", "clear", "cls", "exit", "quit",
-        "ai", "ai-mode", "ai-help", "ai-test", "ai-stats", "ai-provider", "ai-model", "ai-runtime",
+        "ai", "ai-mode", "ai-help", "ai-test", "ai-stats", "ai-provider", "ai-model", "ai-runtime", "net-status",
         "cd", "pwd", "cat", "stat", "test", "[", "mkdir", "rmdir", "cp", "mv", "rm",
         "kill", "spawn", "yield", "jobs", "top", "getpid", "uptime", "date", "whoami",
         "alias", "unalias", "export", "which", "rc",
@@ -1907,6 +1908,16 @@ static void cmd_ai_runtime(shell_context_t* ctx, char args[][128], int arg_count
     print_string("Secrets OpenAI     : jamais integres a l'image de boot\n\n");
 }
 
+static void cmd_net_status(shell_context_t* ctx, char args[][128], int arg_count) {
+    (void)ctx; (void)args; (void)arg_count;
+    print_colored("\n=== Reseau bare-metal ===\n", COLOR_CYAN);
+    print_string("Carte Ethernet : absente (aucun pilote NIC initialise)\n");
+    print_string("ARP / IPv4 / DHCP : absents\n");
+    print_string("DNS / TCP / TLS   : absents\n");
+    print_string("OpenAI en ligne   : bloque, aucune requete n'est emise\n");
+    print_string("net-status ok stub AOS-025\n");
+}
+
 static void cmd_reboot(shell_context_t* ctx, char args[][128], int arg_count) {
     (void)ctx; (void)args; (void)arg_count;
     print_warning("reboot: simule (QEMU reste actif, tapez exit pour quitter le shell)");
@@ -2229,6 +2240,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "ai-runtime") == 0) {
         cmd_ai_runtime(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "net-status") == 0) {
+        cmd_net_status(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "logout") == 0) {
         cmd_exit(ctx, args, arg_count);

--- a/userspace/spin.c
+++ b/userspace/spin.c
@@ -1,0 +1,12 @@
+/* spin.c - tâche de charge non coopérative pour valider la préemption IRQ0.
+ * Aucun syscall n'est exécuté dans la boucle : le shell ne peut redevenir
+ * réactif que si le timer peut reprendre une autre tâche Ring 3. */
+
+volatile unsigned long spin_counter;
+
+void main(void) {
+    for (;;) {
+        spin_counter++;
+        asm volatile("" ::: "memory");
+    }
+}


### PR DESCRIPTION
## Résumé

Cette pull request livre les jalons **AOS-020 à AOS-025** du prototype i386, avec tests, contrats QEMU et documentation en français.

| Jalon | Livraison |
|---|---|
| AOS-020 | Sonde GGUF v3 bornée, primitives FP16/Q8_0×FP32 et tests de robustesse |
| AOS-021 | Tokenisation BPE UTF-8 avec couverture de lettres Unicode ciblée |
| AOS-022 | Contrat d’intégration QEMU reproductible pour boot, runtime IA, overlay et reprise du shell |
| AOS-023 | Overlay ATA PIO V2 : 64 nœuds, chemins 80 octets, données 384 octets, restauration V1/V2 |
| AOS-024 | Préemption IRQ0 Ring 3 à quantum de 20 ticks, avec contrat `spawn spin` sans syscall |
| AOS-025 | Stub OpenAI/réseau explicite, `net-status` et smoke QEMU empêchant tout faux succès réseau |

## Validations exécutées

```text
make kernel-only      # noyau i386 compilé
make test-all         # 161/161 tests passants
make integration-qemu # AOS-022, AOS-024 et AOS-025 passants
make iso              # ISO BIOS/GRUB produite avec initrd GPT-2 local
```

## Limites assumées

- La sonde GGUF valide la structure v3 mais les kernels Q3_K/Q4_K/Q6_K ne sont pas encore présents : les modèles GGUF quantifiés ne sont pas exécutables.
- Sous QEMU TCG sans KVM, la latence locale GPT-2 reste de l’ordre de 7 à 9 secondes ; l’objectif inférieur à une seconde n’est pas atteint.
- AOS-025 ne livre pas de pilote NIC ni de pile ARP/IPv4/DHCP/DNS/TCP/TLS. Le profil OpenAI reste volontairement bloqué, sans clé ni requête dans l’image.
- Les modèles, l’ISO, l’initrd généré et les binaires restent exclus de Git.
