### PR TITLE
fix: vérifie l’émetteur des réponses backend VFS

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -100,6 +100,8 @@ Le trente-quatrième incrément ajoute `SYS_SERVICE_BACKEND_OBSERVE` (50), le pr
 
 Le trente-cinquième incrément porte cette génération à la granularité du service publié. Une mutation backend de `demo` ne rend plus l’observation de `vfs` obsolète ; seules les mutations, révocations, transferts et purges associés au même nom font avancer sa génération. Aucun nouveau syscall ni droit n’est ajouté.
 
+Le trente-sixième incrément lie les réponses corrélées des commandes `vfs-backend-*` au PID du médiateur `vfs` résolu avant l’envoi. Une réponse du bon type et du bon `request_id` issue d’un autre PID n’est pas décodée comme valide. Cette protection couvre l’octroi, les profils scoped, la révocation, le statut, l’inventaire et l’observation backend ; les autres familles de réponses VFS restent explicitement hors périmètre.
+
 ### IA locale, GGUF et BPE
 
 Le chemin `ai <texte>` appelle `SYS_GPT2_GENERATE` avec le profil local GPT-2. Le chargeur utilise le checkpoint `llm.c v3`, le tokenizer binaire, des activations CPU freestanding, le cache clé/valeur par couche et position, SSE2 et un échantillonnage top-k. Le contexte est limité à 64 jetons ; l’interface indique quatre jetons générés au maximum afin de borner l’exécution. Sous QEMU TCG sans KVM, l’objectif inférieur à une seconde n’est **pas atteint** : les mesures disponibles restent de l’ordre de 7 à 9 secondes pour une courte génération. L’amélioration du cache KV et de SSE2 reste néanmoins substantielle par rapport à l’ancien chemin non optimisé.

--- a/docs/mohhos_foundation_increment_36_vfs_backend_reply_sender.md
+++ b/docs/mohhos_foundation_increment_36_vfs_backend_reply_sender.md
@@ -1,0 +1,25 @@
+# Incrément Foundation 36 — Émetteur des réponses de capacité backend VFS
+
+## Objet
+
+L’incrément 36 durcit les commandes de capacité backend VFS en liant une réponse IPC corrélée au PID du médiateur `vfs` résolu avant l’envoi de la requête. Une réponse qui possède le bon type et le bon `request_id`, mais dont `sender_pid` ne correspond pas à ce PID, n’est pas décodée comme une réponse valide.
+
+| Commande protégée | Réponse attendue |
+|---|---|
+| `vfs-backend-grant` | `OS_IPC_VFS_BACKEND_GRANT_REPLY` |
+| `vfs-backend-grant-read` | `OS_IPC_VFS_BACKEND_GRANT_SCOPED_REPLY` |
+| `vfs-backend-grant-mutate` | `OS_IPC_VFS_BACKEND_GRANT_SCOPED_REPLY` |
+| `vfs-backend-revoke` | `OS_IPC_VFS_BACKEND_REVOKE_REPLY` |
+| `vfs-backend-status` | `OS_IPC_VFS_BACKEND_STATUS_REPLY` |
+| `vfs-backend-list` | `OS_IPC_VFS_BACKEND_LIST_REPLY` |
+| `vfs-backend-observe` | `OS_IPC_VFS_BACKEND_OBSERVE_REPLY` |
+
+Le contrôle est appliqué à la fois aux messages retirés de la file différée et à ceux qui arrivent directement dans la boucle d’attente. Les messages hors séquence restent placés dans la file différée conformément au contrat existant ; un message corrélé du mauvais émetteur ne peut toutefois pas produire un succès, un refus métier ou un masque observé.
+
+> Ce contrôle établit l’origine locale de la réponse par PID, mais ne fournit ni identité cryptographique, ni capability non forgeable, ni protection contre l’usurpation d’un PID par un noyau compromis.
+
+## Vérification
+
+La compilation Ring 3 est réussie et `make test-all` reste vert avec **217/217** tests. Le contrat QEMU VFS complet atteint sa fin attendue, notamment `rc ok 0` après le retrait du service VFS. Les commandes de capacité continuent donc d’accepter les réponses légitimes du médiateur dans l’image réellement amorcée.
+
+Les autres familles de réponses VFS — lecture, écriture, métadonnées, répertoires et montages — ne sont pas incluses dans cet incrément. Leur durcissement doit être traité séparément afin de préserver une couverture explicite et testable de chaque chemin de corrélation.

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -1776,8 +1776,9 @@ static void cmd_vfs_backend_grant(shell_context_t* ctx, char args[][128], int ar
     if (rc == 0) rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-backend-grant: demande refusee"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_BACKEND_GRANT_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_backend_grant_reply(&message, &status, request_id);
-    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_GRANT_REPLY && message.request_id == request_id) rc = os_vfs_parse_backend_grant_reply(&message, &status, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
+    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_GRANT_REPLY && message.request_id == request_id && message.sender_pid == pid) rc = os_vfs_parse_backend_grant_reply(&message, &status, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
     if (rc != 0 || status != 0) { print_error("vfs-backend-grant: delegation refusee"); ctx->last_rc = rc != 0 ? rc : status; return; }
     ctx->last_rc = 0; print_string("vfs-backend-grant ok request "); print_int((int)request_id); print_string("\n");
 }
