### PR TITLE
feat: ajouter l’IPC Foundation MOHHOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ userspace/test_program
 userspace/ai_assistant
 userspace/idle
 userspace/spin
+userspace/ipcserver
 userspace/ok
 userspace/*.o
 userspace/*.bin
@@ -14,6 +15,7 @@ initrd_content/bin/ai_assistant
 initrd_content/bin/user_program
 initrd_content/bin/idle
 initrd_content/bin/spin
+initrd_content/bin/ipcserver
 initrd_content/bin/ok
 
 # Build and QEMU artefacts

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/multiboot.o build/kernel.o build/kbd_buffer.o
+          build/keyboard.o build/timer.o build/ipc.o build/multiboot.o build/kernel.o build/kbd_buffer.o
 
 # Cible par défaut : construire le système complet (noyau + initrd + disque overlay)
 all: $(OS_IMAGE) pack-initrd disk
@@ -104,6 +104,10 @@ build/kbd_buffer.o: kernel/input/kbd_buffer.c kernel/input/kbd_buffer.h
 
 
 build/timer.o: kernel/timer.c kernel/timer.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/ipc.o: kernel/ipc.c kernel/ipc.h include/os_syscalls.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
@@ -255,6 +259,7 @@ pack-initrd: userspace-all
 	@cp -f userspace/test_program $(BIN_DEST_DIR)/user_program
 	@cp -f userspace/idle $(BIN_DEST_DIR)/idle
 	@cp -f userspace/spin $(BIN_DEST_DIR)/spin
+	@cp -f userspace/ipcserver $(BIN_DEST_DIR)/ipcserver
 	@cp -f userspace/ok $(BIN_DEST_DIR)/ok
 	@tar -C $(INITRD_DIR) -cf $(INITRD_IMAGE) .
 	@echo "[mkinitrd] Packed executables into $(INITRD_IMAGE)"
@@ -299,7 +304,7 @@ iso-clean:
 	@rm -rf build/isodir $(ISO_IMAGE)
 
 # Compile tous les programmes utilisateur
-user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle userspace/spin userspace/ok: userspace-all
+user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle userspace/spin userspace/ipcserver userspace/ok: userspace-all
 
 # Cible pour exécuter l'OS dans QEMU avec initrd (mode console corrigé)
 run: $(OS_IMAGE) pack-initrd disk
@@ -455,17 +460,21 @@ qemu-smoke: $(OS_IMAGE) pack-initrd disk
 
 # Contrats d’intégration QEMU versionnés : boot, shell/overlay, préemption IRQ0
 # et absence réseau OpenAI explicitement vérifiable.
-.PHONY: integration-qemu qemu-irq0-preemption qemu-ai-provider
+.PHONY: integration-qemu qemu-irq0-preemption qemu-ai-provider qemu-ipc-foundation
 qemu-irq0-preemption: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/integration/test_qemu_irq0_preemption.py
 
 qemu-ai-provider: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/scripts/test_ai_provider_commands.py
 
+qemu-ipc-foundation: $(OS_IMAGE) pack-initrd disk
+	@python3 tests/integration/test_qemu_ipc_foundation.py
+
 integration-qemu: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/integration/test_qemu_core_contract.py
 	@python3 tests/integration/test_qemu_irq0_preemption.py
 	@python3 tests/scripts/test_ai_provider_commands.py
+	@python3 tests/integration/test_qemu_ipc_foundation.py
 
 # Tests d'intégration réels GPT-2 : les poids locaux sous models/ sont requis.
 .PHONY: gpt2-recovery gpt2-benchmark gpt2-tests
@@ -510,6 +519,7 @@ help:
 	@echo "  integration-qemu - Contrats QEMU : boot, shell/overlay, IRQ0 et fournisseur IA"
 	@echo "  qemu-irq0-preemption - Prouve la reprise du shell après spawn spin"
 	@echo "  qemu-ai-provider - Vérifie le stub OpenAI/réseau explicite"
+	@echo "  qemu-ipc-foundation - Vérifie l’IPC entre tâches Ring 3"
 	@echo "  disk            - Cree build/overlay.img (IDE, 32 Kio) si absent"
 	@echo "  gpt2-recovery   - Modèle requis : réponse GPT-2 puis reprise shell (rc)"
 	@echo "  gpt2-benchmark  - Modèle requis : mesure de latence QEMU SSE2"

--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ AI-OS est un **prototype de hobby OS i386 32-bit** démarrant par Multiboot. Il 
 | Domaine | Fonction réellement disponible |
 |---|---|
 | Démarrage | Multiboot BIOS, VGA/série, GDT, IDT, PIC, PIT et clavier PS/2 |
-| Utilisateur | Shell ELF Ring 3, syscalls 0–22, `spawn`, `yield`, `exec`, `ps`, `kill` |
+| Utilisateur | Shell ELF Ring 3, syscalls 0–24, `spawn`, `yield`, `exec`, `ps`, `kill` |
 | Préemption | Quantum IRQ0 de 20 ticks, uniquement entre tâches utilisateur prêtes |
+| IPC Foundation | Boîte aux lettres FIFO entre tâches Ring 3, messages de 96 octets, 4 entrées par tâche ; pas de capabilities |
 | Fichiers | Initrd TAR en lecture seule et overlay ATA PIO V2 persistant (64 nœuds, V1 compatible) |
 | IA locale | GPT-2 124M `llm.c v3`, BPE UTF-8, cache KV, SSE2 et top-k, sans réseau au boot |
 | GGUF | Sonde structurelle GGUF v3 et primitives Q8_0 ; pas encore d’inférence quantifiée |
 | Réseau | `net-status` et profil OpenAI explicitement bloqué ; aucune pile réseau noyau |
 
-Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `spawn`, `yield`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les programmes initrd incluent `shell`, `idle`, `spin`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
+Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les programmes initrd incluent `shell`, `idle`, `spin`, `ipcserver`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
 
 ## Démarrage rapide
 
@@ -40,11 +41,12 @@ make run
 | Cible | Rôle |
 |---|---|
 | `make all` | Noyau, initrd et image overlay IDE de 64 secteurs |
-| `make test-all` | 161 tests C Unity/robustesse sans dépendre des poids GPT-2 |
+| `make test-all` | 166 tests C Unity/robustesse sans dépendre des poids GPT-2 |
 | `make qemu-smoke` | Scénarios QEMU classiques : overlay, persistance, spawn/yield et exec |
-| `make integration-qemu` | Contrats QEMU AOS-022, AOS-024 et AOS-025 |
+| `make integration-qemu` | Contrats QEMU AOS-022, AOS-024, AOS-025 et IPC Foundation |
 | `make qemu-irq0-preemption` | Lance `spin` puis exige un shell toujours réactif |
 | `make qemu-ai-provider` | Vérifie le diagnostic réseau et le blocage OpenAI |
+| `make qemu-ipc-foundation` | Lance `ipcserver`, envoie un message et vérifie sa réception |
 | `make iso` | Produit l’ISO BIOS/GRUB bootable |
 | `make run` / `make run-gui` | Session QEMU interactive curses ou GTK |
 
@@ -85,7 +87,7 @@ Le profil `ai-provider openai` est un **stub contrôlé**. `net-status` affiche 
 
 ## Tests et artefacts
 
-`make test-all` a validé **161/161** tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` ajoute trois validations QEMU séparées et réinitialise son disque de contrat, sans toucher à `build/overlay.img`.
+`make test-all` a validé **166/166** tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` ajoute quatre validations QEMU séparées, dont le contrat IPC Foundation, et réinitialise son disque de contrat sans toucher à `build/overlay.img`.
 
 Une ISO BIOS/GRUB peut être produite avec l’initrd. Lorsque les poids GPT-2 sont fournis, ils sont bien incorporés à l’ISO pour un fonctionnement local sur une machine vierge ; ils restent ignorés par Git.
 
@@ -100,6 +102,8 @@ Le backlog courant est [US/ai_os_us.md](US/ai_os_us.md). La vision MOHHOS est co
 - [x] Overlay ATA PIO V2, 64 nœuds et restauration V1
 - [x] Préemption IRQ0 sûre entre tâches Ring 3
 - [x] Stub OpenAI/network honnête et testable
+- [x] IPC Foundation non bloquant entre tâches Ring 3, avec identité d’émetteur noyau
+- [ ] Externalisation d’un premier service et migration microkernel réelle
 - [ ] Inference GGUF quantifiée et latence QEMU inférieure à une seconde
 - [ ] Pilote NIC, DHCP, DNS, TCP, TLS et client OpenAI effectif
 - [ ] Système de fichiers disque général (ext2/FAT)

--- a/US/README.md
+++ b/US/README.md
@@ -4,8 +4,8 @@ Deux couches distinctes. Ne pas les mélanger.
 
 | Couche | Document | Statut |
 |---|---|---|
-| **Prototype qui tourne** | [ai_os_us.md](ai_os_us.md) + [docs/ETAT_REEL.md](../docs/ETAT_REEL.md) | Fait / suite proche |
-| **Vision MOHHOS** | fichiers `mohhos_*.md` + [individual_us/](individual_us/INDEX.md) | Spécifications uniquement |
+| **Prototype qui tourne** | [ai_os_us.md](ai_os_us.md) + [docs/ETAT_REEL.md](../docs/ETAT_REEL.md) | AOS-001 à AOS-025 et IPC Foundation MOHHOS vérifiés |
+| **Vision MOHHOS** | fichiers `mohhos_*.md` + [individual_us/](individual_us/INDEX.md) | Spécifications, sauf incrément Foundation IPC documenté |
 
 En cas de contradiction, **ETAT_REEL** et **ai_os_us.md** priment.
 
@@ -21,9 +21,9 @@ Ce n'est **pas** TensorFlow Lite, pas un microkernel, pas `fake_ai` comme moteur
 
 ## Couche 2 — MOHHOS (archives de conception)
 
-Plan historique pour transformer AI-OS v5 en « Manus Operating Hybrid Hosted OS » (8 phases, 120 US, ~1640 j-h). **Aucune phase n'est livrée** dans le noyau.
+Plan historique pour transformer AI-OS v5 en « Manus Operating Hybrid Hosted OS » (8 phases, 120 US, ~1640 j-h). La première tranche de **Foundation** est maintenant livrée : une boîte aux lettres IPC locale, bornée et testée entre tâches Ring 3. Elle prépare US-001/US-003/US-013, mais ne migre encore aucun service vers un espace d’adressage séparé ; le noyau reste monolithique.
 
-Quelques fichiers MOHHOS **chevauchent** le prototype (mémoire, tests, moteur IA local, assistant). Le recouvrement est accidentel et partiel : voir le tableau dans [individual_us/INDEX.md](individual_us/INDEX.md). Un ✅ dans l'index MOHHOS signifie « fichier de spec présent », **pas** « implémenté ».
+Les autres fichiers MOHHOS restent des **spécifications**. Le recouvrement avec le prototype (mémoire, tests, moteur IA local, assistant et désormais IPC local) est partiel : voir le tableau dans [individual_us/INDEX.md](individual_us/INDEX.md). Un ✅ dans l’index MOHHOS signifie « fichier de spec présent », **pas** « implémenté », sauf lorsqu’un statut explicite de tranche livrée est indiqué.
 
 ### Fichiers MOHHOS
 
@@ -31,7 +31,8 @@ Quelques fichiers MOHHOS **chevauchent** le prototype (mémoire, tests, moteur I
 |---|---|
 | [mohhos_user_stories_master.md](mohhos_user_stories_master.md) | Index historique des 120 titres (numérotation parfois **différente** des fichiers) |
 | [recherche_technologies_mohhos.md](recherche_technologies_mohhos.md) | Veille (P2P, federated learning, navigateur-OS) |
-| [mohhos_us_phase1_foundation.md](mohhos_us_phase1_foundation.md) | Phase 1 détaillée (microkernel) — non commencée dans le code |
+| [mohhos_us_phase1_foundation.md](mohhos_us_phase1_foundation.md) | Phase 1 détaillée : incrément IPC livré, microkernel/services séparés non commencés |
+| [../docs/mohhos_foundation_increment_01_ipc.md](../docs/mohhos_foundation_increment_01_ipc.md) | Conception et contrat de l’incrément IPC Foundation livré |
 | [mohhos_us_phase2_ai_core.md](mohhos_us_phase2_ai_core.md) | Phase 2 (TensorFlow Lite, NLU, fédéré) — non livrée ; l'IA réelle est GPT-2 freestanding |
 | [mohhos_us_phase3_web_runtime.md](mohhos_us_phase3_web_runtime.md) | Phase 3 navigateur-OS — absente |
 | [mohhos_us_phases_4_8_synthese.md](mohhos_us_phases_4_8_synthese.md) | Phases 4-8 (PromptMessage, P2P, etc.) — absentes |
@@ -48,7 +49,7 @@ Quelques fichiers MOHHOS **chevauchent** le prototype (mémoire, tests, moteur I
 7. Collaborative (points)  
 8. Production  
 
-Ne pas planifier un sprint « US-001 microkernel » comme suite d'AI-OS. La suite proche est dans [ai_os_us.md](ai_os_us.md) (GGUF, BPE unicode, FS disque, tests d'intégration).
+La migration complète de US-001 reste une refonte à haut risque : l’incrément actuel fournit seulement le mécanisme IPC local. La suite doit externaliser un service précis derrière ce contrat, sans affirmer prématurément que les fichiers, pilotes ou le réseau sont déjà hors du noyau.
 
 ## Contribution
 

--- a/US/individual_us/INDEX.md
+++ b/US/individual_us/INDEX.md
@@ -3,6 +3,7 @@
 > **Légende (août 2026)**  
 > - **Spec** = fichier rédigé, **pas** livré dans le noyau.  
 > - **Chevauchement** = le prototype AI-OS a un voisinage technique (souvent une fraction du besoin).  
+> - **Livraison partielle** = mécanisme réellement compilé et testé, sans satisfaire tous les critères de la spec.
 > - Backlog du code réel : [../ai_os_us.md](../ai_os_us.md). Runtime : [../../docs/ETAT_REEL.md](../../docs/ETAT_REEL.md).
 
 Les titres du [document maître](../mohhos_user_stories_master.md) **ne correspondent pas toujours** aux noms de fichiers ci-dessous (ex. maître US-008 = « mise à jour automatique », fichier = tests automatisés). **Le fichier individuel fait foi** pour le texte de la spec. Les IDs **US-023, US-024 et US-025 existent en double**.
@@ -13,13 +14,14 @@ Il n'y a **pas** 120 fichiers : environ 78 specs détaillées + des phases décr
 
 | US fichier | Spec MOHHOS | Dans le prototype |
 |---|---|---|
-| US-001 | Microkernel + IPC | Non. Noyau monolithique `kernel/kernel.c` |
+| US-001 | Microkernel + IPC | **Livraison partielle :** endpoints FIFO IPC locaux entre tâches Ring 3 ; noyau monolithique, services non externalisés |
 | US-002 | Gestionnaire de ressources IA | PMM / VMM / heap / `SYS_MEMINFO` seulement |
-| US-003 | Sécurité adaptative IA | Isolation Ring 0/3, pas de détection de menaces |
+| US-003 | Sécurité adaptative IA | Isolation Ring 0/3 et PID d’émetteur IPC attribué par le noyau ; pas de capabilities ni de détection de menaces |
 | US-007 | Monitoring temps réel | `ps` / `mem` / `uptime` / `SYS_TICKS`, pas de télémétrie |
-| US-008 | Framework de tests IA | Unity 144 + `make qemu-smoke` + GitHub Actions ; dossiers integration/system/performance/robustness vides |
+| US-008 | Framework de tests IA | Unity 166 + contrats QEMU (cœur, IRQ0, fournisseur IA, IPC) + GitHub Actions ; pas de framework distribué |
 | US-010 | Pilotes modulaires | PIC, PIT, PS/2, ATA PIO ; pas de framework de drivers |
-| US-012 | APIs unifiées | `include/os_syscalls.h` (23 syscalls) |
+| US-012 | APIs unifiées | `include/os_syscalls.h` (25 syscalls), dont `SYS_IPC_SEND`/`SYS_IPC_RECV` |
+| US-013 | Communication inter-services | **Livraison partielle :** boîte aux lettres IPC locale non bloquante ; pas de protocoles inter-services complets |
 | US-016 | Moteur TensorFlow Lite | GPT-2 124M freestanding (`SYS_GPT2_GENERATE`), pas TFLite |
 | US-017 | NLU 90 % d'intentions | BPE + complétion 12 jetons, pas d'analyse d'intention |
 | US-021 | Assistant IA proactif | Builtin `ai <texte>` synchrone et borné |

--- a/US/mohhos_us_phase1_foundation.md
+++ b/US/mohhos_us_phase1_foundation.md
@@ -1,6 +1,6 @@
 # MOHHOS - Phase 1 Foundation - User Stories Détaillées
 
-> **État réel (août 2026).** Phase **non commencée dans le code** : le noyau reste monolithique (`kernel/kernel.c`). Ce n'est pas la suite du prototype (voir [ai_os_us.md](ai_os_us.md)). Specs conservées. Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+> **État réel (août 2026).** L’incrément Foundation 01 a livré une boîte aux lettres IPC locale, bornée et testée entre tâches Ring 3 ; voir [la note de conception](../docs/mohhos_foundation_increment_01_ipc.md). Le noyau reste monolithique (`kernel/kernel.c`) : aucun VFS, pilote ou réseau n’a encore été déplacé dans un service isolé. Les critères complets de microkernel ci-dessous restent à réaliser. Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
 
 ## Vue d'Ensemble de la Phase 1
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -14,6 +14,7 @@ AI-OS démarre sans système hôte dans QEMU, charge un initrd TAR, lance un she
 | IA locale | GPT-2 124M `llm.c v3`, BPE, cache KV, SSE2 et top-k, sans réseau au boot |
 | Stockage | Initrd TAR en lecture seule et overlay ATA PIO persistant V2 |
 | Ordonnancement | Coopératif par syscall et quantum IRQ0 sûr entre tâches utilisateur |
+| IPC Foundation MOHHOS | Boîte aux lettres FIFO non bloquante entre tâches Ring 3, messages de 96 octets, 4 entrées par tâche |
 | Réseau | **Aucun transport réseau noyau** ; diagnostic et profil OpenAI explicitement bloqués |
 
 > Les poids GPT-2 ne sont pas versionnés dans Git. Une image utilisable sans réseau les embarque dans l’initrd au moment du build.
@@ -27,6 +28,8 @@ Le noyau configure GDT, IDT, PIC 8259, PIT 100 Hz, i8042 PS/2, PMM/VMM/heap, pag
 L’overlay RAM persistant utilise désormais le format snapshot **V2** : 64 nœuds, chemins de 80 octets, contenu de 384 octets et 64 secteurs ATA PIO. `overlay_restore()` reconnaît également le format V1 afin de restaurer les images de disque déjà créées. Il ne s’agit pas d’un système de fichiers général : ext2, FAT, répertoires sur disque et cache de blocs sont absents.
 
 Les appels `spawn`, `yield` et `exec` continuent de changer de contexte depuis le cadre utilisateur de `int 0x80`. En complément, IRQ0 déclenche un round-robin toutes les 20 interruptions uniquement si le cadre interrompu est Ring 3 et si une **autre** tâche utilisateur est `READY`. Cela évite les cadres noyau incomplets et empêche un quantum inutile en mono-tâche. Le contrat QEMU lance `spin`, une boucle utilisateur sans syscall, puis exige une nouvelle commande du shell : la réactivité obtenue démontre la préemption réelle.
+
+Le premier incrément MOHHOS ajoute une boîte aux lettres **IPC Foundation** par tâche utilisateur. `SYS_IPC_SEND` transmet un payload borné de 96 octets vers un PID utilisateur valide et le noyau inscrit lui-même le PID d’émetteur ; `SYS_IPC_RECV` retire le plus ancien message de la FIFO. Chaque endpoint tient quatre messages, rejette explicitement la saturation et ne bloque jamais le destinataire. Après un envoi réussi, le noyau réalise un handoff coopératif lorsqu’une autre tâche utilisateur est prête : cela permet au destinataire de traiter le message avant que le shell ne retourne dans `SYS_GETS`, cadre Ring 0 non préemptable par IRQ0. Le contrat QEMU lance `ipcserver`, envoie `bonjour`, vérifie l’émetteur puis confirme une boîte aux lettres vide. Ce mécanisme prépare l’externalisation ultérieure des services ; il ne constitue ni un microkernel ni un IPC à capabilities.
 
 ### IA locale, GGUF et BPE
 
@@ -53,29 +56,29 @@ QEMU sait relier une carte réseau virtuelle ISA ou PCI à un backend hôte, et 
 
 ## Shell et ABI observables
 
-Le shell Ring 3 propose `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `test`, `grep`, `wc`, `sort`, `head`, `tail`, `ps`, `jobs`, `top`, `spawn`, `yield`, `kill`, `exec`, `mem`, `uptime`, `history`, `alias`, `env`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les opérations de fichiers modifiables passent par l’overlay noyau ; l’initrd demeure en lecture seule. Les programmes empaquetés incluent `shell`, `idle`, `spin`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
+Le shell Ring 3 propose `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `test`, `grep`, `wc`, `sort`, `head`, `tail`, `ps`, `jobs`, `top`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `kill`, `exec`, `mem`, `uptime`, `history`, `alias`, `env`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les opérations de fichiers modifiables passent par l’overlay noyau ; l’initrd demeure en lecture seule. Les programmes empaquetés incluent `shell`, `idle`, `spin`, `ipcserver`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
 
-L’ABI contient les syscalls 0–22 (`MAX_SYSCALLS = 23`) dont `SYS_APPEND` et `SYS_GPT2_GENERATE`. Le profil local ne nécessite aucun secret ni aucune dépendance réseau à l’exécution.
+L’ABI contient les syscalls 0–24 (`MAX_SYSCALLS = 25`), dont `SYS_APPEND`, `SYS_GPT2_GENERATE`, `SYS_IPC_SEND` et `SYS_IPC_RECV`. Le profil local ne nécessite aucun secret ni aucune dépendance réseau à l’exécution.
 
 ## Vérification reproductible
 
 ```bash
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386 grub-pc-bin xorriso
 make clean && make all       # noyau, initrd et disque overlay
-make test-all                # 161/161 tests C Unity et robustesse
-make integration-qemu        # contrats AOS-022, AOS-024 et AOS-025
+make test-all                # 166/166 tests C Unity et robustesse
+make integration-qemu        # contrats AOS-022/AOS-024/AOS-025 et IPC Foundation
 make iso                     # ISO BIOS/GRUB bootable
 make run                     # console curses
 make run-gui                 # fenêtre GTK
 ```
 
-La suite C exécute 161 assertions de tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` démarre trois machines QEMU séparées : le contrat cœur AOS-022 utilise une image overlay de test isolée, le contrat IRQ0 AOS-024 préempte `spin`, et le smoke AOS-025 vérifie que le profil OpenAI reste bloqué.
+La suite C exécute 166 assertions de tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` démarre quatre machines QEMU séparées : le contrat cœur AOS-022 utilise une image overlay de test isolée, le contrat IRQ0 AOS-024 préempte `spin`, le smoke AOS-025 vérifie que le profil OpenAI reste bloqué, et le contrat Foundation livre un message à `ipcserver`.
 
 Le build a également produit une ISO GRUB BIOS avec l’initrd GPT-2 local. Avec les actifs disponibles dans l’environnement de vérification, l’ISO est d’environ 481 Mio ; les modèles restent exclus du versionnement.
 
 ## Absences importantes
 
-AI-OS ne fournit pas de système de fichiers disque général, de pilote réseau, de pile TCP/IP/TLS, de client OpenAI/Ollama effectif, d’UEFI, de gestion multiprocesseur, de GUI native, de microkernel, d’IPC général ni des fonctionnalités de la vision MOHHOS. Les rapports historiques conservés dans `docs/` sont des éléments de chronologie et non la description de l’état courant.
+AI-OS ne fournit pas de système de fichiers disque général, de pilote réseau, de pile TCP/IP/TLS, de client OpenAI/Ollama effectif, d’UEFI, de gestion multiprocesseur, de GUI native, de microkernel, d’IPC bloquant avec réponses corrélées, de transfert de capabilities ni des fonctionnalités avancées de la vision MOHHOS. La boîte aux lettres IPC Foundation est un mécanisme local préparatoire, non une migration de services hors du noyau. Les rapports historiques conservés dans `docs/` sont des éléments de chronologie et non la description de l’état courant.
 
 ## Références
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,12 @@ Depuis la racine du dépôt : `make deps` (script [`scripts/bootstrap-dev.sh`](.
 
 1. [ETAT_REEL.md](ETAT_REEL.md) - **état actuel du code**, y compris GPT-2 local et limites vérifiées
 2. [../US/ai_os_us.md](../US/ai_os_us.md) - user stories du prototype (fait + suite)
-3. [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) - sonde GGUF v3 et quantification préparatoire
-4. [aos025_network_stub.md](aos025_network_stub.md) - statut réseau/OpenAI et suite de livraison
-5. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
-6. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
-7. [../README.md](../README.md) - compilation, tests, architecture des sources
+3. [mohhos_foundation_increment_01_ipc.md](mohhos_foundation_increment_01_ipc.md) - IPC Foundation MOHHOS, limites et contrat QEMU
+4. [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) - sonde GGUF v3 et quantification préparatoire
+5. [aos025_network_stub.md](aos025_network_stub.md) - statut réseau/OpenAI et suite de livraison
+6. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
+7. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
+8. [../README.md](../README.md) - compilation, tests, architecture des sources
 
 Les autres fichiers de ce dossier sont conservés : rapports de debug, chronologie des correctifs clavier, spécifications d'étapes. Beaucoup décrivent un état **intermédiaire** (shell simulé dans le kernel, crash timer, clavier mort). Ils ne sont pas effacés.
 
@@ -22,6 +23,7 @@ Les autres fichiers de ce dossier sont conservés : rapports de debug, chronolog
 |---|---|
 | [ETAT_REEL.md](ETAT_REEL.md) | État fonctionnel, GPT-2 local et limites vérifiées |
 | [../US/ai_os_us.md](../US/ai_os_us.md) | Backlog du prototype, AOS-001…025 et limites restantes |
+| [mohhos_foundation_increment_01_ipc.md](mohhos_foundation_increment_01_ipc.md) | IPC Foundation entre tâches Ring 3, limites de la tranche et contrat QEMU |
 | [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) | Sonde GGUF v3, primitives Q8_0 et limites des kernels quantifiés |
 | [aos025_network_stub.md](aos025_network_stub.md) | Stub OpenAI, diagnostic réseau et critères de sortie d’un transport réel |
 | [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) | Préparation des artefacts, construction et démarrage d'une ISO GPT-2 hors ligne |
@@ -87,4 +89,4 @@ Les captures QEMU et les exports Word ont été retirés du dépôt (la source r
 - [../US/README.md](../US/README.md) — deux couches : AI-OS vs vision MOHHOS
 - [../US/individual_us/INDEX.md](../US/individual_us/INDEX.md) — specs MOHHOS, chevauchements, IDs dupliqués
 
-Les 8 phases MOHHOS restent des **spécifications**. Elles ne décrivent pas GPT-2, l'overlay ATA ni `spawn`/`exec`.
+Les phases MOHHOS restent majoritairement des **spécifications**. L’exception actuelle est l’incrément Foundation IPC, réellement compilé et testé ; il ne transforme pas encore le noyau monolithique en microkernel et n’implémente pas les autres phases.

--- a/docs/mohhos_foundation_increment_01_ipc.md
+++ b/docs/mohhos_foundation_increment_01_ipc.md
@@ -1,0 +1,59 @@
+# MOHHOS Foundation — incrément 01 : IPC local borné
+
+**Statut :** première tranche livrée, compatible avec AI-OS.
+
+**Portée MOHHOS :** prérequis réduit de US-001 (microkernel/IPC), US-003 (contrôle d’accès) et US-013 (communication inter-services).
+
+**Non-objectif :** cette livraison ne transforme pas encore AI-OS en microkernel.
+
+## Décision d’architecture
+
+La migration directe des services de fichiers, réseau et pilotes vers des processus séparés détruirait l’ABI et le chemin de boot actuellement testés. La première étape introduit donc le mécanisme qui manque au prototype : une **boîte aux lettres FIFO par tâche utilisateur**, gérée par le noyau et accessible par deux syscalls. Les services restent temporairement dans le noyau ; le transport est séparé et peut ensuite être utilisé lors de leur externalisation.
+
+Cette approche reprend uniquement les propriétés minimales utiles du modèle d’endpoint : messages courts, files d’attente bornées et identité de l’émetteur attribuée par le noyau. Les microkernels L4/seL4 utilisent des endpoints pour des transmissions IPC bornées et synchrones ; leur modèle distingue le mécanisme noyau de la politique portée par les services [1] [2]. AI-OS démarre avec une variante **asynchrone non bloquante**, plus facile à intégrer à son ordonnanceur actuel.
+
+| Élément | Contrat de l’incrément |
+|---|---|
+| Destinataire | Tâche utilisateur existante et non terminée, sélectionnée par PID |
+| Identité de l’émetteur | PID de `current_task`, jamais fourni par l’appelant |
+| File | FIFO fixe de 4 messages par tâche |
+| Charge utile | 96 octets au maximum, copiés par valeur dans le noyau |
+| Envoi quand la file est pleine | Échec explicite, sans écrasement de message |
+| Après un envoi réussi | Handoff coopératif vers une autre tâche utilisateur prête, pour livrer avant le prochain `SYS_GETS` du shell |
+| Réception quand la file est vide | Échec explicite non bloquant |
+| Accès noyau | Interdit via l’API syscall : seules les tâches Ring 3 sont des endpoints |
+| Partage mémoire/capabilities | Hors périmètre de cette tranche |
+
+## ABI proposée
+
+Deux numéros sont ajoutés après `SYS_GPT2_GENERATE` sans modifier les numéros existants.
+
+| Syscall | Registres | Retour |
+|---|---|---|
+| `SYS_IPC_SEND` (23) | `EBX = pid cible`, `ECX = os_ipc_payload_t*` | `0` ou erreur IPC négative |
+| `SYS_IPC_RECV` (24) | `EBX = os_ipc_message_t*` | `0` ou `OS_IPC_EMPTY` |
+
+`os_ipc_payload_t` contient seulement le type et les octets transmis. `os_ipc_message_t`, reçu par le destinataire, ajoute le PID d’émetteur construit par le noyau. Cette séparation interdit à un client de revendiquer l’identité d’une autre tâche.
+
+| Code | Sens |
+|---|---|
+| `OS_IPC_EMPTY` | Aucune donnée à lire ; le destinataire reste exécutable |
+| `OS_IPC_FULL` | File du destinataire saturée ; aucun message n’est perdu |
+| `OS_IPC_BAD_TARGET` | PID absent, tâche noyau ou tâche terminée |
+| `OS_IPC_BAD_MESSAGE` | Pointeur nul ou taille supérieure à 96 octets |
+
+## Démonstration et non-régression
+
+Le shell ajoute `ipc-send <pid> <texte>` et `ipc-recv`. Le programme initrd `ipcserver` appelle `ipc-recv` dans une boucle, affiche le PID et le contenu reçus, puis cède le processeur. Le contrat QEMU lance ce serveur, envoie un message depuis le shell et vérifie la réception. Les tests C vérifient l’ordre FIFO, la conservation de l’émetteur, la saturation et le rejet de cible invalide.
+
+Les systèmes de fichiers, GPT-2, overlay, préemption IRQ0 et syscalls existants restent inchangés et sont revalidés par `make test-all` et `make integration-qemu`.
+
+## Limites et prochain incrément
+
+Une boîte aux lettres fixe n’apporte pas l’isolation d’un microkernel : le VFS, l’ATA, le GPT-2 et les pilotes s’exécutent toujours en Ring 0. Le handoff est nécessaire parce que le shell attend les caractères dans `SYS_GETS`, cadre Ring 0 que le quantum IRQ0 ne préempte volontairement pas. L’incrément suivant pourra construire un **service VFS Ring 3** autour de l’IPC, avec une politique d’autorisation explicite et un modèle d’attente repensé. Un IPC bloquant, des réponses corrélées et des capabilities déléguées sont également reportés.
+
+## Références
+
+[1] [seL4 FAQ — définition d’un microkernel et séparation mécanisme/politique](https://sel4.systems/About/FAQ.html)
+
+[2] [seL4 IPC tutorial — endpoints, files de threads et messages bornés](https://docs.sel4.systems/Tutorials/ipc.html)

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -29,8 +29,19 @@
 #define SYS_APPEND   21
 /* prompt (EBX), buffer de reponse (ECX), taille du buffer (EDX) */
 #define SYS_GPT2_GENERATE 22
