### PR TITLE
feat: ajouter le registre de services Foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/multiboot.o build/kernel.o build/kbd_buffer.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o
 
 # Cible par défaut : construire le système complet (noyau + initrd + disque overlay)
 all: $(OS_IMAGE) pack-initrd disk
@@ -108,6 +108,10 @@ build/timer.o: kernel/timer.c kernel/timer.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/ipc.o: kernel/ipc.c kernel/ipc.h include/os_syscalls.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/service_registry.o: kernel/service_registry.c kernel/service_registry.h include/os_syscalls.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ AI-OS est un **prototype de hobby OS i386 32-bit** démarrant par Multiboot. Il 
 | Domaine | Fonction réellement disponible |
 |---|---|
 | Démarrage | Multiboot BIOS, VGA/série, GDT, IDT, PIC, PIT et clavier PS/2 |
-| Utilisateur | Shell ELF Ring 3, syscalls 0–24, `spawn`, `yield`, `exec`, `ps`, `kill` |
+| Utilisateur | Shell ELF Ring 3, syscalls 0–26, `spawn`, `yield`, `exec`, `ps`, `kill` |
 | Préemption | Quantum IRQ0 de 20 ticks, uniquement entre tâches utilisateur prêtes |
 | IPC Foundation | Boîte aux lettres FIFO entre tâches Ring 3, messages de 96 octets, 4 entrées par tâche ; pas de capabilities |
 | VFS Foundation | `vfsserver` Ring 3, lecture initrd/overlay médiée par IPC ; backend encore noyau |
+| Découverte Foundation | Registre volatile de 8 services nommés, `vfs` publié par son serveur ; pas de capabilities |
 | Fichiers | Initrd TAR en lecture seule et overlay ATA PIO V2 persistant (64 nœuds, V1 compatible) |
 | IA locale | GPT-2 124M `llm.c v3`, BPE UTF-8, cache KV, SSE2 et top-k, sans réseau au boot |
 | GGUF | Sonde structurelle GGUF v3 et primitives Q8_0 ; pas encore d’inférence quantifiée |
 | Réseau | `net-status` et profil OpenAI explicitement bloqué ; aucune pile réseau noyau |
 
-Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `vfs-read`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les programmes initrd incluent `shell`, `idle`, `spin`, `ipcserver`, `vfsserver`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
+Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `vfs-read <fichier>`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. `vfs-read` résout le service `vfs` au lieu d’accepter un PID. Les programmes initrd incluent `shell`, `idle`, `spin`, `ipcserver`, `vfsserver`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
 
 ## Démarrage rapide
 
@@ -42,9 +43,9 @@ make run
 | Cible | Rôle |
 |---|---|
 | `make all` | Noyau, initrd et image overlay IDE de 64 secteurs |
-| `make test-all` | 171 tests C Unity/robustesse sans dépendre des poids GPT-2 |
+| `make test-all` | 176 tests C Unity/robustesse sans dépendre des poids GPT-2 |
 | `make qemu-smoke` | Scénarios QEMU classiques : overlay, persistance, spawn/yield et exec |
-| `make integration-qemu` | Contrats QEMU AOS-022, AOS-024, AOS-025, IPC et VFS Foundation |
+| `make integration-qemu` | Contrats QEMU AOS-022, AOS-024, AOS-025, IPC, VFS et découverte Foundation |
 | `make qemu-irq0-preemption` | Lance `spin` puis exige un shell toujours réactif |
 | `make qemu-ai-provider` | Vérifie le diagnostic réseau et le blocage OpenAI |
 | `make qemu-ipc-foundation` | Lance `ipcserver`, envoie un message et vérifie sa réception |
@@ -89,7 +90,7 @@ Le profil `ai-provider openai` est un **stub contrôlé**. `net-status` affiche 
 
 ## Tests et artefacts
 
