### PR TITLE
feat: ajouter le mediateur VFS Foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ userspace/ai_assistant
 userspace/idle
 userspace/spin
 userspace/ipcserver
+userspace/vfsserver
 userspace/ok
 userspace/*.o
 userspace/*.bin
@@ -16,6 +17,7 @@ initrd_content/bin/user_program
 initrd_content/bin/idle
 initrd_content/bin/spin
 initrd_content/bin/ipcserver
+initrd_content/bin/vfsserver
 initrd_content/bin/ok
 
 # Build and QEMU artefacts

--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,7 @@ pack-initrd: userspace-all
 	@cp -f userspace/idle $(BIN_DEST_DIR)/idle
 	@cp -f userspace/spin $(BIN_DEST_DIR)/spin
 	@cp -f userspace/ipcserver $(BIN_DEST_DIR)/ipcserver
+	@cp -f userspace/vfsserver $(BIN_DEST_DIR)/vfsserver
 	@cp -f userspace/ok $(BIN_DEST_DIR)/ok
 	@tar -C $(INITRD_DIR) -cf $(INITRD_IMAGE) .
 	@echo "[mkinitrd] Packed executables into $(INITRD_IMAGE)"
@@ -304,7 +305,7 @@ iso-clean:
 	@rm -rf build/isodir $(ISO_IMAGE)
 
 # Compile tous les programmes utilisateur
-user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle userspace/spin userspace/ipcserver userspace/ok: userspace-all
+user-program userspace/shell userspace/fake_ai userspace/test_program userspace/ai_assistant userspace/idle userspace/spin userspace/ipcserver userspace/vfsserver userspace/ok: userspace-all
 
 # Cible pour exécuter l'OS dans QEMU avec initrd (mode console corrigé)
 run: $(OS_IMAGE) pack-initrd disk
@@ -460,7 +461,7 @@ qemu-smoke: $(OS_IMAGE) pack-initrd disk
 
 # Contrats d’intégration QEMU versionnés : boot, shell/overlay, préemption IRQ0
 # et absence réseau OpenAI explicitement vérifiable.
-.PHONY: integration-qemu qemu-irq0-preemption qemu-ai-provider qemu-ipc-foundation
+.PHONY: integration-qemu qemu-irq0-preemption qemu-ai-provider qemu-ipc-foundation qemu-vfs-service
 qemu-irq0-preemption: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/integration/test_qemu_irq0_preemption.py
 
@@ -470,11 +471,15 @@ qemu-ai-provider: $(OS_IMAGE) pack-initrd disk
 qemu-ipc-foundation: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/integration/test_qemu_ipc_foundation.py
 
+qemu-vfs-service: $(OS_IMAGE) pack-initrd disk
+	@python3 tests/integration/test_qemu_vfs_service.py
+
 integration-qemu: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/integration/test_qemu_core_contract.py
 	@python3 tests/integration/test_qemu_irq0_preemption.py
 	@python3 tests/scripts/test_ai_provider_commands.py
 	@python3 tests/integration/test_qemu_ipc_foundation.py
+	@python3 tests/integration/test_qemu_vfs_service.py
 
 # Tests d'intégration réels GPT-2 : les poids locaux sous models/ sont requis.
 .PHONY: gpt2-recovery gpt2-benchmark gpt2-tests
@@ -520,6 +525,7 @@ help:
 	@echo "  qemu-irq0-preemption - Prouve la reprise du shell après spawn spin"
 	@echo "  qemu-ai-provider - Vérifie le stub OpenAI/réseau explicite"
 	@echo "  qemu-ipc-foundation - Vérifie l’IPC entre tâches Ring 3"
+	@echo "  qemu-vfs-service - Vérifie une lecture via le médiateur VFS Ring 3"
 	@echo "  disk            - Cree build/overlay.img (IDE, 32 Kio) si absent"
 	@echo "  gpt2-recovery   - Modèle requis : réponse GPT-2 puis reprise shell (rc)"
 	@echo "  gpt2-benchmark  - Modèle requis : mesure de latence QEMU SSE2"

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ AI-OS est un **prototype de hobby OS i386 32-bit** démarrant par Multiboot. Il 
 | Utilisateur | Shell ELF Ring 3, syscalls 0–24, `spawn`, `yield`, `exec`, `ps`, `kill` |
 | Préemption | Quantum IRQ0 de 20 ticks, uniquement entre tâches utilisateur prêtes |
 | IPC Foundation | Boîte aux lettres FIFO entre tâches Ring 3, messages de 96 octets, 4 entrées par tâche ; pas de capabilities |
+| VFS Foundation | `vfsserver` Ring 3, lecture initrd/overlay médiée par IPC ; backend encore noyau |
 | Fichiers | Initrd TAR en lecture seule et overlay ATA PIO V2 persistant (64 nœuds, V1 compatible) |
 | IA locale | GPT-2 124M `llm.c v3`, BPE UTF-8, cache KV, SSE2 et top-k, sans réseau au boot |
 | GGUF | Sonde structurelle GGUF v3 et primitives Q8_0 ; pas encore d’inférence quantifiée |
 | Réseau | `net-status` et profil OpenAI explicitement bloqué ; aucune pile réseau noyau |
 
-Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les programmes initrd incluent `shell`, `idle`, `spin`, `ipcserver`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
+Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `vfs-read`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les programmes initrd incluent `shell`, `idle`, `spin`, `ipcserver`, `vfsserver`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
 
 ## Démarrage rapide
 
@@ -41,12 +42,13 @@ make run
 | Cible | Rôle |
 |---|---|
 | `make all` | Noyau, initrd et image overlay IDE de 64 secteurs |
-| `make test-all` | 166 tests C Unity/robustesse sans dépendre des poids GPT-2 |
+| `make test-all` | 171 tests C Unity/robustesse sans dépendre des poids GPT-2 |
 | `make qemu-smoke` | Scénarios QEMU classiques : overlay, persistance, spawn/yield et exec |
-| `make integration-qemu` | Contrats QEMU AOS-022, AOS-024, AOS-025 et IPC Foundation |
+| `make integration-qemu` | Contrats QEMU AOS-022, AOS-024, AOS-025, IPC et VFS Foundation |
 | `make qemu-irq0-preemption` | Lance `spin` puis exige un shell toujours réactif |
 | `make qemu-ai-provider` | Vérifie le diagnostic réseau et le blocage OpenAI |
 | `make qemu-ipc-foundation` | Lance `ipcserver`, envoie un message et vérifie sa réception |
+| `make qemu-vfs-service` | Lance `vfsserver` et lit `hello.txt` via IPC |
 | `make iso` | Produit l’ISO BIOS/GRUB bootable |
 | `make run` / `make run-gui` | Session QEMU interactive curses ou GTK |
 
@@ -87,7 +89,7 @@ Le profil `ai-provider openai` est un **stub contrôlé**. `net-status` affiche 
 
 ## Tests et artefacts
 
-`make test-all` a validé **166/166** tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` ajoute quatre validations QEMU séparées, dont le contrat IPC Foundation, et réinitialise son disque de contrat sans toucher à `build/overlay.img`.
+`make test-all` a validé **171/171** tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), protocole VFS (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` ajoute cinq validations QEMU séparées, dont les contrats IPC et médiateur VFS Foundation, et réinitialise son disque de contrat sans toucher à `build/overlay.img`.
 
 Une ISO BIOS/GRUB peut être produite avec l’initrd. Lorsque les poids GPT-2 sont fournis, ils sont bien incorporés à l’ISO pour un fonctionnement local sur une machine vierge ; ils restent ignorés par Git.
 
@@ -103,7 +105,8 @@ Le backlog courant est [US/ai_os_us.md](US/ai_os_us.md). La vision MOHHOS est co
 - [x] Préemption IRQ0 sûre entre tâches Ring 3
 - [x] Stub OpenAI/network honnête et testable
 - [x] IPC Foundation non bloquant entre tâches Ring 3, avec identité d’émetteur noyau
-- [ ] Externalisation d’un premier service et migration microkernel réelle
+- [x] Médiateur VFS Ring 3, lecture bornée et réponse IPC structurée
+- [ ] Externalisation d’un backend VFS et migration microkernel réelle
 - [ ] Inference GGUF quantifiée et latence QEMU inférieure à une seconde
 - [ ] Pilote NIC, DHCP, DNS, TCP, TLS et client OpenAI effectif
 - [ ] Système de fichiers disque général (ext2/FAT)

--- a/US/README.md
+++ b/US/README.md
@@ -21,9 +21,9 @@ Ce n'est **pas** TensorFlow Lite, pas un microkernel, pas `fake_ai` comme moteur
 
 ## Couche 2 — MOHHOS (archives de conception)
 
-Plan historique pour transformer AI-OS v5 en « Manus Operating Hybrid Hosted OS » (8 phases, 120 US, ~1640 j-h). La première tranche de **Foundation** est maintenant livrée : une boîte aux lettres IPC locale, bornée et testée entre tâches Ring 3. Elle prépare US-001/US-003/US-013, mais ne migre encore aucun service vers un espace d’adressage séparé ; le noyau reste monolithique.
+Plan historique pour transformer AI-OS v5 en « Manus Operating Hybrid Hosted OS » (8 phases, 120 US, ~1640 j-h). Deux incréments de **Foundation** sont maintenant livrés : une boîte aux lettres IPC locale, bornée et testée entre tâches Ring 3, puis un médiateur VFS Ring 3 de lecture via cette boîte aux lettres. Ils préparent US-001/US-003/US-013, mais ne déplacent encore ni backend VFS, ni pilotes, ni réseau vers un espace d’adressage séparé ; le noyau reste monolithique.
 
-Les autres fichiers MOHHOS restent des **spécifications**. Le recouvrement avec le prototype (mémoire, tests, moteur IA local, assistant et désormais IPC local) est partiel : voir le tableau dans [individual_us/INDEX.md](individual_us/INDEX.md). Un ✅ dans l’index MOHHOS signifie « fichier de spec présent », **pas** « implémenté », sauf lorsqu’un statut explicite de tranche livrée est indiqué.
+Les autres fichiers MOHHOS restent des **spécifications**. Le recouvrement avec le prototype (mémoire, tests, moteur IA local, assistant, IPC local et médiateur VFS) est partiel : voir le tableau dans [individual_us/INDEX.md](individual_us/INDEX.md). Un ✅ dans l’index MOHHOS signifie « fichier de spec présent », **pas** « implémenté », sauf lorsqu’un statut explicite de tranche livrée est indiqué.
 
 ### Fichiers MOHHOS
 
@@ -33,6 +33,7 @@ Les autres fichiers MOHHOS restent des **spécifications**. Le recouvrement avec
 | [recherche_technologies_mohhos.md](recherche_technologies_mohhos.md) | Veille (P2P, federated learning, navigateur-OS) |
 | [mohhos_us_phase1_foundation.md](mohhos_us_phase1_foundation.md) | Phase 1 détaillée : incrément IPC livré, microkernel/services séparés non commencés |
 | [../docs/mohhos_foundation_increment_01_ipc.md](../docs/mohhos_foundation_increment_01_ipc.md) | Conception et contrat de l’incrément IPC Foundation livré |
+| [../docs/mohhos_foundation_increment_02_vfs_service.md](../docs/mohhos_foundation_increment_02_vfs_service.md) | Médiateur VFS Ring 3 et contrat de lecture IPC livré |
 | [mohhos_us_phase2_ai_core.md](mohhos_us_phase2_ai_core.md) | Phase 2 (TensorFlow Lite, NLU, fédéré) — non livrée ; l'IA réelle est GPT-2 freestanding |
 | [mohhos_us_phase3_web_runtime.md](mohhos_us_phase3_web_runtime.md) | Phase 3 navigateur-OS — absente |
 | [mohhos_us_phases_4_8_synthese.md](mohhos_us_phases_4_8_synthese.md) | Phases 4-8 (PromptMessage, P2P, etc.) — absentes |
@@ -49,7 +50,7 @@ Les autres fichiers MOHHOS restent des **spécifications**. Le recouvrement avec
 7. Collaborative (points)  
 8. Production  
 
-La migration complète de US-001 reste une refonte à haut risque : l’incrément actuel fournit seulement le mécanisme IPC local. La suite doit externaliser un service précis derrière ce contrat, sans affirmer prématurément que les fichiers, pilotes ou le réseau sont déjà hors du noyau.
+La migration complète de US-001 reste une refonte à haut risque : les incréments actuels fournissent un mécanisme IPC et un médiateur VFS de lecture. La suite doit externaliser le backend VFS lui-même, puis les pilotes ou le réseau derrière des droits explicites, sans affirmer prématurément que ces composants sont déjà hors du noyau.
 
 ## Contribution
 

--- a/US/individual_us/INDEX.md
+++ b/US/individual_us/INDEX.md
@@ -14,14 +14,14 @@ Il n'y a **pas** 120 fichiers : environ 78 specs détaillées + des phases décr
 
 | US fichier | Spec MOHHOS | Dans le prototype |
 |---|---|---|
-| US-001 | Microkernel + IPC | **Livraison partielle :** endpoints FIFO IPC locaux entre tâches Ring 3 ; noyau monolithique, services non externalisés |
+| US-001 | Microkernel + IPC | **Livraison partielle :** endpoints FIFO IPC et médiateur VFS Ring 3 de lecture ; noyau monolithique, backend VFS non externalisé |
 | US-002 | Gestionnaire de ressources IA | PMM / VMM / heap / `SYS_MEMINFO` seulement |
 | US-003 | Sécurité adaptative IA | Isolation Ring 0/3 et PID d’émetteur IPC attribué par le noyau ; pas de capabilities ni de détection de menaces |
 | US-007 | Monitoring temps réel | `ps` / `mem` / `uptime` / `SYS_TICKS`, pas de télémétrie |
-| US-008 | Framework de tests IA | Unity 166 + contrats QEMU (cœur, IRQ0, fournisseur IA, IPC) + GitHub Actions ; pas de framework distribué |
+| US-008 | Framework de tests IA | Unity 171 + contrats QEMU (cœur, IRQ0, fournisseur IA, IPC, VFS) + GitHub Actions ; pas de framework distribué |
 | US-010 | Pilotes modulaires | PIC, PIT, PS/2, ATA PIO ; pas de framework de drivers |
 | US-012 | APIs unifiées | `include/os_syscalls.h` (25 syscalls), dont `SYS_IPC_SEND`/`SYS_IPC_RECV` |
-| US-013 | Communication inter-services | **Livraison partielle :** boîte aux lettres IPC locale non bloquante ; pas de protocoles inter-services complets |
+| US-013 | Communication inter-services | **Livraison partielle :** boîte aux lettres IPC et requête/réponse VFS locale ; pas de corrélation ni de registre de services |
 | US-016 | Moteur TensorFlow Lite | GPT-2 124M freestanding (`SYS_GPT2_GENERATE`), pas TFLite |
 | US-017 | NLU 90 % d'intentions | BPE + complétion 12 jetons, pas d'analyse d'intention |
 | US-021 | Assistant IA proactif | Builtin `ai <texte>` synchrone et borné |

--- a/US/mohhos_us_phase1_foundation.md
+++ b/US/mohhos_us_phase1_foundation.md
@@ -1,6 +1,6 @@
 # MOHHOS - Phase 1 Foundation - User Stories Détaillées
 
-> **État réel (août 2026).** L’incrément Foundation 01 a livré une boîte aux lettres IPC locale, bornée et testée entre tâches Ring 3 ; voir [la note de conception](../docs/mohhos_foundation_increment_01_ipc.md). Le noyau reste monolithique (`kernel/kernel.c`) : aucun VFS, pilote ou réseau n’a encore été déplacé dans un service isolé. Les critères complets de microkernel ci-dessous restent à réaliser. Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+> **État réel (août 2026).** Les incréments Foundation 01 et 02 ont livré une boîte aux lettres IPC locale, bornée et testée, puis un médiateur VFS Ring 3 de lecture ; voir les [notes IPC](../docs/mohhos_foundation_increment_01_ipc.md) et [VFS](../docs/mohhos_foundation_increment_02_vfs_service.md). Le noyau reste monolithique (`kernel/kernel.c`) : le backend VFS, les pilotes et le réseau n’ont pas encore été déplacés dans des services isolés. Les critères complets de microkernel ci-dessous restent à réaliser. Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
 
 ## Vue d'Ensemble de la Phase 1
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -31,6 +31,8 @@ Les appels `spawn`, `yield` et `exec` continuent de changer de contexte depuis l
 
 Le premier incrément MOHHOS ajoute une boîte aux lettres **IPC Foundation** par tâche utilisateur. `SYS_IPC_SEND` transmet un payload borné de 96 octets vers un PID utilisateur valide et le noyau inscrit lui-même le PID d’émetteur ; `SYS_IPC_RECV` retire le plus ancien message de la FIFO. Chaque endpoint tient quatre messages, rejette explicitement la saturation et ne bloque jamais le destinataire. Après un envoi réussi, le noyau réalise un handoff coopératif lorsqu’une autre tâche utilisateur est prête : cela permet au destinataire de traiter le message avant que le shell ne retourne dans `SYS_GETS`, cadre Ring 0 non préemptable par IRQ0. Le contrat QEMU lance `ipcserver`, envoie `bonjour`, vérifie l’émetteur puis confirme une boîte aux lettres vide. Ce mécanisme prépare l’externalisation ultérieure des services ; il ne constitue ni un microkernel ni un IPC à capabilities.
 
+Le deuxième incrément construit un premier **médiateur VFS Ring 3** sur cet endpoint. `vfsserver` reçoit une requête `OS_IPC_VFS_READ`, valide un chemin NUL-terminé de 47 octets utiles au plus et refuse `..`, lit au plus 80 octets via l’ABI existante, puis répond au PID expéditeur avec statut et données. La commande `vfs-read <pid> <chemin>` exerce ce chemin client–serveur ; le contrat QEMU lit `hello.txt` et confirme le retour au shell. Le backend initrd/overlay/ATA demeure néanmoins noyau, et un client peut encore appeler `SYS_READFILE` directement : il s’agit d’un médiateur de politique, non d’un VFS isolé.
+
 ### IA locale, GGUF et BPE
 
 Le chemin `ai <texte>` appelle `SYS_GPT2_GENERATE` avec le profil local GPT-2. Le chargeur utilise le checkpoint `llm.c v3`, le tokenizer binaire, des activations CPU freestanding, le cache clé/valeur par couche et position, SSE2 et un échantillonnage top-k. Le contexte est limité à 64 jetons ; l’interface indique quatre jetons générés au maximum afin de borner l’exécution. Sous QEMU TCG sans KVM, l’objectif inférieur à une seconde n’est **pas atteint** : les mesures disponibles restent de l’ordre de 7 à 9 secondes pour une courte génération. L’amélioration du cache KV et de SSE2 reste néanmoins substantielle par rapport à l’ancien chemin non optimisé.
@@ -56,7 +58,7 @@ QEMU sait relier une carte réseau virtuelle ISA ou PCI à un backend hôte, et 
 
 ## Shell et ABI observables
 
-Le shell Ring 3 propose `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `test`, `grep`, `wc`, `sort`, `head`, `tail`, `ps`, `jobs`, `top`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `kill`, `exec`, `mem`, `uptime`, `history`, `alias`, `env`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les opérations de fichiers modifiables passent par l’overlay noyau ; l’initrd demeure en lecture seule. Les programmes empaquetés incluent `shell`, `idle`, `spin`, `ipcserver`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
+Le shell Ring 3 propose `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `test`, `grep`, `wc`, `sort`, `head`, `tail`, `ps`, `jobs`, `top`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `vfs-read`, `kill`, `exec`, `mem`, `uptime`, `history`, `alias`, `env`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les opérations de fichiers modifiables passent par l’overlay noyau ; l’initrd demeure en lecture seule. Les programmes empaquetés incluent `shell`, `idle`, `spin`, `ipcserver`, `vfsserver`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
 
 L’ABI contient les syscalls 0–24 (`MAX_SYSCALLS = 25`), dont `SYS_APPEND`, `SYS_GPT2_GENERATE`, `SYS_IPC_SEND` et `SYS_IPC_RECV`. Le profil local ne nécessite aucun secret ni aucune dépendance réseau à l’exécution.
 
@@ -65,20 +67,20 @@ L’ABI contient les syscalls 0–24 (`MAX_SYSCALLS = 25`), dont `SYS_APPEND`, `
 ```bash
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386 grub-pc-bin xorriso
 make clean && make all       # noyau, initrd et disque overlay
-make test-all                # 166/166 tests C Unity et robustesse
-make integration-qemu        # contrats AOS-022/AOS-024/AOS-025 et IPC Foundation
+make test-all                # 171/171 tests C Unity et robustesse
+make integration-qemu        # contrats AOS-022/AOS-024/AOS-025, IPC et VFS Foundation
 make iso                     # ISO BIOS/GRUB bootable
 make run                     # console curses
 make run-gui                 # fenêtre GTK
 ```
 
-La suite C exécute 166 assertions de tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` démarre quatre machines QEMU séparées : le contrat cœur AOS-022 utilise une image overlay de test isolée, le contrat IRQ0 AOS-024 préempte `spin`, le smoke AOS-025 vérifie que le profil OpenAI reste bloqué, et le contrat Foundation livre un message à `ipcserver`.
+La suite C exécute 171 assertions de tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), protocole VFS (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` démarre cinq machines QEMU séparées : le contrat cœur AOS-022 utilise une image overlay de test isolée, le contrat IRQ0 AOS-024 préempte `spin`, le smoke AOS-025 vérifie que le profil OpenAI reste bloqué, le contrat Foundation livre un message à `ipcserver`, et le contrat VFS lit `hello.txt` à travers `vfsserver`.
 
 Le build a également produit une ISO GRUB BIOS avec l’initrd GPT-2 local. Avec les actifs disponibles dans l’environnement de vérification, l’ISO est d’environ 481 Mio ; les modèles restent exclus du versionnement.
 
 ## Absences importantes
 
-AI-OS ne fournit pas de système de fichiers disque général, de pilote réseau, de pile TCP/IP/TLS, de client OpenAI/Ollama effectif, d’UEFI, de gestion multiprocesseur, de GUI native, de microkernel, d’IPC bloquant avec réponses corrélées, de transfert de capabilities ni des fonctionnalités avancées de la vision MOHHOS. La boîte aux lettres IPC Foundation est un mécanisme local préparatoire, non une migration de services hors du noyau. Les rapports historiques conservés dans `docs/` sont des éléments de chronologie et non la description de l’état courant.
+AI-OS ne fournit pas de système de fichiers disque général, de pilote réseau, de pile TCP/IP/TLS, de client OpenAI/Ollama effectif, d’UEFI, de gestion multiprocesseur, de GUI native, de microkernel, d’IPC bloquant avec réponses corrélées, de transfert de capabilities ni des fonctionnalités avancées de la vision MOHHOS. La boîte aux lettres IPC Foundation et `vfsserver` sont des mécanismes locaux préparatoires : le backend fichiers reste noyau et l’ABI directe reste accessible aux clients. Les rapports historiques conservés dans `docs/` sont des éléments de chronologie et non la description de l’état courant.
 
 ## Références
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,11 +9,12 @@ Depuis la racine du dépôt : `make deps` (script [`scripts/bootstrap-dev.sh`](.
 1. [ETAT_REEL.md](ETAT_REEL.md) - **état actuel du code**, y compris GPT-2 local et limites vérifiées
 2. [../US/ai_os_us.md](../US/ai_os_us.md) - user stories du prototype (fait + suite)
 3. [mohhos_foundation_increment_01_ipc.md](mohhos_foundation_increment_01_ipc.md) - IPC Foundation MOHHOS, limites et contrat QEMU
-4. [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) - sonde GGUF v3 et quantification préparatoire
-5. [aos025_network_stub.md](aos025_network_stub.md) - statut réseau/OpenAI et suite de livraison
-6. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
-7. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
-8. [../README.md](../README.md) - compilation, tests, architecture des sources
+4. [mohhos_foundation_increment_02_vfs_service.md](mohhos_foundation_increment_02_vfs_service.md) - médiateur VFS Ring 3, protocole et contrat QEMU
+5. [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) - sonde GGUF v3 et quantification préparatoire
+6. [aos025_network_stub.md](aos025_network_stub.md) - statut réseau/OpenAI et suite de livraison
+7. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
+8. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
+9. [../README.md](../README.md) - compilation, tests, architecture des sources
 
 Les autres fichiers de ce dossier sont conservés : rapports de debug, chronologie des correctifs clavier, spécifications d'étapes. Beaucoup décrivent un état **intermédiaire** (shell simulé dans le kernel, crash timer, clavier mort). Ils ne sont pas effacés.
 
@@ -24,6 +25,7 @@ Les autres fichiers de ce dossier sont conservés : rapports de debug, chronolog
 | [ETAT_REEL.md](ETAT_REEL.md) | État fonctionnel, GPT-2 local et limites vérifiées |
 | [../US/ai_os_us.md](../US/ai_os_us.md) | Backlog du prototype, AOS-001…025 et limites restantes |
 | [mohhos_foundation_increment_01_ipc.md](mohhos_foundation_increment_01_ipc.md) | IPC Foundation entre tâches Ring 3, limites de la tranche et contrat QEMU |
+| [mohhos_foundation_increment_02_vfs_service.md](mohhos_foundation_increment_02_vfs_service.md) | Médiateur VFS Ring 3, protocole de lecture et limites du backend noyau |
 | [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) | Sonde GGUF v3, primitives Q8_0 et limites des kernels quantifiés |
 | [aos025_network_stub.md](aos025_network_stub.md) | Stub OpenAI, diagnostic réseau et critères de sortie d’un transport réel |
 | [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) | Préparation des artefacts, construction et démarrage d'une ISO GPT-2 hors ligne |
@@ -89,4 +91,4 @@ Les captures QEMU et les exports Word ont été retirés du dépôt (la source r
 - [../US/README.md](../US/README.md) — deux couches : AI-OS vs vision MOHHOS
 - [../US/individual_us/INDEX.md](../US/individual_us/INDEX.md) — specs MOHHOS, chevauchements, IDs dupliqués
 
-Les phases MOHHOS restent majoritairement des **spécifications**. L’exception actuelle est l’incrément Foundation IPC, réellement compilé et testé ; il ne transforme pas encore le noyau monolithique en microkernel et n’implémente pas les autres phases.
+Les phases MOHHOS restent majoritairement des **spécifications**. Les exceptions actuelles sont les incréments Foundation IPC et médiateur VFS, réellement compilés et testés ; ils ne transforment pas encore le noyau monolithique en microkernel et n’implémentent pas les autres phases.

--- a/docs/mohhos_foundation_increment_02_vfs_service.md
+++ b/docs/mohhos_foundation_increment_02_vfs_service.md
@@ -1,0 +1,48 @@
+# MOHHOS Foundation — incrément 02 : médiateur VFS Ring 3
+
+**Statut :** conception de la tranche suivante, fondée sur l’IPC Foundation livré.
+
+**Portée MOHHOS :** premier jalon de l’extraction progressive du VFS prévue par US-001, avec un protocole minimal de communication inter-services de US-013.
+
+**Non-objectif :** le backend initrd/overlay/ATA ne quitte pas encore Ring 0.
+
+## Décision d’architecture
+
+Le premier service externalisé ne doit pas réimplémenter un système de fichiers : il doit exercer une frontière client–serveur observable. `vfsserver`, processus Ring 3, reçoit une demande de lecture via son endpoint IPC, appelle l’ABI de lecture déjà stable, puis renvoie une réponse structurée au PID émetteur. Le shell devient le client et n’appelle plus directement `SYS_READFILE` dans ce scénario.
+
+Cette forme client–serveur s’aligne sur le motif d’échange requête/réponse des microkernels, où un endpoint transporte de petites données entre un client et un serveur [1]. AI-OS ne possède pas encore les reply capabilities, l’attente bloquante, le registre de services ou l’isolation d’un espace VFS : le client passe donc explicitement le PID du serveur et lit sa réponse dans sa propre boîte aux lettres.
+
+| Élément | Contrat de l’incrément |
+|---|---|
+| Serveur | Programme Ring 3 `vfsserver`, lancé par `spawn vfsserver` |
+| Client | Commande shell `vfs-read <pid> <chemin>` |
+| Requête | Type `OS_IPC_VFS_READ`, chemin NUL-terminé de 47 octets utiles au plus |
+| Réponse | Type `OS_IPC_VFS_READ_REPLY`, statut signé, longueur et au plus 80 octets lus |
+| Routage | Le serveur répond au `sender_pid` fourni par le noyau, jamais à une identité issue de la charge utile |
+| Sécurité initiale | Rejet des chemins vides, tronqués ou contenant `..` ; aucune écriture dans cette tranche |
+| Capacité | Une réponse tient dans les 96 octets d’un message IPC ; les fichiers plus longs sont tronqués à 80 octets |
+
+## ABI de protocole
+
+Le protocole est défini dans `include/os_vfs_service.h`, partagé entre le shell et le serveur. Il ne modifie pas les numéros de syscall : le service s’appuie uniquement sur `SYS_IPC_SEND`, `SYS_IPC_RECV` et `SYS_READFILE`.
+
+| Type IPC | Charge |
+|---|---|
+| `OS_IPC_VFS_READ` | `os_vfs_read_request_t { char path[48]; }` |
+| `OS_IPC_VFS_READ_REPLY` | `os_vfs_read_reply_t { int32_t status; uint32_t size; uint8_t data[80]; }` |
+
+Le serveur renvoie une réponse même lorsque la lecture échoue, à condition que la requête soit structurellement valide. Une réponse n’est pas corrélée par identifiant de requête : cette version cible une interaction shell–serveur à la fois. La prochaine version devra ajouter une corrélation, une file de réponses et un registre d’endpoints.
+
+## Démonstration et tests
+
+Le contrat QEMU lance `vfsserver`, demande `hello.txt` avec `vfs-read`, exige une ligne `vfs-read ok` contenant la donnée attendue, puis contrôle le retour du shell. Les tests C du protocole valident l’absence de dépassement, la forme des messages et les rejets de chemins non sûrs.
+
+Les validations globales restent `make test-all` et `make integration-qemu`.
+
+## Limites et suite
+
+`vfsserver` est un **médiateur de politique**, non un vrai VFS isolé : le syscall de lecture continue d’accéder aux implémentations noyau initrd et overlay. Un processus malveillant conserve aussi la possibilité d’appeler `SYS_READFILE` directement. L’étape suivante devra introduire des droits par endpoint, retirer progressivement l’ABI de fichiers directe des clients ordinaires et déléguer un backend sûr au service.
+
+## Références
+
+[1] [seL4 IPC tutorial — communication client–serveur sur endpoint](https://docs.sel4.systems/Tutorials/ipc.html)

--- a/include/os_vfs_service.h
+++ b/include/os_vfs_service.h
@@ -1,0 +1,111 @@
+#ifndef OS_VFS_SERVICE_H
+#define OS_VFS_SERVICE_H
+
+#include <stdint.h>
+#include "os_syscalls.h"
+
+#define OS_IPC_VFS_READ       0x56465301U
+#define OS_IPC_VFS_READ_REPLY 0x56465302U
+
+#define OS_VFS_PATH_MAX 48U
+#define OS_VFS_READ_MAX 80U
+
+#define OS_VFS_STATUS_OK        0
+#define OS_VFS_STATUS_INVALID  (-60)
+#define OS_VFS_STATUS_TRUNCATED 1
+
+typedef struct {
+    char path[OS_VFS_PATH_MAX];
+} os_vfs_read_request_t;
+
+typedef struct {
+    int32_t status;
+    uint32_t size;
+    uint8_t data[OS_VFS_READ_MAX];
+} os_vfs_read_reply_t;
+
+static inline int os_vfs_path_is_safe(const char* path) {
+    uint32_t i;
+    if (!path || path[0] == '\0') return 0;
+    for (i = 0U; i < OS_VFS_PATH_MAX; i++) {
+        if (path[i] == '\0') return 1;
+        if (path[i] == '.' && i + 1U < OS_VFS_PATH_MAX && path[i + 1U] == '.') return 0;
+    }
+    return 0;
+}
+
+static inline int os_vfs_make_read_request(os_ipc_payload_t* payload, const char* path) {
+    uint32_t i;
+    if (!payload || !os_vfs_path_is_safe(path)) return OS_VFS_STATUS_INVALID;
+    payload->type = OS_IPC_VFS_READ;
+    payload->size = OS_VFS_PATH_MAX;
+    for (i = 0U; i < OS_VFS_PATH_MAX; i++) {
+        if (path[i] == '\0') break;
+        payload->data[i] = (uint8_t)path[i];
+    }
+    for (; i < OS_IPC_MAX_DATA; i++) payload->data[i] = 0U;
+    return 0;
+}
+
+static inline int os_vfs_parse_read_request(const os_ipc_message_t* message, char* path_out) {
+    uint32_t i;
+    if (!message || !path_out || message->type != OS_IPC_VFS_READ ||
+        message->size != OS_VFS_PATH_MAX) return OS_VFS_STATUS_INVALID;
+    for (i = 0U; i < OS_VFS_PATH_MAX; i++) path_out[i] = (char)message->data[i];
+    if (!os_vfs_path_is_safe(path_out)) return OS_VFS_STATUS_INVALID;
+    return 0;
+}
+
+static inline void os_vfs_encode_i32(uint8_t* out, int32_t value) {
+    uint32_t raw = (uint32_t)value;
+    out[0] = (uint8_t)(raw & 0xffU);
+    out[1] = (uint8_t)((raw >> 8) & 0xffU);
+    out[2] = (uint8_t)((raw >> 16) & 0xffU);
+    out[3] = (uint8_t)((raw >> 24) & 0xffU);
+}
+
+static inline int32_t os_vfs_decode_i32(const uint8_t* in) {
+    uint32_t raw = (uint32_t)in[0] | ((uint32_t)in[1] << 8) |
+                   ((uint32_t)in[2] << 16) | ((uint32_t)in[3] << 24);
+    return (int32_t)raw;
+}
+
+static inline void os_vfs_encode_u32(uint8_t* out, uint32_t value) {
+    out[0] = (uint8_t)(value & 0xffU);
+    out[1] = (uint8_t)((value >> 8) & 0xffU);
+    out[2] = (uint8_t)((value >> 16) & 0xffU);
+    out[3] = (uint8_t)((value >> 24) & 0xffU);
+}
+
+static inline uint32_t os_vfs_decode_u32(const uint8_t* in) {
+    return (uint32_t)in[0] | ((uint32_t)in[1] << 8) |
+           ((uint32_t)in[2] << 16) | ((uint32_t)in[3] << 24);
+}
+
+static inline int os_vfs_make_read_reply(os_ipc_payload_t* payload, int32_t status,
+                                  const uint8_t* data, uint32_t size) {
+    uint32_t i;
+    if (!payload || size > OS_VFS_READ_MAX || (size > 0U && !data)) return OS_VFS_STATUS_INVALID;
+    payload->type = OS_IPC_VFS_READ_REPLY;
+    payload->size = 8U + OS_VFS_READ_MAX;
+    os_vfs_encode_i32(&payload->data[0], status);
+    os_vfs_encode_u32(&payload->data[4], size);
+    for (i = 0U; i < size; i++) payload->data[8U + i] = data[i];
+    for (; i < OS_VFS_READ_MAX; i++) payload->data[8U + i] = 0U;
+    for (i = 8U + OS_VFS_READ_MAX; i < OS_IPC_MAX_DATA; i++) payload->data[i] = 0U;
+    return 0;
+}
+
+static inline int os_vfs_parse_read_reply(const os_ipc_message_t* message,
+                                   os_vfs_read_reply_t* reply_out) {
+    uint32_t i;
+    if (!message || !reply_out || message->type != OS_IPC_VFS_READ_REPLY ||
+        message->size != 8U + OS_VFS_READ_MAX) return OS_VFS_STATUS_INVALID;
+    reply_out->status = os_vfs_decode_i32(&message->data[0]);
+    reply_out->size = os_vfs_decode_u32(&message->data[4]);
+    if (reply_out->size > OS_VFS_READ_MAX) return OS_VFS_STATUS_INVALID;
+    for (i = 0U; i < OS_VFS_READ_MAX; i++) reply_out->data[i] = message->data[8U + i];
+    return 0;
+}
+
+#endif

--- a/tests/integration/test_qemu_vfs_service.py
+++ b/tests/integration/test_qemu_vfs_service.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-"""Smoke test for the AI provider/model control plane in AI-OS."""
+"""Contrat MOHHOS Foundation : lecture VFS par médiateur Ring 3."""
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -8,9 +9,9 @@ import time
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 LOG_DIR = os.path.join(ROOT, "test_logs")
-LOG = os.path.join(LOG_DIR, "ai-provider-smoke.log")
-ERR = os.path.join(LOG_DIR, "ai-provider-smoke.err")
-MON = os.path.join(LOG_DIR, "ai-provider-monitor.sock")
+LOG = os.path.join(LOG_DIR, "vfs-service.log")
+ERR = os.path.join(LOG_DIR, "vfs-service.err")
+MON = os.path.join(LOG_DIR, "vfs-service-monitor.sock")
 KERNEL = os.path.join(ROOT, "build", "ai_os.bin")
 INITRD = os.path.join(ROOT, "my_initrd.tar")
 
@@ -23,15 +24,15 @@ def log_text():
         return ""
 
 
-def wait_for(needle, proc, timeout=15):
+def wait_for(needle, proc, offset=0, timeout=15):
     deadline = time.time() + timeout
     while time.time() < deadline:
         if proc.poll() is not None:
-            raise RuntimeError("QEMU stopped early")
-        if needle in log_text():
+            raise RuntimeError("QEMU s'est arrêté prématurément")
+        if needle in log_text()[offset:]:
             return
         time.sleep(0.1)
-    raise RuntimeError("missing output: %s" % needle)
+    raise RuntimeError("sortie manquante : %s" % needle)
 
 
 def connect_monitor():
@@ -50,31 +51,15 @@ def connect_monitor():
             except OSError:
                 client.close()
         time.sleep(0.1)
-    raise RuntimeError("QEMU monitor unavailable")
+    raise RuntimeError("moniteur QEMU indisponible")
 
 
-def send_keys(client, keys):
-    for key in keys:
-        client.sendall(("sendkey %s\n" % key).encode("ascii"))
-        time.sleep(0.12)
-
-
-def key_sequence(command):
-    special = {" ": "spc", ".": "dot", "-": "minus", "_": "shift-minus"}
-    return [special.get(char, char.lower()) for char in command] + ["ret"]
-
-
-def run_command(client, proc, command, expected):
-    before = len(log_text())
-    send_keys(client, key_sequence(command))
-    deadline = time.time() + 10
-    while time.time() < deadline:
-        if proc.poll() is not None:
-            raise RuntimeError("QEMU stopped while executing %s" % command)
-        if expected in log_text()[before:]:
-            return
-        time.sleep(0.1)
-    raise RuntimeError("command %s did not emit %s" % (command, expected))
+def send_command(client, command):
+    special = {" ": "spc", "-": "minus", ".": "dot"}
+    for char in command:
+        client.sendall(("sendkey %s\n" % special.get(char, char.lower())).encode("ascii"))
+        time.sleep(0.06)
+    client.sendall(b"sendkey ret\n")
 
 
 def main():
@@ -98,16 +83,22 @@ def main():
             wait_for("(-.-)", proc)
             monitor = connect_monitor()
             time.sleep(0.5)
-            run_command(monitor, proc, "ai-provider", "Fournisseur IA : local")
-            run_command(monitor, proc, "ai-model list", "qwen2.5-1.5b-instruct-q4_0.gguf")
-            run_command(monitor, proc, "ai-model use control.bin", "Profil memorise; seul GPT-2")
-            run_command(monitor, proc, "ai-model", "control.bin")
-            run_command(monitor, proc, "ai-runtime", "Runtime IA bare-metal")
-            run_command(monitor, proc, "net-status", "net-status ok stub AOS-025")
-            run_command(monitor, proc, "ai-provider openai", "OpenAI selectionne")
-            run_command(monitor, proc, "ai hello", "OpenAI configure mais indisponible")
-            run_command(monitor, proc, "ai-provider local", "Fournisseur local selectionne")
-            print("AI provider control-plane smoke passed.")
+            before_spawn = len(log_text())
+            send_command(monitor, "spawn vfsserver")
+            wait_for("spawn ok pid", proc, before_spawn)
+            spawned = re.search(r"spawn ok pid (\d+) vfsserver", log_text()[before_spawn:])
+            if not spawned:
+                raise RuntimeError("PID du serveur VFS absent")
+            server_pid = spawned.group(1)
+            wait_for("vfsserver ready", proc, before_spawn)
+            before_read = len(log_text())
+            send_command(monitor, "vfs-read %s hello.txt" % server_pid)
+            wait_for("vfs-read ok", proc, before_read)
+            wait_for("Un autre fichier de demonstration.", proc, before_read)
+            before_return = len(log_text())
+            send_command(monitor, "rc")
+            wait_for("rc ok 0", proc, before_return)
+            print("MOHHOS Foundation VFS service contract passed")
             return 0
         finally:
             if monitor is not None:
@@ -128,5 +119,5 @@ if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except Exception as error:
-        print("AI provider control-plane smoke failed: %s" % error, file=sys.stderr)
+        print("MOHHOS Foundation VFS service contract failed: %s" % error, file=sys.stderr)
         raise SystemExit(1)

--- a/tests/unit/kernel/test_vfs_service.c
+++ b/tests/unit/kernel/test_vfs_service.c
@@ -1,0 +1,79 @@
+#include "../../framework/unity.h"
+#include "../../../include/os_vfs_service.h"
+
+static void test_read_request_is_bounded_and_zero_padded(void) {
+    os_ipc_payload_t payload;
+    TEST_ASSERT_EQUAL(0, os_vfs_make_read_request(&payload, "hello.txt"));
+    TEST_ASSERT_EQUAL(OS_IPC_VFS_READ, payload.type);
+    TEST_ASSERT_EQUAL(OS_VFS_PATH_MAX, payload.size);
+    TEST_ASSERT_EQUAL('h', payload.data[0]);
+    TEST_ASSERT_EQUAL('t', payload.data[8]);
+    TEST_ASSERT_EQUAL(0, payload.data[9]);
+    TEST_ASSERT_EQUAL(0, payload.data[OS_IPC_MAX_DATA - 1U]);
+}
+
+static void test_unsafe_or_unterminated_path_is_rejected(void) {
+    os_ipc_payload_t payload;
+    char unterminated[OS_VFS_PATH_MAX];
+    uint32_t i;
+    for (i = 0U; i < OS_VFS_PATH_MAX; i++) unterminated[i] = 'a';
+    TEST_ASSERT_EQUAL(OS_VFS_STATUS_INVALID, os_vfs_make_read_request(&payload, "../secret"));
+    TEST_ASSERT_EQUAL(OS_VFS_STATUS_INVALID, os_vfs_make_read_request(&payload, ""));
+    TEST_ASSERT_EQUAL(OS_VFS_STATUS_INVALID, os_vfs_make_read_request(&payload, unterminated));
+}
+
+static void test_server_can_parse_valid_request(void) {
+    os_ipc_payload_t payload;
+    os_ipc_message_t message;
+    char path[OS_VFS_PATH_MAX];
+    uint32_t i;
+    TEST_ASSERT_EQUAL(0, os_vfs_make_read_request(&payload, "config.cfg"));
+    message.sender_pid = 7;
+    message.type = payload.type;
+    message.size = payload.size;
+    for (i = 0U; i < OS_IPC_MAX_DATA; i++) message.data[i] = payload.data[i];
+    TEST_ASSERT_EQUAL(0, os_vfs_parse_read_request(&message, path));
+    TEST_ASSERT_EQUAL('c', path[0]);
+    TEST_ASSERT_EQUAL('g', path[9]);
+    TEST_ASSERT_EQUAL(0, path[10]);
+}
+
+static void test_read_reply_preserves_status_and_data(void) {
+    os_ipc_payload_t payload;
+    os_ipc_message_t message;
+    os_vfs_read_reply_t reply;
+    uint8_t data[3] = {'o', 'k', '\n'};
+    uint32_t i;
+    TEST_ASSERT_EQUAL(0, os_vfs_make_read_reply(&payload, OS_VFS_STATUS_OK, data, 3U));
+    message.sender_pid = 2;
+    message.type = payload.type;
+    message.size = payload.size;
+    for (i = 0U; i < OS_IPC_MAX_DATA; i++) message.data[i] = payload.data[i];
+    TEST_ASSERT_EQUAL(0, os_vfs_parse_read_reply(&message, &reply));
+    TEST_ASSERT_EQUAL(OS_VFS_STATUS_OK, reply.status);
+    TEST_ASSERT_EQUAL(3, reply.size);
+    TEST_ASSERT_EQUAL('o', reply.data[0]);
+    TEST_ASSERT_EQUAL('\n', reply.data[2]);
+}
+
+static void test_malformed_reply_is_rejected(void) {
+    os_ipc_message_t message;
+    os_vfs_read_reply_t reply;
+    uint32_t i;
+    message.type = OS_IPC_VFS_READ_REPLY;
+    message.size = 8U + OS_VFS_READ_MAX - 1U;
+    for (i = 0U; i < OS_IPC_MAX_DATA; i++) message.data[i] = 0U;
+    TEST_ASSERT_EQUAL(OS_VFS_STATUS_INVALID, os_vfs_parse_read_reply(&message, &reply));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_read_request_is_bounded_and_zero_padded);
+    RUN_TEST(test_unsafe_or_unterminated_path_is_rejected);
+    RUN_TEST(test_server_can_parse_valid_request);
+    RUN_TEST(test_read_reply_preserves_status_and_data);
+    RUN_TEST(test_malformed_reply_is_rejected);
+    unity_print_results();
+    unity_cleanup();
+    return unity_stats.tests_failed == 0 ? 0 : 1;
+}

--- a/userspace/Makefile
+++ b/userspace/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -nostdlib -Ttext=0x40000000
 ASFLAGS = --32
 
 # Programmes à compiler
-PROGRAMS = shell fake_ai test_program ai_assistant idle spin ipcserver ok
+PROGRAMS = shell fake_ai test_program ai_assistant idle spin ipcserver vfsserver ok
 
 all: $(PROGRAMS)
 
@@ -38,6 +38,10 @@ spin: spin.o start.o
 
 ipcserver: ipc_server.o start.o
 	@echo "Linking ipcserver..."
+	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
+
+vfsserver: vfs_server.o start.o
+	@echo "Linking vfsserver..."
 	$(LD) -m elf_i386 $(LDFLAGS) -o $@ $^
 
 ok: ok.o start.o

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -6,6 +6,7 @@
 #include "ramfs.h"
 #include "procsim.h"
 #include "os_syscalls.h"
+#include "os_vfs_service.h"
 
 // ==============================================================================
 // STRUCTURES ET DÉFINITIONS
@@ -524,6 +525,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  yield              - Ceder le CPU (SYS_YIELD, cooperatif)\n");
     print_string("  ipc-send <pid> <txt> - Envoyer un message IPC borne\n");
     print_string("  ipc-recv           - Lire un message IPC non bloquant\n");
+    print_string("  vfs-read <pid> <f> - Lire un fichier via le service VFS\n");
     print_string("  kill <pid>         - Terminer un processus\n");
     print_string("  jobs               - Afficher les tâches\n");
     print_string("  top                - Moniteur système\n");
@@ -1107,7 +1109,7 @@ static int is_builtin(const char* cmd) {
         "history", "env", "echo", "write", "append", "touch", "clear", "cls", "exit", "quit",
         "ai", "ai-mode", "ai-help", "ai-test", "ai-stats", "ai-provider", "ai-model", "ai-runtime", "net-status",
         "cd", "pwd", "cat", "stat", "test", "[", "mkdir", "rmdir", "cp", "mv", "rm",
-        "kill", "spawn", "yield", "ipc-send", "ipc-recv", "jobs", "top", "getpid", "uptime", "date", "whoami",
+        "kill", "spawn", "yield", "ipc-send", "ipc-recv", "vfs-read", "jobs", "top", "getpid", "uptime", "date", "whoami",
         "alias", "unalias", "export", "which", "rc",
         "grep", "wc", "sort", "head", "tail",
         "logout", "reboot", "shutdown",
@@ -1435,6 +1437,52 @@ static void cmd_ipc_recv(shell_context_t* ctx, char args[][128], int arg_count) 
     print_string(" data ");
     for (i = 0U; i < message.size; i++) putc((char)message.data[i]);
     print_string("\n");
+}
+
+static void cmd_vfs_read(shell_context_t* ctx, char args[][128], int arg_count) {
+    os_ipc_payload_t request;
+    os_ipc_message_t message;
+    os_vfs_read_reply_t reply;
+    int pid;
+    int rc;
+    uint32_t i;
+    if (arg_count != 2) {
+        print_error("Usage: vfs-read <pid> <chemin>");
+        return;
+    }
+    pid = parse_int(args[0]);
+    if (pid <= 0) {
+        print_error("vfs-read: pid invalide");
+        return;
+    }
+    rc = os_vfs_make_read_request(&request, args[1]);
+    if (rc != 0) {
+        print_error("vfs-read: chemin invalide ou trop long");
+        ctx->last_rc = rc;
+        return;
+    }
+    rc = sys_ipc_send(pid, &request);
+    if (rc != 0) {
+        print_error("vfs-read: service indisponible");
+        ctx->last_rc = rc;
+        return;
+    }
+    rc = sys_ipc_receive(&message);
+    if (rc != 0 || os_vfs_parse_read_reply(&message, &reply) != 0) {
+        print_error("vfs-read: reponse VFS absente ou invalide");
+        ctx->last_rc = rc != 0 ? rc : OS_VFS_STATUS_INVALID;
+        return;
+    }
+    ctx->last_rc = reply.status;
+    if (reply.status != OS_VFS_STATUS_OK) {
+        print_error("vfs-read: lecture refusee ou fichier absent");
+        return;
+    }
+    print_string("vfs-read ok ");
+    print_int((int)reply.size);
+    print_string(" data ");
+    for (i = 0U; i < reply.size; i++) putc((char)reply.data[i]);
+    if (reply.size == 0U || reply.data[reply.size - 1U] != '\n') print_string("\n");
 }
 
 static void cmd_yield(shell_context_t* ctx, char args[][128], int arg_count) {
@@ -2264,6 +2312,9 @@ int execute_builtin_command(shell_context_t* ctx, const char* command,
         return 1;
     } else if (strcmp(command, "ipc-recv") == 0) {
         cmd_ipc_recv(ctx, args, arg_count);
+        return 1;
+    } else if (strcmp(command, "vfs-read") == 0) {
+        cmd_vfs_read(ctx, args, arg_count);
         return 1;
     } else if (strcmp(command, "yield") == 0) {
         cmd_yield(ctx, args, arg_count);

--- a/userspace/vfs_server.c
+++ b/userspace/vfs_server.c
@@ -1,0 +1,57 @@
+#include "os_syscalls.h"
+#include "os_vfs_service.h"
+
+static void putc(char c) {
+    asm volatile("int $0x80" : : "a"(SYS_PUTC), "b"(c));
+}
+
+static void puts(const char* text) {
+    int i = 0;
+    while (text[i] != '\0') putc(text[i++]);
+}
+
+static int ipc_receive(os_ipc_message_t* message) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_IPC_RECV), "b"(message));
+    return result;
+}
+
+static int ipc_send(int target_pid, const os_ipc_payload_t* payload) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_IPC_SEND), "b"(target_pid), "c"(payload));
+    return result;
+}
+
+static int read_file(const char* path, char* buffer, uint32_t max) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_READFILE), "b"(path), "c"(buffer), "d"(max));
+    return result;
+}
+
+static void yield(void) {
+    asm volatile("int $0x80" : : "a"(SYS_YIELD));
+}
+
+void main(void) {
+    os_ipc_message_t message;
+    os_ipc_payload_t reply_payload;
+    char path[OS_VFS_PATH_MAX];
+    uint8_t data[OS_VFS_READ_MAX];
+    puts("vfsserver ready\n");
+    for (;;) {
+        int received = ipc_receive(&message);
+        if (received == 0 && message.type == OS_IPC_VFS_READ) {
+            int status = os_vfs_parse_read_request(&message, path);
+            uint32_t size = 0U;
+            if (status == 0) {
+                int read = read_file(path, (char*)data, OS_VFS_READ_MAX);
+                if (read < 0) status = read;
+                else size = (uint32_t)read;
+            }
+            if (os_vfs_make_read_reply(&reply_payload, status, data, size) == 0) {
+                (void)ipc_send(message.sender_pid, &reply_payload);
+            }
+        }
+        yield();
+    }
+}


### PR DESCRIPTION
## Résumé

Cette pull request livre le deuxième incrément **MOHHOS Foundation** : un premier médiateur VFS Ring 3, construit au-dessus de l’IPC Foundation fusionné précédemment.

| Élément | Livraison |
|---|---|
| Protocole | `include/os_vfs_service.h` : requête `OS_IPC_VFS_READ` et réponse structurée |
| Service | `vfsserver` Ring 3, lancé par `spawn vfsserver` |
| Client | `vfs-read <pid> <chemin>` dans le shell |
| Limites de message | Chemin de 47 octets utiles au plus ; lecture retournée limitée à 80 octets |
| Contrôles | Rejet des chemins vides, tronqués ou contenant `..` ; réponse routée au PID fourni par le noyau |
| Tests | 5 tests Unity de protocole et contrat QEMU de lecture de `hello.txt` |

## Validations exécutées

```text
make test-all         # 171/171 tests réussis
make qemu-vfs-service # médiateur VFS Ring 3 réussi
make integration-qemu # AOS-022, AOS-024, AOS-025, IPC et VFS réussis
```

## Limites assumées

- `vfsserver` est un médiateur de politique : initrd, overlay et ATA PIO restent exécutés en Ring 0.
- `SYS_READFILE` reste accessible aux clients ; aucun droit par endpoint ni capability VFS n’est encore appliqué.
- Le protocole est à une requête/réponse à la fois : pas de corrélation, pas de registre de services et pas de mémoire partagée.
- Ce jalon progresse vers US-001/US-013 sans prétendre satisfaire le microkernel complet ni externaliser le backend VFS.