+/* EBX = PID cible, ECX = os_ipc_payload_t* */
+#define SYS_IPC_SEND      23
+/* EBX = os_ipc_message_t* */
+#define SYS_IPC_RECV      24
 
-#define MAX_SYSCALLS 23
+#define MAX_SYSCALLS 25
+
+/* IPC Foundation : messages courts, copies par valeur et retours non bloquants. */
+#define OS_IPC_MAX_DATA 96U
+#define OS_IPC_EMPTY       (-40)
+#define OS_IPC_FULL        (-41)
+#define OS_IPC_BAD_TARGET  (-42)
+#define OS_IPC_BAD_MESSAGE (-43)
 
 #define OS_NAME_MAX 64
 #define OS_PROC_NAME_MAX 32
@@ -64,5 +75,20 @@ typedef struct {
     uint32_t used_pages;
     uint32_t free_pages;
 } os_meminfo_t;
+
+/* Charge fournie par l'émetteur : son identité est ajoutée par le noyau. */
+typedef struct {
+    uint32_t type;
+    uint32_t size;
+    uint8_t data[OS_IPC_MAX_DATA];
+} os_ipc_payload_t;
+
+/* Message délivré au destinataire depuis sa boîte aux lettres noyau. */
+typedef struct {
+    int32_t sender_pid;
+    uint32_t type;
+    uint32_t size;
+    uint8_t data[OS_IPC_MAX_DATA];
+} os_ipc_message_t;
 
 #endif