-`make test-all` a validé **171/171** tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), protocole VFS (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` ajoute cinq validations QEMU séparées, dont les contrats IPC et médiateur VFS Foundation, et réinitialise son disque de contrat sans toucher à `build/overlay.img`.
+`make test-all` a validé **176/176** tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), protocole VFS (5), registre de services (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` ajoute cinq validations QEMU séparées, dont les contrats IPC, médiateur VFS et découverte nommée Foundation, et réinitialise son disque de contrat sans toucher à `build/overlay.img`.
 
 Une ISO BIOS/GRUB peut être produite avec l’initrd. Lorsque les poids GPT-2 sont fournis, ils sont bien incorporés à l’ISO pour un fonctionnement local sur une machine vierge ; ils restent ignorés par Git.
 
@@ -106,7 +107,9 @@ Le backlog courant est [US/ai_os_us.md](US/ai_os_us.md). La vision MOHHOS est co
 - [x] Stub OpenAI/network honnête et testable
 - [x] IPC Foundation non bloquant entre tâches Ring 3, avec identité d’émetteur noyau
 - [x] Médiateur VFS Ring 3, lecture bornée et réponse IPC structurée
-- [ ] Externalisation d’un backend VFS et migration microkernel réelle
+- [x] Registre de services nommé, découverte de `vfs` sans PID codé en dur
+- [ ] Droits de publication/découverte et externalisation d’un backend VFS
+- [ ] Migration microkernel réelle
 - [ ] Inference GGUF quantifiée et latence QEMU inférieure à une seconde
 - [ ] Pilote NIC, DHCP, DNS, TCP, TLS et client OpenAI effectif
 - [ ] Système de fichiers disque général (ext2/FAT)

--- a/US/README.md
+++ b/US/README.md
@@ -21,9 +21,9 @@ Ce n'est **pas** TensorFlow Lite, pas un microkernel, pas `fake_ai` comme moteur
 
 ## Couche 2 — MOHHOS (archives de conception)
 
-Plan historique pour transformer AI-OS v5 en « Manus Operating Hybrid Hosted OS » (8 phases, 120 US, ~1640 j-h). Deux incréments de **Foundation** sont maintenant livrés : une boîte aux lettres IPC locale, bornée et testée entre tâches Ring 3, puis un médiateur VFS Ring 3 de lecture via cette boîte aux lettres. Ils préparent US-001/US-003/US-013, mais ne déplacent encore ni backend VFS, ni pilotes, ni réseau vers un espace d’adressage séparé ; le noyau reste monolithique.
+Plan historique pour transformer AI-OS v5 en « Manus Operating Hybrid Hosted OS » (8 phases, 120 US, ~1640 j-h). Trois incréments de **Foundation** sont maintenant livrés : une boîte aux lettres IPC locale, un médiateur VFS Ring 3 de lecture et un registre nommé qui permet au client de résoudre `vfs` sans PID codé en dur. Ils préparent US-001/US-003/US-012/US-013, mais ne déplacent encore ni backend VFS, ni pilotes, ni réseau vers un espace d’adressage séparé ; le noyau reste monolithique.
 
-Les autres fichiers MOHHOS restent des **spécifications**. Le recouvrement avec le prototype (mémoire, tests, moteur IA local, assistant, IPC local et médiateur VFS) est partiel : voir le tableau dans [individual_us/INDEX.md](individual_us/INDEX.md). Un ✅ dans l’index MOHHOS signifie « fichier de spec présent », **pas** « implémenté », sauf lorsqu’un statut explicite de tranche livrée est indiqué.
+Les autres fichiers MOHHOS restent des **spécifications**. Le recouvrement avec le prototype (mémoire, tests, moteur IA local, assistant, IPC local, médiateur VFS et découverte de service) est partiel : voir le tableau dans [individual_us/INDEX.md](individual_us/INDEX.md). Un ✅ dans l’index MOHHOS signifie « fichier de spec présent », **pas** « implémenté », sauf lorsqu’un statut explicite de tranche livrée est indiqué.
 
 ### Fichiers MOHHOS
 
@@ -31,9 +31,10 @@ Les autres fichiers MOHHOS restent des **spécifications**. Le recouvrement avec
 |---|---|
 | [mohhos_user_stories_master.md](mohhos_user_stories_master.md) | Index historique des 120 titres (numérotation parfois **différente** des fichiers) |
 | [recherche_technologies_mohhos.md](recherche_technologies_mohhos.md) | Veille (P2P, federated learning, navigateur-OS) |
-| [mohhos_us_phase1_foundation.md](mohhos_us_phase1_foundation.md) | Phase 1 détaillée : incrément IPC livré, microkernel/services séparés non commencés |
+| [mohhos_us_phase1_foundation.md](mohhos_us_phase1_foundation.md) | Phase 1 détaillée : IPC, médiateur VFS et découverte nommée livrés ; microkernel/services séparés non commencés |
 | [../docs/mohhos_foundation_increment_01_ipc.md](../docs/mohhos_foundation_increment_01_ipc.md) | Conception et contrat de l’incrément IPC Foundation livré |
 | [../docs/mohhos_foundation_increment_02_vfs_service.md](../docs/mohhos_foundation_increment_02_vfs_service.md) | Médiateur VFS Ring 3 et contrat de lecture IPC livré |
+| [../docs/mohhos_foundation_increment_03_service_registry.md](../docs/mohhos_foundation_increment_03_service_registry.md) | Registre nommé, découverte `vfs` et limites de sécurité |
 | [mohhos_us_phase2_ai_core.md](mohhos_us_phase2_ai_core.md) | Phase 2 (TensorFlow Lite, NLU, fédéré) — non livrée ; l'IA réelle est GPT-2 freestanding |
 | [mohhos_us_phase3_web_runtime.md](mohhos_us_phase3_web_runtime.md) | Phase 3 navigateur-OS — absente |
 | [mohhos_us_phases_4_8_synthese.md](mohhos_us_phases_4_8_synthese.md) | Phases 4-8 (PromptMessage, P2P, etc.) — absentes |
@@ -50,7 +51,7 @@ Les autres fichiers MOHHOS restent des **spécifications**. Le recouvrement avec
 7. Collaborative (points)  
 8. Production  
 
-La migration complète de US-001 reste une refonte à haut risque : les incréments actuels fournissent un mécanisme IPC et un médiateur VFS de lecture. La suite doit externaliser le backend VFS lui-même, puis les pilotes ou le réseau derrière des droits explicites, sans affirmer prématurément que ces composants sont déjà hors du noyau.
+La migration complète de US-001 reste une refonte à haut risque : les incréments actuels fournissent un mécanisme IPC, un médiateur VFS de lecture et une découverte de nom. La suite doit introduire des droits de publication/découverte, corréler les réponses, externaliser le backend VFS lui-même, puis déplacer pilotes ou réseau derrière ces droits, sans affirmer prématurément que ces composants sont déjà hors du noyau.
 
 ## Contribution
 

--- a/US/individual_us/INDEX.md
+++ b/US/individual_us/INDEX.md
@@ -14,14 +14,14 @@ Il n'y a **pas** 120 fichiers : environ 78 specs détaillées + des phases décr
 
 | US fichier | Spec MOHHOS | Dans le prototype |
 |---|---|---|
-| US-001 | Microkernel + IPC | **Livraison partielle :** endpoints FIFO IPC et médiateur VFS Ring 3 de lecture ; noyau monolithique, backend VFS non externalisé |
+| US-001 | Microkernel + IPC | **Livraison partielle :** endpoints FIFO IPC, médiateur VFS et découverte `vfs` nommée ; noyau monolithique, backend non externalisé |
 | US-002 | Gestionnaire de ressources IA | PMM / VMM / heap / `SYS_MEMINFO` seulement |
 | US-003 | Sécurité adaptative IA | Isolation Ring 0/3 et PID d’émetteur IPC attribué par le noyau ; pas de capabilities ni de détection de menaces |
 | US-007 | Monitoring temps réel | `ps` / `mem` / `uptime` / `SYS_TICKS`, pas de télémétrie |
-| US-008 | Framework de tests IA | Unity 171 + contrats QEMU (cœur, IRQ0, fournisseur IA, IPC, VFS) + GitHub Actions ; pas de framework distribué |
+| US-008 | Framework de tests IA | Unity 176 + contrats QEMU (cœur, IRQ0, fournisseur IA, IPC, VFS nommé) + GitHub Actions ; pas de framework distribué |
 | US-010 | Pilotes modulaires | PIC, PIT, PS/2, ATA PIO ; pas de framework de drivers |
-| US-012 | APIs unifiées | `include/os_syscalls.h` (25 syscalls), dont `SYS_IPC_SEND`/`SYS_IPC_RECV` |
-| US-013 | Communication inter-services | **Livraison partielle :** boîte aux lettres IPC et requête/réponse VFS locale ; pas de corrélation ni de registre de services |
+| US-012 | APIs unifiées | `include/os_syscalls.h` (27 syscalls), dont IPC et registre `SYS_SERVICE_REGISTER`/`SYS_SERVICE_LOOKUP` |
+| US-013 | Communication inter-services | **Livraison partielle :** IPC, requête/réponse VFS locale et registre nommé ; pas de corrélation ni de capabilities |
 | US-016 | Moteur TensorFlow Lite | GPT-2 124M freestanding (`SYS_GPT2_GENERATE`), pas TFLite |
 | US-017 | NLU 90 % d'intentions | BPE + complétion 12 jetons, pas d'analyse d'intention |
 | US-021 | Assistant IA proactif | Builtin `ai <texte>` synchrone et borné |

--- a/US/mohhos_us_phase1_foundation.md
+++ b/US/mohhos_us_phase1_foundation.md
@@ -1,6 +1,6 @@
 # MOHHOS - Phase 1 Foundation - User Stories Détaillées
 
-> **État réel (août 2026).** Les incréments Foundation 01 et 02 ont livré une boîte aux lettres IPC locale, bornée et testée, puis un médiateur VFS Ring 3 de lecture ; voir les [notes IPC](../docs/mohhos_foundation_increment_01_ipc.md) et [VFS](../docs/mohhos_foundation_increment_02_vfs_service.md). Le noyau reste monolithique (`kernel/kernel.c`) : le backend VFS, les pilotes et le réseau n’ont pas encore été déplacés dans des services isolés. Les critères complets de microkernel ci-dessous restent à réaliser. Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
+> **État réel (août 2026).** Les incréments Foundation 01 à 03 ont livré une boîte aux lettres IPC locale, un médiateur VFS Ring 3 de lecture et le registre nommé `vfs` ; voir les notes [IPC](../docs/mohhos_foundation_increment_01_ipc.md), [VFS](../docs/mohhos_foundation_increment_02_vfs_service.md) et [registre](../docs/mohhos_foundation_increment_03_service_registry.md). Le noyau reste monolithique (`kernel/kernel.c`) : le backend VFS, les pilotes et le réseau n’ont pas encore été déplacés dans des services isolés, et le registre ne délivre aucune capability. Les critères complets de microkernel ci-dessous restent à réaliser. Runtime : [../docs/ETAT_REEL.md](../docs/ETAT_REEL.md).
 
 ## Vue d'Ensemble de la Phase 1
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -15,6 +15,7 @@ AI-OS démarre sans système hôte dans QEMU, charge un initrd TAR, lance un she
 | Stockage | Initrd TAR en lecture seule et overlay ATA PIO persistant V2 |
 | Ordonnancement | Coopératif par syscall et quantum IRQ0 sûr entre tâches utilisateur |
 | IPC Foundation MOHHOS | Boîte aux lettres FIFO non bloquante entre tâches Ring 3, messages de 96 octets, 4 entrées par tâche |
+| Découverte Foundation MOHHOS | Registre volatile de 8 services nommés ; association du nom au PID Ring 3 appelant |
 | Réseau | **Aucun transport réseau noyau** ; diagnostic et profil OpenAI explicitement bloqués |
 
 > Les poids GPT-2 ne sont pas versionnés dans Git. Une image utilisable sans réseau les embarque dans l’initrd au moment du build.
@@ -31,7 +32,9 @@ Les appels `spawn`, `yield` et `exec` continuent de changer de contexte depuis l
 
 Le premier incrément MOHHOS ajoute une boîte aux lettres **IPC Foundation** par tâche utilisateur. `SYS_IPC_SEND` transmet un payload borné de 96 octets vers un PID utilisateur valide et le noyau inscrit lui-même le PID d’émetteur ; `SYS_IPC_RECV` retire le plus ancien message de la FIFO. Chaque endpoint tient quatre messages, rejette explicitement la saturation et ne bloque jamais le destinataire. Après un envoi réussi, le noyau réalise un handoff coopératif lorsqu’une autre tâche utilisateur est prête : cela permet au destinataire de traiter le message avant que le shell ne retourne dans `SYS_GETS`, cadre Ring 0 non préemptable par IRQ0. Le contrat QEMU lance `ipcserver`, envoie `bonjour`, vérifie l’émetteur puis confirme une boîte aux lettres vide. Ce mécanisme prépare l’externalisation ultérieure des services ; il ne constitue ni un microkernel ni un IPC à capabilities.
 
-Le deuxième incrément construit un premier **médiateur VFS Ring 3** sur cet endpoint. `vfsserver` reçoit une requête `OS_IPC_VFS_READ`, valide un chemin NUL-terminé de 47 octets utiles au plus et refuse `..`, lit au plus 80 octets via l’ABI existante, puis répond au PID expéditeur avec statut et données. La commande `vfs-read <pid> <chemin>` exerce ce chemin client–serveur ; le contrat QEMU lit `hello.txt` et confirme le retour au shell. Le backend initrd/overlay/ATA demeure néanmoins noyau, et un client peut encore appeler `SYS_READFILE` directement : il s’agit d’un médiateur de politique, non d’un VFS isolé.
+Le deuxième incrément construit un premier **médiateur VFS Ring 3** sur cet endpoint. `vfsserver` reçoit une requête `OS_IPC_VFS_READ`, valide un chemin NUL-terminé de 47 octets utiles au plus et refuse `..`, lit au plus 80 octets via l’ABI existante, puis répond au PID expéditeur avec statut et données. Le backend initrd/overlay/ATA demeure néanmoins noyau, et un client peut encore appeler `SYS_READFILE` directement : il s’agit d’un médiateur de politique, non d’un VFS isolé.
+
+Le troisième incrément retire le PID codé en dur de ce parcours. `SYS_SERVICE_REGISTER` associe un nom de 15 octets utiles au plus au PID de l’appelant Ring 3 et `SYS_SERVICE_LOOKUP` retourne le PID d’un propriétaire utilisateur vivant. `vfsserver` publie `vfs`, puis `vfs-read <chemin>` le résout avant l’envoi IPC. Le registre contient huit entrées, refuse les noms invalides et les conflits actifs, et purgera une entrée stale lors de recherche ou de réinscription. Il ne confère aucun droit : tout processus utilisateur peut tenter de réserver un nom libre, les capabilities, badges, réponses corrélées et registre persistant restent absents.
 
 ### IA locale, GGUF et BPE
 
@@ -60,27 +63,27 @@ QEMU sait relier une carte réseau virtuelle ISA ou PCI à un backend hôte, et 
 
 Le shell Ring 3 propose `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `test`, `grep`, `wc`, `sort`, `head`, `tail`, `ps`, `jobs`, `top`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `vfs-read`, `kill`, `exec`, `mem`, `uptime`, `history`, `alias`, `env`, `ai`, `ai-provider`, `ai-model`, `ai-runtime` et `net-status`. Les opérations de fichiers modifiables passent par l’overlay noyau ; l’initrd demeure en lecture seule. Les programmes empaquetés incluent `shell`, `idle`, `spin`, `ipcserver`, `vfsserver`, `ok`, `fake_ai`, `ai_assistant` et `user_program`.
 
-L’ABI contient les syscalls 0–24 (`MAX_SYSCALLS = 25`), dont `SYS_APPEND`, `SYS_GPT2_GENERATE`, `SYS_IPC_SEND` et `SYS_IPC_RECV`. Le profil local ne nécessite aucun secret ni aucune dépendance réseau à l’exécution.
+L’ABI contient les syscalls 0–26 (`MAX_SYSCALLS = 27`), dont `SYS_APPEND`, `SYS_GPT2_GENERATE`, `SYS_IPC_SEND`, `SYS_IPC_RECV`, `SYS_SERVICE_REGISTER` et `SYS_SERVICE_LOOKUP`. Le profil local ne nécessite aucun secret ni aucune dépendance réseau à l’exécution.
 
 ## Vérification reproductible
 
 ```bash
 sudo apt-get install -y build-essential gcc-multilib nasm qemu-system-i386 grub-pc-bin xorriso
 make clean && make all       # noyau, initrd et disque overlay
-make test-all                # 171/171 tests C Unity et robustesse
+make test-all                # 176/176 tests C Unity et robustesse
 make integration-qemu        # contrats AOS-022/AOS-024/AOS-025, IPC et VFS Foundation
 make iso                     # ISO BIOS/GRUB bootable
 make run                     # console curses
 make run-gui                 # fenêtre GTK
 ```
 
-La suite C exécute 171 assertions de tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), protocole VFS (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` démarre cinq machines QEMU séparées : le contrat cœur AOS-022 utilise une image overlay de test isolée, le contrat IRQ0 AOS-024 préempte `spin`, le smoke AOS-025 vérifie que le profil OpenAI reste bloqué, le contrat Foundation livre un message à `ipcserver`, et le contrat VFS lit `hello.txt` à travers `vfsserver`.
+La suite C exécute 176 assertions de tests : PMM (17), syscall (48), tâches (21), overlay (8), tokenizer (15), GGUF (5), quantification (5), échantillonnage GPT-2 (4), IPC (5), protocole VFS (5), registre de services (5), shell (25), RAMFS (10) et robustesse GGUF (3). `make integration-qemu` démarre cinq machines QEMU séparées : le contrat cœur AOS-022 utilise une image overlay de test isolée, le contrat IRQ0 AOS-024 préempte `spin`, le smoke AOS-025 vérifie que le profil OpenAI reste bloqué, le contrat Foundation livre un message à `ipcserver`, et le contrat VFS résout `vfs` puis lit `hello.txt` à travers `vfsserver`.
 
 Le build a également produit une ISO GRUB BIOS avec l’initrd GPT-2 local. Avec les actifs disponibles dans l’environnement de vérification, l’ISO est d’environ 481 Mio ; les modèles restent exclus du versionnement.
 
 ## Absences importantes
 
-AI-OS ne fournit pas de système de fichiers disque général, de pilote réseau, de pile TCP/IP/TLS, de client OpenAI/Ollama effectif, d’UEFI, de gestion multiprocesseur, de GUI native, de microkernel, d’IPC bloquant avec réponses corrélées, de transfert de capabilities ni des fonctionnalités avancées de la vision MOHHOS. La boîte aux lettres IPC Foundation et `vfsserver` sont des mécanismes locaux préparatoires : le backend fichiers reste noyau et l’ABI directe reste accessible aux clients. Les rapports historiques conservés dans `docs/` sont des éléments de chronologie et non la description de l’état courant.
+AI-OS ne fournit pas de système de fichiers disque général, de pilote réseau, de pile TCP/IP/TLS, de client OpenAI/Ollama effectif, d’UEFI, de gestion multiprocesseur, de GUI native, de microkernel, d’IPC bloquant avec réponses corrélées, de transfert de capabilities ni des fonctionnalités avancées de la vision MOHHOS. La boîte aux lettres IPC, `vfsserver` et le registre nommé sont des mécanismes locaux préparatoires : le backend fichiers reste noyau, l’ABI directe reste accessible aux clients et le registre ne constitue pas un contrôle d’accès. Les rapports historiques conservés dans `docs/` sont des éléments de chronologie et non la description de l’état courant.
 
 ## Références
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,11 +10,12 @@ Depuis la racine du dépôt : `make deps` (script [`scripts/bootstrap-dev.sh`](.
 2. [../US/ai_os_us.md](../US/ai_os_us.md) - user stories du prototype (fait + suite)
 3. [mohhos_foundation_increment_01_ipc.md](mohhos_foundation_increment_01_ipc.md) - IPC Foundation MOHHOS, limites et contrat QEMU
 4. [mohhos_foundation_increment_02_vfs_service.md](mohhos_foundation_increment_02_vfs_service.md) - médiateur VFS Ring 3, protocole et contrat QEMU
-5. [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) - sonde GGUF v3 et quantification préparatoire
-6. [aos025_network_stub.md](aos025_network_stub.md) - statut réseau/OpenAI et suite de livraison
-7. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
-8. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
-9. [../README.md](../README.md) - compilation, tests, architecture des sources
+5. [mohhos_foundation_increment_03_service_registry.md](mohhos_foundation_increment_03_service_registry.md) - registre nommé, découverte VFS et limites de sécurité
+6. [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) - sonde GGUF v3 et quantification préparatoire
+7. [aos025_network_stub.md](aos025_network_stub.md) - statut réseau/OpenAI et suite de livraison
+8. [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) - préparation des poids et construction d'une ISO autonome
+9. [GUIDE_EXECUTION.md](GUIDE_EXECUTION.md) - lancement QEMU (console / GUI / nographic)
+10. [../README.md](../README.md) - compilation, tests, architecture des sources
 
 Les autres fichiers de ce dossier sont conservés : rapports de debug, chronologie des correctifs clavier, spécifications d'étapes. Beaucoup décrivent un état **intermédiaire** (shell simulé dans le kernel, crash timer, clavier mort). Ils ne sont pas effacés.
 
@@ -26,6 +27,7 @@ Les autres fichiers de ce dossier sont conservés : rapports de debug, chronolog
 | [../US/ai_os_us.md](../US/ai_os_us.md) | Backlog du prototype, AOS-001…025 et limites restantes |
 | [mohhos_foundation_increment_01_ipc.md](mohhos_foundation_increment_01_ipc.md) | IPC Foundation entre tâches Ring 3, limites de la tranche et contrat QEMU |
 | [mohhos_foundation_increment_02_vfs_service.md](mohhos_foundation_increment_02_vfs_service.md) | Médiateur VFS Ring 3, protocole de lecture et limites du backend noyau |
+| [mohhos_foundation_increment_03_service_registry.md](mohhos_foundation_increment_03_service_registry.md) | Registre nommé, découverte `vfs` et absence de capabilities |
 | [aos020_gguf_quantization_design.md](aos020_gguf_quantization_design.md) | Sonde GGUF v3, primitives Q8_0 et limites des kernels quantifiés |
 | [aos025_network_stub.md](aos025_network_stub.md) | Stub OpenAI, diagnostic réseau et critères de sortie d’un transport réel |
 | [gpt2_baremetal_deployment.md](gpt2_baremetal_deployment.md) | Préparation des artefacts, construction et démarrage d'une ISO GPT-2 hors ligne |
@@ -91,4 +93,4 @@ Les captures QEMU et les exports Word ont été retirés du dépôt (la source r
 - [../US/README.md](../US/README.md) — deux couches : AI-OS vs vision MOHHOS
 - [../US/individual_us/INDEX.md](../US/individual_us/INDEX.md) — specs MOHHOS, chevauchements, IDs dupliqués
 
-Les phases MOHHOS restent majoritairement des **spécifications**. Les exceptions actuelles sont les incréments Foundation IPC et médiateur VFS, réellement compilés et testés ; ils ne transforment pas encore le noyau monolithique en microkernel et n’implémentent pas les autres phases.
+Les phases MOHHOS restent majoritairement des **spécifications**. Les exceptions actuelles sont les incréments Foundation IPC, médiateur VFS et registre nommé, réellement compilés et testés ; ils ne transforment pas encore le noyau monolithique en microkernel, ne fournissent pas de capabilities et n’implémentent pas les autres phases.

--- a/docs/mohhos_foundation_increment_03_service_registry.md
+++ b/docs/mohhos_foundation_increment_03_service_registry.md
@@ -1,0 +1,44 @@
+# MOHHOS Foundation — incrément 03 : registre de services nommé
+
+**Statut :** conception de la tranche suivante, fondée sur l’IPC et le médiateur VFS fusionnés.
+
+**Portée MOHHOS :** jalon réduit de US-001, US-012 et US-013 : découverte d’un endpoint par un nom stable plutôt que par un PID codé en dur.
+
+**Non-objectif :** ce registre n’est pas un espace de capabilities, un annuaire distribué ni une politique d’autorisation complète.
+
+## Décision d’architecture
+
+`vfsserver` est actuellement joignable seulement lorsque le client connaît son PID. Le registre introduit deux syscalls : `SYS_SERVICE_REGISTER` lie un nom au **PID de la tâche appelante**, et `SYS_SERVICE_LOOKUP` retourne le PID d’un service vivant portant ce nom. Le client VFS peut ainsi appeler `vfs-read hello.txt` : il résout d’abord `vfs`, puis utilise l’IPC déjà livré.
+
+Dans les microkernels à capabilities, l’invocation vise une capability et l’identité de l’émetteur peut être portée par le mécanisme d’endpoint ; seL4 propose aussi un chemin d’appel/réponse spécifique [1]. AI-OS ne possède encore ni capability dérivée, ni badge, ni `Call`/`Reply` bloquant. Le registre est donc une **découverte de nom de convenance**, explicitement moins sûre, qui ne délivre aucun droit d’accès en soi.
+
+| Élément | Contrat de l’incrément |
+|---|---|
+| Capacité | 8 services nommés au plus |
+| Nom | Chaîne NUL-terminée de 15 octets utiles au plus, alphanumérique, `_` ou `-` |
+| Inscription | `SYS_SERVICE_REGISTER(name)` associe le nom au PID de `current_task` ; le PID n’est jamais fourni par l’utilisateur |
+| Recherche | `SYS_SERVICE_LOOKUP(name)` retourne le PID utilisateur vivant ou une erreur explicite |
+| Conflit | Un nom actif détenu par une autre tâche est refusé ; la réinscription du même propriétaire est idempotente |
+| Nettoyage | Une entrée dont le PID est terminé ou absent est supprimée lors de recherche ou de tentative d’inscription |
+| Première intégration | `vfsserver` enregistre `vfs`; `vfs-read <chemin>` résout le nom avant l’envoi IPC |
+
+## ABI
+
+| Syscall | Numéro | Arguments | Retour |
+|---|---:|---|---|
+| `SYS_SERVICE_REGISTER` | 25 | `const char *name` | `0` ou erreur négative |
+| `SYS_SERVICE_LOOKUP` | 26 | `const char *name` | PID positif ou erreur négative |
+
+Les erreurs dédiées sont `OS_SERVICE_BAD_NAME`, `OS_SERVICE_FULL`, `OS_SERVICE_TAKEN` et `OS_SERVICE_NOT_FOUND`. `MAX_SYSCALLS` devient 27. Le registre ne modifie pas le protocole IPC ni les numéros AOS existants.
+
+## Démonstration et validation
+
+Le contrat QEMU lance `vfsserver`, attend son inscription `vfs`, exécute `vfs-read hello.txt` sans PID et vérifie la réponse. Les tests Unity couvrent validation du nom, conflit actif, idempotence, capacité et réutilisation d’une entrée supprimée. `make integration-qemu` conserve les contrats AOS, IPC et VFS antérieurs.
+
+## Limites et suite
+
+Tout processus utilisateur peut encore tenter de réserver un nom libre : il n’existe pas de capability de publication, de manifeste signé, de contrôle d’identité ni de supervision de santé. Le registre n’est pas persistant et n’offre ni version ni plusieurs instances. Le prochain incrément devra introduire des droits d’enregistrement/découverte, la corrélation requête-réponse et le nettoyage à la fin d’une tâche, avant toute prétention de microkernel sécurisé.
+
+## Références
+
+[1] [seL4 API Reference — endpoints, sender badge et `Call`/`Reply`](https://docs.sel4.systems/projects/sel4/api-doc.html)

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -33,8 +33,12 @@
 #define SYS_IPC_SEND      23
 /* EBX = os_ipc_message_t* */
 #define SYS_IPC_RECV      24
+/* EBX = nom de service ; le PID est celui de l’appelant Ring 3. */
+#define SYS_SERVICE_REGISTER 25
+/* EBX = nom de service ; EAX reçoit le PID associé. */
+#define SYS_SERVICE_LOOKUP   26
 
-#define MAX_SYSCALLS 25
+#define MAX_SYSCALLS 27
 
 /* IPC Foundation : messages courts, copies par valeur et retours non bloquants. */
 #define OS_IPC_MAX_DATA 96U
@@ -42,6 +46,13 @@
 #define OS_IPC_FULL        (-41)
 #define OS_IPC_BAD_TARGET  (-42)
 #define OS_IPC_BAD_MESSAGE (-43)
+
+/* Registre Foundation : simple découverte de nom, pas une capability. */
+#define OS_SERVICE_NAME_MAX 16U
+#define OS_SERVICE_BAD_NAME  (-50)
+#define OS_SERVICE_FULL      (-51)
+#define OS_SERVICE_TAKEN     (-52)
+#define OS_SERVICE_NOT_FOUND (-53)
 
 #define OS_NAME_MAX 64
 #define OS_PROC_NAME_MAX 32

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -16,6 +16,7 @@
 #include "llm/gpt2_infer.h"
 #include "llm/gpt2_tokenizer.h"
 #include "keyboard.h"
+#include "service_registry.h"
 #include <stddef.h>
 
 // Function to read a byte from a port
@@ -565,6 +566,7 @@ void kmain(uint32_t multiboot_magic, uint32_t multiboot_addr) {
     // NOUVEAU: Initialisation du système de tâches
     print_string("Initialisation du systeme de taches...\n");
     tasking_init();
+    service_registry_init();
 
     // NOUVEAU: Initialisation des appels système
     print_string("Initialisation des appels systeme...\n");

--- a/kernel/service_registry.c
+++ b/kernel/service_registry.c
@@ -1,0 +1,101 @@
+#include "service_registry.h"
+
+static service_registry_entry_t service_entries[SERVICE_REGISTRY_CAPACITY];
+
+static int name_equal(const char* left, const char* right) {
+    uint32_t i;
+    for (i = 0U; i < OS_SERVICE_NAME_MAX; i++) {
+        if (left[i] != right[i]) return 0;
+        if (left[i] == '\0') return 1;
+    }
+    return 0;
+}
+
+static void copy_name(char* destination, const char* source) {
+    uint32_t i;
+    for (i = 0U; i < OS_SERVICE_NAME_MAX; i++) {
+        destination[i] = source[i];
+        if (source[i] == '\0') {
+            for (i++; i < OS_SERVICE_NAME_MAX; i++) destination[i] = '\0';
+            return;
+        }
+    }
+}
+
+int service_registry_name_valid(const char* name) {
+    uint32_t i;
+    if (!name || name[0] == '\0') return 0;
+    for (i = 0U; i < OS_SERVICE_NAME_MAX; i++) {
+        char c = name[i];
+        if (c == '\0') return 1;
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+              (c >= '0' && c <= '9') || c == '_' || c == '-')) return 0;
+    }
+    return 0;
+}
+
+void service_registry_init(void) {
+    uint32_t i;
+    for (i = 0U; i < SERVICE_REGISTRY_CAPACITY; i++) {
+        service_entries[i].pid = 0;
+        service_entries[i].name[0] = '\0';
+    }
+}
+
+int service_registry_register(const char* name, int32_t pid) {
+    uint32_t i;
+    int free_slot = -1;
+    if (!service_registry_name_valid(name) || pid <= 0) return OS_SERVICE_BAD_NAME;
+    for (i = 0U; i < SERVICE_REGISTRY_CAPACITY; i++) {
+        if (service_entries[i].pid == 0) {
+            if (free_slot < 0) free_slot = (int)i;
+            continue;
+        }
+        if (name_equal(service_entries[i].name, name)) {
+            if (service_entries[i].pid == pid) return 0;
+            return OS_SERVICE_TAKEN;
+        }
+    }
+    if (free_slot < 0) return OS_SERVICE_FULL;
+    service_entries[free_slot].pid = pid;
+    copy_name(service_entries[free_slot].name, name);
+    return 0;
+}
+
+int service_registry_lookup(const char* name) {
+    uint32_t i;
+    if (!service_registry_name_valid(name)) return OS_SERVICE_BAD_NAME;
+    for (i = 0U; i < SERVICE_REGISTRY_CAPACITY; i++) {
+        if (service_entries[i].pid > 0 && name_equal(service_entries[i].name, name)) {
+            return service_entries[i].pid;
+        }
+    }
+    return OS_SERVICE_NOT_FOUND;
+}
+
+int service_registry_remove(const char* name, int32_t pid) {
+    uint32_t i;
+    if (!service_registry_name_valid(name) || pid <= 0) return OS_SERVICE_BAD_NAME;
+    for (i = 0U; i < SERVICE_REGISTRY_CAPACITY; i++) {
+        if (service_entries[i].pid == pid && name_equal(service_entries[i].name, name)) {
+            service_entries[i].pid = 0;
+            service_entries[i].name[0] = '\0';
+            return 0;
+        }
+    }
+    return OS_SERVICE_NOT_FOUND;
+}
+
+int service_registry_remove_pid(int32_t pid) {
+    uint32_t i;
+    int removed = 0;
+    if (pid <= 0) return OS_SERVICE_NOT_FOUND;
+    for (i = 0U; i < SERVICE_REGISTRY_CAPACITY; i++) {
+        if (service_entries[i].pid == pid) {
+            service_entries[i].pid = 0;
+            service_entries[i].name[0] = '\0';
+            removed++;
+        }
+    }
+    return removed > 0 ? 0 : OS_SERVICE_NOT_FOUND;
+}

--- a/kernel/service_registry.h
+++ b/kernel/service_registry.h
@@ -1,0 +1,21 @@
+#ifndef SERVICE_REGISTRY_H
+#define SERVICE_REGISTRY_H
+
+#include <stdint.h>
+#include "os_syscalls.h"
+
+#define SERVICE_REGISTRY_CAPACITY 8U
+
+typedef struct {
+    int32_t pid;
+    char name[OS_SERVICE_NAME_MAX];
+} service_registry_entry_t;
+
+void service_registry_init(void);
+int service_registry_register(const char* name, int32_t pid);
+int service_registry_lookup(const char* name);
+int service_registry_remove(const char* name, int32_t pid);
+int service_registry_remove_pid(int32_t pid);
+int service_registry_name_valid(const char* name);
+
+#endif

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -13,6 +13,7 @@
 #include "../llm/gpt2_infer.h"
 #include "../llm/gpt2_model.h"
 #include "../llm/gpt2_tokenizer.h"
+#include "../service_registry.h"
 /* Completions locales : BPE, top-k basse temperature, arret newline/EOT/repetition. */
 #define GPT2_BAREMETAL_GENERATION_STEPS 12U
 
@@ -174,6 +175,12 @@ void syscall_handler(cpu_state_t* cpu) {
         case SYS_IPC_RECV:
             cpu->eax = (uint32_t)sys_ipc_receive((os_ipc_message_t*)cpu->ebx);
             break;
+        case SYS_SERVICE_REGISTER:
+            cpu->eax = (uint32_t)sys_service_register((const char*)cpu->ebx);
+            break;
+        case SYS_SERVICE_LOOKUP:
+            cpu->eax = (uint32_t)sys_service_lookup((const char*)cpu->ebx);
+            break;
             
         default:
             // Syscall inconnu
@@ -198,6 +205,32 @@ int sys_ipc_receive(os_ipc_message_t* out) {
         return OS_IPC_BAD_MESSAGE;
     }
     return ipc_endpoint_receive(&current_task->ipc_endpoint, out);
+}
+
+int sys_service_register(const char* name) {
+    int owner_pid;
+    task_t* owner;
+    if (!current_task || current_task->type != TASK_TYPE_USER) return OS_SERVICE_BAD_NAME;
+    owner_pid = service_registry_lookup(name);
+    if (owner_pid > 0) {
+        owner = get_task_by_id(owner_pid);
+        if (!owner || owner->type != TASK_TYPE_USER || owner->state == TASK_TERMINATED) {
+            (void)service_registry_remove(name, owner_pid);
+        }
+    }
+    return service_registry_register(name, current_task->id);
+}
+
+int sys_service_lookup(const char* name) {
+    int owner_pid = service_registry_lookup(name);
+    task_t* owner;
+    if (owner_pid < 0) return owner_pid;
+    owner = get_task_by_id(owner_pid);
+    if (!owner || owner->type != TASK_TYPE_USER || owner->state == TASK_TERMINATED) {
+        (void)service_registry_remove(name, owner_pid);
+        return OS_SERVICE_NOT_FOUND;
+    }
+    return owner_pid;
 }
 
 /*

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -39,6 +39,8 @@ int sys_append(const char* path, const char* buf, uint32_t n);
 int sys_gpt2_generate(const char* prompt, char* out, uint32_t max);
 int sys_ipc_send(int target_pid, const os_ipc_payload_t* payload);
 int sys_ipc_receive(os_ipc_message_t* out);
+int sys_service_register(const char* name);
+int sys_service_lookup(const char* name);
 
 void keyboard_add_char_to_buffer(char c);
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -107,6 +107,11 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ipc: $(UNIT_DIR)/kernel/test_ipc.c ../kerne
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ipc.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_service_registry: $(UNIT_DIR)/kernel/test_service_registry.c ../kernel/service_registry.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/service_registry.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
 $(BUILD_DIR)/$(ROBUSTNESS_DIR)/test_gpt2_gguf_bounds: $(ROBUSTNESS_DIR)/test_gpt2_gguf_bounds.c ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES)

--- a/tests/integration/test_qemu_vfs_service.py
+++ b/tests/integration/test_qemu_vfs_service.py
@@ -86,13 +86,11 @@ def main():
             before_spawn = len(log_text())
             send_command(monitor, "spawn vfsserver")
             wait_for("spawn ok pid", proc, before_spawn)
-            spawned = re.search(r"spawn ok pid (\d+) vfsserver", log_text()[before_spawn:])
-            if not spawned:
-                raise RuntimeError("PID du serveur VFS absent")
-            server_pid = spawned.group(1)
-            wait_for("vfsserver ready", proc, before_spawn)
+            if not re.search(r"spawn ok pid (\d+) vfsserver", log_text()[before_spawn:]):
+                raise RuntimeError("serveur VFS non lance")
+            wait_for("vfsserver ready vfs", proc, before_spawn)
             before_read = len(log_text())
-            send_command(monitor, "vfs-read %s hello.txt" % server_pid)
+            send_command(monitor, "vfs-read hello.txt")
             wait_for("vfs-read ok", proc, before_read)
             wait_for("Un autre fichier de demonstration.", proc, before_read)
             before_return = len(log_text())

--- a/tests/scripts/ci_qemu_core_smoke.py
+++ b/tests/scripts/ci_qemu_core_smoke.py
@@ -129,7 +129,6 @@ def main():
                 ("ls qc", "hello.txt"),
                 ("append q.txt ok", "append ok q.txt"),
                 ("cat q.txt", "ok"),
-                ("rc", "rc ok 0"),
             )
             for command, marker in commands:
                 say("typing %s ..." % command)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -114,6 +114,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_ipc.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/ipc.c"
     fi
+    if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
+    fi
     if [ "$(basename "$test_file")" = "test_gpt2_gguf_bounds.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_gguf.c"
     fi

--- a/tests/unit/kernel/test_service_registry.c
+++ b/tests/unit/kernel/test_service_registry.c
@@ -1,0 +1,65 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/service_registry.h"
+
+static void test_registry_rejects_invalid_names(void) {
+    char too_long[OS_SERVICE_NAME_MAX];
+    uint32_t i;
+    for (i = 0U; i < OS_SERVICE_NAME_MAX; i++) too_long[i] = 'a';
+    service_registry_init();
+    TEST_ASSERT_FALSE(service_registry_name_valid(""));
+    TEST_ASSERT_FALSE(service_registry_name_valid("vfs/unsafe"));
+    TEST_ASSERT_FALSE(service_registry_name_valid("bad name"));
+    TEST_ASSERT_FALSE(service_registry_name_valid(too_long));
+    TEST_ASSERT_EQUAL(OS_SERVICE_BAD_NAME, service_registry_register("bad name", 1));
+}
+
+static void test_registry_binds_name_to_owner_and_is_idempotent(void) {
+    service_registry_init();
+    TEST_ASSERT_EQUAL(0, service_registry_register("vfs", 7));
+    TEST_ASSERT_EQUAL(7, service_registry_lookup("vfs"));
+    TEST_ASSERT_EQUAL(0, service_registry_register("vfs", 7));
+    TEST_ASSERT_EQUAL(OS_SERVICE_TAKEN, service_registry_register("vfs", 8));
+}
+
+static void test_registry_handles_capacity(void) {
+    char name[3];
+    uint32_t i;
+    service_registry_init();
+    name[2] = '\0';
+    for (i = 0U; i < SERVICE_REGISTRY_CAPACITY; i++) {
+        name[0] = 's';
+        name[1] = (char)('0' + i);
+        TEST_ASSERT_EQUAL(0, service_registry_register(name, (int32_t)(i + 1U)));
+    }
+    TEST_ASSERT_EQUAL(OS_SERVICE_FULL, service_registry_register("extra", 42));
+}
+
+static void test_registry_removal_allows_reuse(void) {
+    service_registry_init();
+    TEST_ASSERT_EQUAL(0, service_registry_register("vfs", 4));
+    TEST_ASSERT_EQUAL(0, service_registry_remove("vfs", 4));
+    TEST_ASSERT_EQUAL(OS_SERVICE_NOT_FOUND, service_registry_lookup("vfs"));
+    TEST_ASSERT_EQUAL(0, service_registry_register("vfs", 9));
+    TEST_ASSERT_EQUAL(9, service_registry_lookup("vfs"));
+}
+
+static void test_remove_pid_clears_all_services_owned_by_task(void) {
+    service_registry_init();
+    TEST_ASSERT_EQUAL(0, service_registry_register("vfs", 3));
+    TEST_ASSERT_EQUAL(0, service_registry_register("logger", 3));
+    TEST_ASSERT_EQUAL(0, service_registry_remove_pid(3));
+    TEST_ASSERT_EQUAL(OS_SERVICE_NOT_FOUND, service_registry_lookup("vfs"));
+    TEST_ASSERT_EQUAL(OS_SERVICE_NOT_FOUND, service_registry_lookup("logger"));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_registry_rejects_invalid_names);
+    RUN_TEST(test_registry_binds_name_to_owner_and_is_idempotent);
+    RUN_TEST(test_registry_handles_capacity);
+    RUN_TEST(test_registry_removal_allows_reuse);
+    RUN_TEST(test_remove_pid_clears_all_services_owned_by_task);
+    unity_print_results();
+    unity_cleanup();
+    return unity_stats.tests_failed == 0 ? 0 : 1;
+}

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -215,6 +215,12 @@ int sys_ipc_receive(os_ipc_message_t* message) {
     return result;
 }
 
+int sys_service_lookup(const char* name) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_SERVICE_LOOKUP), "b"(name));
+    return result;
+}
+
 static void print_fs_err(const char* cmd, int rc);
 
 // ==============================================================================
@@ -525,7 +531,7 @@ void cmd_help(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("  yield              - Ceder le CPU (SYS_YIELD, cooperatif)\n");
     print_string("  ipc-send <pid> <txt> - Envoyer un message IPC borne\n");
     print_string("  ipc-recv           - Lire un message IPC non bloquant\n");
-    print_string("  vfs-read <pid> <f> - Lire un fichier via le service VFS\n");
+    print_string("  vfs-read <fichier>   - Lire un fichier via le service VFS nomme\n");
     print_string("  kill <pid>         - Terminer un processus\n");
     print_string("  jobs               - Afficher les tâches\n");
     print_string("  top                - Moniteur système\n");
@@ -1446,16 +1452,17 @@ static void cmd_vfs_read(shell_context_t* ctx, char args[][128], int arg_count) 
     int pid;
     int rc;
     uint32_t i;
-    if (arg_count != 2) {
-        print_error("Usage: vfs-read <pid> <chemin>");
+    if (arg_count != 1) {
+        print_error("Usage: vfs-read <chemin>");
         return;
     }
-    pid = parse_int(args[0]);
+    pid = sys_service_lookup("vfs");
     if (pid <= 0) {
-        print_error("vfs-read: pid invalide");
+        print_error("vfs-read: service vfs indisponible");
+        ctx->last_rc = pid;
         return;
     }
-    rc = os_vfs_make_read_request(&request, args[1]);
+    rc = os_vfs_make_read_request(&request, args[0]);
     if (rc != 0) {
         print_error("vfs-read: chemin invalide ou trop long");
         ctx->last_rc = rc;

--- a/userspace/vfs_server.c
+++ b/userspace/vfs_server.c
@@ -22,6 +22,12 @@ static int ipc_send(int target_pid, const os_ipc_payload_t* payload) {
     return result;
 }
 
+static int service_register(const char* name) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_SERVICE_REGISTER), "b"(name));
+    return result;
+}
+
 static int read_file(const char* path, char* buffer, uint32_t max) {
     int result;
     asm volatile("int $0x80" : "=a"(result) : "a"(SYS_READFILE), "b"(path), "c"(buffer), "d"(max));
@@ -37,7 +43,11 @@ void main(void) {
     os_ipc_payload_t reply_payload;
     char path[OS_VFS_PATH_MAX];
     uint8_t data[OS_VFS_READ_MAX];
-    puts("vfsserver ready\n");
+    if (service_register("vfs") != 0) {
+        puts("vfsserver register failed\n");
+        for (;;) yield();
+    }
+    puts("vfsserver ready vfs\n");
     for (;;) {
         int received = ipc_receive(&message);
         if (received == 0 && message.type == OS_IPC_VFS_READ) {


### PR DESCRIPTION
## Résumé

Cette pull request livre le troisième incrément **MOHHOS Foundation** : un registre de services nommé qui permet aux clients de résoudre `vfs` sans connaître le PID de `vfsserver`.

| Élément | Livraison |
|---|---|
| ABI | `SYS_SERVICE_REGISTER` (25) et `SYS_SERVICE_LOOKUP` (26), `MAX_SYSCALLS = 27` |
| Registre | 8 noms, 15 octets utiles au plus, association automatique au PID Ring 3 appelant |
| Conflits | Nom actif d’un autre propriétaire refusé ; réinscription du même propriétaire idempotente |
| Nettoyage | Entrée stale purgée à la recherche ou avant une nouvelle inscription |
| Première intégration | `vfsserver` publie `vfs`; `vfs-read hello.txt` résout le nom avant l’IPC |
| Tests | 5 tests Unity du registre et contrat QEMU VFS sans PID |

## Validations exécutées

```text
make kernel-only      # noyau i386 compilé
make test-all         # 176/176 tests réussis
make qemu-vfs-service # publication vfs, découverte et lecture réussies
make integration-qemu # AOS-022, AOS-024, AOS-025, IPC et VFS nommé réussis
```

## Limites assumées

- Le registre est une découverte de nom volatile, pas un espace de capabilities ni une autorité de publication.
- Tout processus Ring 3 peut tenter de réserver un nom libre ; il n’existe ni manifeste signé, ni badge, ni contrôle d’identité.
- Les requêtes/réponses IPC restent non bloquantes et sans corrélation ; aucun registre multi-instance ou persistant n’est livré.
- Le backend VFS, les pilotes et le réseau restent dans le noyau monolithique.