@@ -1792,8 +1793,9 @@ static void cmd_vfs_backend_grant_read(shell_context_t* ctx, char args[][128], i
     if (rc == 0) rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-backend-grant-read: demande refusee"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_BACKEND_GRANT_SCOPED_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_backend_grant_scoped_reply(&message, &status, request_id);
-    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_GRANT_SCOPED_REPLY && message.request_id == request_id) rc = os_vfs_parse_backend_grant_scoped_reply(&message, &status, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
+    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_GRANT_SCOPED_REPLY && message.request_id == request_id && message.sender_pid == pid) rc = os_vfs_parse_backend_grant_scoped_reply(&message, &status, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
     if (rc != 0 || status != 0) { print_error("vfs-backend-grant-read: delegation refusee"); ctx->last_rc = rc != 0 ? rc : status; return; }
     ctx->last_rc = 0; print_string("vfs-backend-grant-read ok request "); print_int((int)request_id); print_string("\n");
 }
@@ -1808,8 +1810,9 @@ static void cmd_vfs_backend_grant_mutate(shell_context_t* ctx, char args[][128],
     if (rc == 0) rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-backend-grant-mutate: demande refusee"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_BACKEND_GRANT_SCOPED_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_backend_grant_scoped_reply(&message, &status, request_id);
-    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_GRANT_SCOPED_REPLY && message.request_id == request_id) rc = os_vfs_parse_backend_grant_scoped_reply(&message, &status, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
+    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_GRANT_SCOPED_REPLY && message.request_id == request_id && message.sender_pid == pid) rc = os_vfs_parse_backend_grant_scoped_reply(&message, &status, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
     if (rc != 0 || status != 0) { print_error("vfs-backend-grant-mutate: delegation refusee"); ctx->last_rc = rc != 0 ? rc : status; return; }
     ctx->last_rc = 0; print_string("vfs-backend-grant-mutate ok request "); print_int((int)request_id); print_string("\n");
 }
@@ -1824,8 +1827,9 @@ static void cmd_vfs_backend_revoke(shell_context_t* ctx, char args[][128], int a
     if (rc == 0) rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-backend-revoke: demande refusee"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_BACKEND_REVOKE_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_backend_revoke_reply(&message, &status, request_id);
-    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_REVOKE_REPLY && message.request_id == request_id) rc = os_vfs_parse_backend_revoke_reply(&message, &status, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
+    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_REVOKE_REPLY && message.request_id == request_id && message.sender_pid == pid) rc = os_vfs_parse_backend_revoke_reply(&message, &status, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
     if (rc != 0 || status != 0) { print_error("vfs-backend-revoke: revocation refusee"); ctx->last_rc = rc != 0 ? rc : status; return; }
     ctx->last_rc = 0; print_string("vfs-backend-revoke ok request "); print_int((int)request_id); print_string("\n");
 }