--- a/kernel/ipc.c
+++ b/kernel/ipc.c
@@ -1,0 +1,58 @@
+#include "ipc.h"
+
+void ipc_endpoint_init(ipc_endpoint_t* endpoint) {
+    uint32_t i;
+    uint32_t j;
+    if (!endpoint) return;
+    endpoint->read_index = 0U;
+    endpoint->write_index = 0U;
+    endpoint->count = 0U;
+    for (i = 0U; i < IPC_ENDPOINT_CAPACITY; i++) {
+        endpoint->messages[i].sender_pid = -1;
+        endpoint->messages[i].type = 0U;
+        endpoint->messages[i].size = 0U;
+        for (j = 0U; j < OS_IPC_MAX_DATA; j++) endpoint->messages[i].data[j] = 0U;
+    }
+}
+
+int ipc_endpoint_send(ipc_endpoint_t* endpoint, int32_t sender_pid,
+                      const os_ipc_payload_t* payload) {
+    os_ipc_message_t* destination;
+    uint32_t i;
+    if (!endpoint || !payload || payload->size > OS_IPC_MAX_DATA) {
+        return OS_IPC_BAD_MESSAGE;
+    }
+    if (endpoint->count >= IPC_ENDPOINT_CAPACITY) return OS_IPC_FULL;
+
+    destination = &endpoint->messages[endpoint->write_index];
+    destination->sender_pid = sender_pid;
+    destination->type = payload->type;
+    destination->size = payload->size;
+    for (i = 0U; i < payload->size; i++) destination->data[i] = payload->data[i];
+    for (; i < OS_IPC_MAX_DATA; i++) destination->data[i] = 0U;
+
+    endpoint->write_index = (endpoint->write_index + 1U) % IPC_ENDPOINT_CAPACITY;
+    endpoint->count++;
+    return 0;
+}
+
+int ipc_endpoint_receive(ipc_endpoint_t* endpoint, os_ipc_message_t* out) {
+    os_ipc_message_t* source;
+    uint32_t i;
+    if (!endpoint || !out) return OS_IPC_BAD_MESSAGE;
+    if (endpoint->count == 0U) return OS_IPC_EMPTY;
+
+    source = &endpoint->messages[endpoint->read_index];
+    out->sender_pid = source->sender_pid;
+    out->type = source->type;
+    out->size = source->size;
+    for (i = 0U; i < OS_IPC_MAX_DATA; i++) out->data[i] = source->data[i];
+
+    source->sender_pid = -1;
+    source->type = 0U;
+    source->size = 0U;
+    for (i = 0U; i < OS_IPC_MAX_DATA; i++) source->data[i] = 0U;
+    endpoint->read_index = (endpoint->read_index + 1U) % IPC_ENDPOINT_CAPACITY;
+    endpoint->count--;
+    return 0;
+}