@@ -1840,8 +1844,9 @@ static void cmd_vfs_backend_status(shell_context_t* ctx, char args[][128], int a
     if (rc == 0) rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-backend-status: demande refusee"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_BACKEND_STATUS_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_backend_status_reply(&message, &status, &rights, request_id);
-    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_STATUS_REPLY && message.request_id == request_id) rc = os_vfs_parse_backend_status_reply(&message, &status, &rights, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
+    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_STATUS_REPLY && message.request_id == request_id && message.sender_pid == pid) rc = os_vfs_parse_backend_status_reply(&message, &status, &rights, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
     if (rc != 0 || status != 0) { print_error("vfs-backend-status: capacite absente ou refusee"); ctx->last_rc = rc != 0 ? rc : status; return; }
     ctx->last_rc = 0; print_string("vfs-backend-status ok rights ");
     if (rights == OS_VFS_BACKEND_RIGHT_READ) print_string("read");
@@ -1861,8 +1866,9 @@ static void cmd_vfs_backend_list(shell_context_t* ctx, char args[][128], int arg
     if (rc == 0) rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-backend-list: demande refusee"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_BACKEND_LIST_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_backend_list_reply(&message, &reply, request_id);
-    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_LIST_REPLY && message.request_id == request_id) rc = os_vfs_parse_backend_list_reply(&message, &reply, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
+    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_LIST_REPLY && message.request_id == request_id && message.sender_pid == pid) rc = os_vfs_parse_backend_list_reply(&message, &reply, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
     if (rc != 0 || reply.status != 0) { print_error("vfs-backend-list: consultation refusee"); ctx->last_rc = rc != 0 ? rc : reply.status; return; }
     ctx->last_rc = 0; print_string("vfs-backend-list ok count "); print_int((int)reply.count); print_string(" request "); print_int((int)request_id); print_string("\n");
     for (i = 0U; i < reply.count; i++) {
@@ -1885,8 +1891,9 @@ static void cmd_vfs_backend_observe(shell_context_t* ctx, char args[][128], int 
     if (rc == 0) rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-backend-observe: demande refusee"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_BACKEND_OBSERVE_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_backend_observe_reply(&message, &reply, request_id);
-    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_OBSERVE_REPLY && message.request_id == request_id) rc = os_vfs_parse_backend_observe_reply(&message, &reply, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
+    for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) { int saved; yield(); rc = sys_ipc_receive(&message); if (rc == 0) { if (message.type == OS_IPC_VFS_BACKEND_OBSERVE_REPLY && message.request_id == request_id && message.sender_pid == pid) rc = os_vfs_parse_backend_observe_reply(&message, &reply, request_id); else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; } } }
     if (rc != 0) { print_error("vfs-backend-observe: reponse invalide"); ctx->last_rc = rc; return; }
     if (reply.status == OS_SERVICE_STALE) { ctx->last_rc = reply.status; print_string("vfs-backend-observe stale generation "); print_int((int)reply.generation); print_string("\n"); return; }
     if (reply.status != 0) { print_error("vfs-backend-observe: consultation refusee"); ctx->last_rc = reply.status; return; }


### PR DESCRIPTION
## Incrément Foundation 36

Durcit les réponses IPC corrélées des commandes de capacité backend VFS.

- les réponses différées et directes doivent provenir du PID `vfs` résolu avant l’envoi ;
- couvre grant, profils read/mutate, revoke, status, list et observe ;
- une réponse corrélée d’un autre PID ne peut plus être décodée comme réponse backend valide ;
- périmètre volontairement limité : lecture, écriture, stat, listes et montages restent hors de cette modification ;
- validation : compilation Ring 3, 217/217 tests Unity et contrat QEMU VFS complet (`rc ok 0`).

Aucun nouveau syscall, format IPC ni privilège n’est ajouté.