--- a/kernel/ipc.h
+++ b/kernel/ipc.h
@@ -1,0 +1,22 @@
+#ifndef IPC_H
+#define IPC_H
+
+#include <stdint.h>
+#include "os_syscalls.h"
+
+/* Une capacité réduite évite qu'une tâche monopolise le tas noyau. */
+#define IPC_ENDPOINT_CAPACITY 4U
+
+typedef struct {
+    os_ipc_message_t messages[IPC_ENDPOINT_CAPACITY];
+    uint32_t read_index;
+    uint32_t write_index;
+    uint32_t count;
+} ipc_endpoint_t;
+
+void ipc_endpoint_init(ipc_endpoint_t* endpoint);
+int ipc_endpoint_send(ipc_endpoint_t* endpoint, int32_t sender_pid,
+                      const os_ipc_payload_t* payload);
+int ipc_endpoint_receive(ipc_endpoint_t* endpoint, os_ipc_message_t* out);
+
+#endif

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -163,11 +163,41 @@ void syscall_handler(cpu_state_t* cpu) {
         case SYS_GPT2_GENERATE:
             cpu->eax = (uint32_t)sys_gpt2_generate((const char*)cpu->ebx, (char*)cpu->ecx, cpu->edx);
             break;
+        case SYS_IPC_SEND:
+            cpu->eax = (uint32_t)sys_ipc_send((int)cpu->ebx,
+                                               (const os_ipc_payload_t*)cpu->ecx);
+            /* Le shell dort ensuite dans SYS_GETS (Ring 0) et ne peut pas être
+             * préempté par IRQ0. Un handoff coopératif livre donc sans délai un
+             * message à une autre tâche utilisateur déjà prête. */
+            if ((int)cpu->eax == 0 && task_has_other_ready_user()) schedule(cpu);
+            break;
+        case SYS_IPC_RECV:
+            cpu->eax = (uint32_t)sys_ipc_receive((os_ipc_message_t*)cpu->ebx);
+            break;
             
         default:
             // Syscall inconnu
             break;
     }
+}
+
+int sys_ipc_send(int target_pid, const os_ipc_payload_t* payload) {
+    task_t* target;
+    if (!current_task || !payload || payload->size > OS_IPC_MAX_DATA) {
+        return OS_IPC_BAD_MESSAGE;
+    }
+    target = get_task_by_id(target_pid);
+    if (!target || target->type != TASK_TYPE_USER || target->state == TASK_TERMINATED) {
+        return OS_IPC_BAD_TARGET;
+    }
+    return ipc_endpoint_send(&target->ipc_endpoint, current_task->id, payload);
+}
+
+int sys_ipc_receive(os_ipc_message_t* out) {
+    if (!current_task || current_task->type != TASK_TYPE_USER || !out) {
+        return OS_IPC_BAD_MESSAGE;
+    }
+    return ipc_endpoint_receive(&current_task->ipc_endpoint, out);
 }
 
 /*

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -37,6 +37,8 @@ int sys_rename(const char* oldpath, const char* newpath);
 int sys_copy(const char* src, const char* dst);
 int sys_append(const char* path, const char* buf, uint32_t n);
 int sys_gpt2_generate(const char* prompt, char* out, uint32_t max);
+int sys_ipc_send(int target_pid, const os_ipc_payload_t* payload);
+int sys_ipc_receive(os_ipc_message_t* out);
 
 void keyboard_add_char_to_buffer(char c);
 

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -34,6 +34,7 @@ void tasking_init() {
     current_task->vmm_dir = kernel_directory;
     current_task->kernel_stack_p = 0;
     current_task->waiter_pid = 0;
+    ipc_endpoint_init(&current_task->ipc_endpoint);
     current_task->name[0] = 'k';
     current_task->name[1] = 'e';
     current_task->name[2] = 'r';
@@ -242,6 +243,7 @@ task_t* create_task_from_initrd_file(const char* filename) {
     new_task->type = TASK_TYPE_USER;
     new_task->vmm_dir = vmm_dir;
     new_task->waiter_pid = 0;
+    ipc_endpoint_init(&new_task->ipc_endpoint);
     {
         int i = 0;
         const char* n = name_src ? name_src : "user";

--- a/kernel/task/task.h
+++ b/kernel/task/task.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include "kernel/mem/vmm.h" // Inclure pour vmm_directory_t
 #include "os_syscalls.h"
+#include "../ipc.h"
 
 // États possibles d'une tâche
 typedef enum {
@@ -43,6 +44,7 @@ typedef struct task {
     uint32_t kernel_stack_p;   // Pointeur vers le sommet de la pile noyau
     char name[32];
     int waiter_pid;            // Parent TASK_WAITING (SYS_EXEC), 0 sinon
+    ipc_endpoint_t ipc_endpoint; // Boîte aux lettres IPC propre à la tâche
     struct task* next;         // Pour la liste chaînée de tâches
     struct task* prev;         // Liste doublement chaînée
 } task_t;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -102,6 +102,11 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_quant: $(UNIT_DIR)/kernel/test_gpt2_qu
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ipc: $(UNIT_DIR)/kernel/test_ipc.c ../kernel/ipc.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ipc.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
 $(BUILD_DIR)/$(ROBUSTNESS_DIR)/test_gpt2_gguf_bounds: $(ROBUSTNESS_DIR)/test_gpt2_gguf_bounds.c ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES)

--- a/tests/integration/test_qemu_ipc_foundation.py
+++ b/tests/integration/test_qemu_ipc_foundation.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Contrat MOHHOS Foundation : transport IPC entre deux tâches Ring 3."""
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+LOG_DIR = os.path.join(ROOT, "test_logs")
+LOG = os.path.join(LOG_DIR, "ipc-foundation.log")
+ERR = os.path.join(LOG_DIR, "ipc-foundation.err")
+MON = os.path.join(LOG_DIR, "ipc-foundation-monitor.sock")
+KERNEL = os.path.join(ROOT, "build", "ai_os.bin")
+INITRD = os.path.join(ROOT, "my_initrd.tar")
+
+
+def log_text():
+    try:
+        with open(LOG, "r", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
+def wait_for(needle, proc, offset=0, timeout=15):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError("QEMU s'est arrêté prématurément")
+        if needle in log_text()[offset:]:
+            return
+        time.sleep(0.1)
+    raise RuntimeError("sortie manquante : %s" % needle)
+
+
+def connect_monitor():
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if os.path.exists(MON):
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                client.connect(MON)
+                client.settimeout(0.1)
+                try:
+                    client.recv(4096)
+                except socket.timeout:
+                    pass
+                return client
+            except OSError:
+                client.close()
+        time.sleep(0.1)
+    raise RuntimeError("moniteur QEMU indisponible")
+
+
+def send_command(client, command):
+    special = {" ": "spc", "-": "minus"}
+    for char in command:
+        client.sendall(("sendkey %s\n" % special.get(char, char.lower())).encode("ascii"))
+        time.sleep(0.06)
+    client.sendall(b"sendkey ret\n")
+
+
+def main():
+    os.makedirs(LOG_DIR, exist_ok=True)
+    for path in (LOG, ERR, MON):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    command = [
+        "qemu-system-i386", "-kernel", KERNEL, "-initrd", INITRD,
+        "-m", "1024M", "-display", "none", "-vga", "none",
+        "-serial", "file:" + LOG,
+        "-monitor", "unix:%s,server,nowait" % MON,
+        "-machine", "type=pc,accel=tcg", "-no-reboot", "-no-shutdown",
+    ]
+    with open(ERR, "wb") as err_handle:
+        proc = subprocess.Popen(command, stdout=err_handle, stderr=err_handle)
+        monitor = None
+        try:
+            wait_for("(-.-)", proc)
+            monitor = connect_monitor()
+            before_spawn = len(log_text())
+            send_command(monitor, "spawn ipcserver")
+            wait_for("spawn ok pid", proc, before_spawn)
+            spawned = re.search(r"spawn ok pid (\d+) ipcserver", log_text()[before_spawn:])
+            if not spawned:
+                raise RuntimeError("PID du serveur IPC absent")
+            server_pid = spawned.group(1)
+            wait_for("ipc_server ready", proc, before_spawn)
+            before_send = len(log_text())
+            send_command(monitor, "ipc-send %s bonjour" % server_pid)
+            wait_for("ipc-send ok %s 7" % server_pid, proc, before_send)
+            wait_for("ipc recv from 1 type 0 data bonjour", proc, before_send)
+            before_receive = len(log_text())
+            send_command(monitor, "ipc-recv")
+            wait_for("ipc-recv empty", proc, before_receive)
+            print("MOHHOS Foundation IPC contract passed")
+            return 0
+        finally:
+            if monitor is not None:
+                monitor.close()
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            try:
+                os.remove(MON)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print("MOHHOS Foundation IPC contract failed: %s" % error, file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -111,6 +111,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_gpt2_quant.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_quant.c"
     fi
+    if [ "$(basename "$test_file")" = "test_ipc.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/ipc.c"
+    fi
     if [ "$(basename "$test_file")" = "test_gpt2_gguf_bounds.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_gguf.c"
     fi

--- a/tests/unit/kernel/test_ipc.c
+++ b/tests/unit/kernel/test_ipc.c
@@ -1,0 +1,89 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/ipc.h"
+
+static ipc_endpoint_t endpoint;
+
+static os_ipc_payload_t make_payload(uint32_t type, const char* text) {
+    os_ipc_payload_t payload;
+    uint32_t i = 0U;
+    payload.type = type;
+    while (text[i] != '\0' && i < OS_IPC_MAX_DATA) {
+        payload.data[i] = (uint8_t)text[i];
+        i++;
+    }
+    payload.size = i;
+    while (i < OS_IPC_MAX_DATA) payload.data[i++] = 0U;
+    return payload;
+}
+
+static void test_endpoint_is_empty_after_init(void) {
+    os_ipc_message_t message;
+    ipc_endpoint_init(&endpoint);
+    TEST_ASSERT_EQUAL(OS_IPC_EMPTY, ipc_endpoint_receive(&endpoint, &message));
+}
+
+static void test_send_copies_payload_and_sender(void) {
+    os_ipc_payload_t payload = make_payload(7U, "bonjour");
+    os_ipc_message_t message;
+    ipc_endpoint_init(&endpoint);
+    TEST_ASSERT_EQUAL(0, ipc_endpoint_send(&endpoint, 42, &payload));
+    payload.data[0] = (uint8_t)'X';
+    TEST_ASSERT_EQUAL(0, ipc_endpoint_receive(&endpoint, &message));
+    TEST_ASSERT_EQUAL(42, message.sender_pid);
+    TEST_ASSERT_EQUAL(7, message.type);
+    TEST_ASSERT_EQUAL(7, message.size);
+    TEST_ASSERT_EQUAL('b', message.data[0]);
+    TEST_ASSERT_EQUAL('r', message.data[6]);
+}
+
+static void test_messages_preserve_fifo_order(void) {
+    os_ipc_payload_t first = make_payload(1U, "un");
+    os_ipc_payload_t second = make_payload(2U, "deux");
+    os_ipc_message_t message;
+    ipc_endpoint_init(&endpoint);
+    TEST_ASSERT_EQUAL(0, ipc_endpoint_send(&endpoint, 10, &first));
+    TEST_ASSERT_EQUAL(0, ipc_endpoint_send(&endpoint, 11, &second));
+    TEST_ASSERT_EQUAL(0, ipc_endpoint_receive(&endpoint, &message));
+    TEST_ASSERT_EQUAL(10, message.sender_pid);
+    TEST_ASSERT_EQUAL(1, message.type);
+    TEST_ASSERT_EQUAL('u', message.data[0]);
+    TEST_ASSERT_EQUAL(0, ipc_endpoint_receive(&endpoint, &message));
+    TEST_ASSERT_EQUAL(11, message.sender_pid);
+    TEST_ASSERT_EQUAL(2, message.type);
+    TEST_ASSERT_EQUAL('d', message.data[0]);
+}
+
+static void test_full_endpoint_keeps_existing_messages(void) {
+    os_ipc_payload_t payload = make_payload(3U, "x");
+    os_ipc_message_t message;
+    uint32_t i;
+    ipc_endpoint_init(&endpoint);
+    for (i = 0U; i < IPC_ENDPOINT_CAPACITY; i++) {
+        payload.type = i;
+        TEST_ASSERT_EQUAL(0, ipc_endpoint_send(&endpoint, (int32_t)i, &payload));
+    }
+    TEST_ASSERT_EQUAL(OS_IPC_FULL, ipc_endpoint_send(&endpoint, 99, &payload));
+    TEST_ASSERT_EQUAL(0, ipc_endpoint_receive(&endpoint, &message));
+    TEST_ASSERT_EQUAL(0, message.sender_pid);
+    TEST_ASSERT_EQUAL(0, message.type);
+}
+
+static void test_invalid_payload_is_rejected(void) {
+    os_ipc_payload_t payload = make_payload(1U, "x");
+    ipc_endpoint_init(&endpoint);
+    payload.size = OS_IPC_MAX_DATA + 1U;
+    TEST_ASSERT_EQUAL(OS_IPC_BAD_MESSAGE, ipc_endpoint_send(&endpoint, 1, &payload));
+    TEST_ASSERT_EQUAL(OS_IPC_BAD_MESSAGE, ipc_endpoint_send(0, 1, &payload));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_endpoint_is_empty_after_init);
+    RUN_TEST(test_send_copies_payload_and_sender);
+    RUN_TEST(test_messages_preserve_fifo_order);
+    RUN_TEST(test_full_endpoint_keeps_existing_messages);
+    RUN_TEST(test_invalid_payload_is_rejected);
+    unity_print_results();
+    unity_cleanup();
+    return unity_stats.tests_failed == 0 ? 0 : 1;
+}

--- a/userspace/Makefile
+++ b/userspace/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -nostdlib -Ttext=0x40000000
 ASFLAGS = --32
 
 # Programmes à compiler
-PROGRAMS = shell fake_ai test_program ai_assistant idle spin ok
+PROGRAMS = shell fake_ai test_program ai_assistant idle spin ipcserver ok
 
 all: $(PROGRAMS)
 
@@ -34,6 +34,10 @@ idle: idle.o start.o
 
 spin: spin.o start.o
 	@echo "Linking spin..."
+	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
+
+ipcserver: ipc_server.o start.o
+	@echo "Linking ipcserver..."
 	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
 
 ok: ok.o start.o

--- a/userspace/ipc_server.c
+++ b/userspace/ipc_server.c
@@ -1,0 +1,60 @@
+#include "os_syscalls.h"
+
+static void putc(char c) {
+    asm volatile("int $0x80" : : "a"(SYS_PUTC), "b"(c));
+}
+
+static void puts(const char* text) {
+    int i = 0;
+    while (text[i] != '\0') putc(text[i++]);
+}
+
+static void print_int(int value) {
+    char digits[12];
+    int n = 0;
+    unsigned int number;
+    if (value < 0) {
+        putc('-');
+        number = (unsigned int)(-value);
+    } else {
+        number = (unsigned int)value;
+    }
+    if (number == 0U) {
+        putc('0');
+        return;
+    }
+    while (number > 0U && n < 11) {
+        digits[n++] = (char)('0' + (number % 10U));
+        number /= 10U;
+    }
+    while (n > 0) putc(digits[--n]);
+}
+
+static int ipc_receive(os_ipc_message_t* message) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_IPC_RECV), "b"(message));
+    return result;
+}
+
+static void yield(void) {
+    asm volatile("int $0x80" : : "a"(SYS_YIELD));
+}
+
+void main(void) {
+    os_ipc_message_t message;
+    puts("ipc_server ready\n");
+    for (;;) {
+        int rc = ipc_receive(&message);
+        if (rc == 0) {
+            uint32_t i;
+            puts("ipc recv from ");
+            print_int(message.sender_pid);
+            puts(" type ");
+            print_int((int)message.type);
+            puts(" data ");
+            for (i = 0U; i < message.size; i++) putc((char)message.data[i]);
+            putc('\n');
+        }
+        yield();
+    }
+}

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -202,6 +202,18 @@ int sys_gpt2_generate(const char* prompt, char* out, int max) {
     return result;
 }
 
+int sys_ipc_send(int target_pid, const os_ipc_payload_t* payload) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_IPC_SEND), "b"(target_pid), "c"(payload));
+    return result;
+}
+
+int sys_ipc_receive(os_ipc_message_t* message) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_IPC_RECV), "b"(message));
+    return result;
+}
+
 static void print_fs_err(const char* cmd, int rc);
 
 // ==============================================================================
@@ -510,6 +522,8 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  ps                 - Afficher les processus\n");
     print_string("  spawn <prog>       - Lancer un programme (cede le CPU une fois)\n");
     print_string("  yield              - Ceder le CPU (SYS_YIELD, cooperatif)\n");
+    print_string("  ipc-send <pid> <txt> - Envoyer un message IPC borne\n");
+    print_string("  ipc-recv           - Lire un message IPC non bloquant\n");
     print_string("  kill <pid>         - Terminer un processus\n");
     print_string("  jobs               - Afficher les tâches\n");
     print_string("  top                - Moniteur système\n");
@@ -1093,7 +1107,7 @@ static int is_builtin(const char* cmd) {
         "history", "env", "echo", "write", "append", "touch", "clear", "cls", "exit", "quit",
         "ai", "ai-mode", "ai-help", "ai-test", "ai-stats", "ai-provider", "ai-model", "ai-runtime", "net-status",
         "cd", "pwd", "cat", "stat", "test", "[", "mkdir", "rmdir", "cp", "mv", "rm",
-        "kill", "spawn", "yield", "jobs", "top", "getpid", "uptime", "date", "whoami",
+        "kill", "spawn", "yield", "ipc-send", "ipc-recv", "jobs", "top", "getpid", "uptime", "date", "whoami",
         "alias", "unalias", "export", "which", "rc",
         "grep", "wc", "sort", "head", "tail",
         "logout", "reboot", "shutdown",
@@ -1356,6 +1370,70 @@ static void cmd_spawn(shell_context_t* ctx, char args[][128], int arg_count) {
     print_int(pid);
     print_string(" ");
     print_string(args[0]);
+    print_string("\n");
+}
+
+static void cmd_ipc_send(shell_context_t* ctx, char args[][128], int arg_count) {
+    os_ipc_payload_t payload;
+    int pid;
+    int rc;
+    uint32_t i = 0U;
+    if (arg_count != 2) {
+        print_error("Usage: ipc-send <pid> <texte_sans_espace>");
+        return;
+    }
+    pid = parse_int(args[0]);
+    if (pid <= 0) {
+        print_error("ipc-send: pid invalide");
+        return;
+    }
+    payload.type = 0U;
+    while (args[1][i] != '\0' && i < OS_IPC_MAX_DATA) {
+        payload.data[i] = (uint8_t)args[1][i];
+        i++;
+    }
+    if (args[1][i] != '\0') {
+        print_error("ipc-send: texte trop long");
+        return;
+    }
+    payload.size = i;
+    while (i < OS_IPC_MAX_DATA) payload.data[i++] = 0U;
+    rc = sys_ipc_send(pid, &payload);
+    ctx->last_rc = rc;
+    if (rc == OS_IPC_FULL) print_error("ipc-send: boite aux lettres pleine");
+    else if (rc == OS_IPC_BAD_TARGET) print_error("ipc-send: cible utilisateur introuvable");
+    else if (rc != 0) print_error("ipc-send: message invalide");
+    else {
+        print_string("ipc-send ok ");
+        print_int(pid);
+        print_string(" ");
+        print_int((int)payload.size);
+        print_string("\n");
+    }
+}
+
+static void cmd_ipc_recv(shell_context_t* ctx, char args[][128], int arg_count) {
+    os_ipc_message_t message;
+    int rc;
+    uint32_t i;
+    (void)args;
+    (void)arg_count;
+    rc = sys_ipc_receive(&message);
+    ctx->last_rc = rc;
+    if (rc == OS_IPC_EMPTY) {
+        print_string("ipc-recv empty\n");
+        return;
+    }
+    if (rc != 0) {
+        print_error("ipc-recv: erreur");
+        return;
+    }
+    print_string("ipc-recv from ");
+    print_int(message.sender_pid);
+    print_string(" type ");
+    print_int((int)message.type);
+    print_string(" data ");
+    for (i = 0U; i < message.size; i++) putc((char)message.data[i]);
     print_string("\n");
 }
 
@@ -2180,6 +2258,12 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "spawn") == 0) {
         cmd_spawn(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "ipc-send") == 0) {
+        cmd_ipc_send(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "ipc-recv") == 0) {
+        cmd_ipc_recv(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "yield") == 0) {
         cmd_yield(ctx, args, arg_count);


### PR DESCRIPTION
## Résumé

Cette pull request ouvre la première tranche **MOHHOS Foundation** sans casser le noyau AI-OS existant. Elle livre une primitive IPC locale et bornée entre tâches Ring 3, préparatoire aux futures extractions de services.

| Élément | Livraison |
|---|---|
| Endpoint IPC | FIFO de 4 messages par tâche, charge utile maximale de 96 octets |
| ABI | `SYS_IPC_SEND` (23) et `SYS_IPC_RECV` (24), `MAX_SYSCALLS = 25` |
| Contrôle d’accès initial | PID d’émetteur attribué par le noyau ; cibles limitées aux tâches utilisateur non terminées |
| Ordonnancement | Handoff coopératif après envoi réussi vers un autre utilisateur prêt |
| Démonstration | Commandes shell `ipc-send` / `ipc-recv` et programme initrd `ipcserver` |
| Tests | 5 tests Unity IPC et un contrat QEMU de livraison/réception complète |

## Validations exécutées

```text
make kernel-only      # noyau i386 compilé
make test-all         # 166/166 tests réussis
make qemu-ipc-foundation
make integration-qemu # AOS-022, AOS-024, AOS-025 et IPC Foundation réussis
```

## Limites assumées

- Le noyau reste monolithique : VFS, ATA, GPT-2 et pilotes ne sont pas externalisés.
- L’IPC est local, asynchrone et non bloquant ; il ne fournit ni réponse corrélée, ni transfert de capabilities, ni mémoire partagée.
- Le handoff après envoi est nécessaire avec le shell actuel, qui attend dans `SYS_GETS` en Ring 0 et n’est volontairement pas préempté par IRQ0.
- Cette tranche prépare US-001, US-003 et US-013 mais ne satisfait pas leurs critères complets de microkernel, de sécurité adaptative ou de communication inter-services.
