### PR TITLE
fix: vérifie l’émetteur de toutes les réponses VFS

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -100,7 +100,9 @@ Le trente-quatrième incrément ajoute `SYS_SERVICE_BACKEND_OBSERVE` (50), le pr
 
 Le trente-cinquième incrément porte cette génération à la granularité du service publié. Une mutation backend de `demo` ne rend plus l’observation de `vfs` obsolète ; seules les mutations, révocations, transferts et purges associés au même nom font avancer sa génération. Aucun nouveau syscall ni droit n’est ajouté.
 
-Le trente-sixième incrément lie les réponses corrélées des commandes `vfs-backend-*` au PID du médiateur `vfs` résolu avant l’envoi. Une réponse du bon type et du bon `request_id` issue d’un autre PID n’est pas décodée comme valide. Cette protection couvre l’octroi, les profils scoped, la révocation, le statut, l’inventaire et l’observation backend ; les autres familles de réponses VFS restent explicitement hors périmètre.
+Le trente-sixième incrément lie les réponses corrélées des commandes `vfs-backend-*` au PID du médiateur `vfs` résolu avant l’envoi. Une réponse du bon type et du bon `request_id` issue d’un autre PID n’est pas décodée comme valide. Cette protection couvre l’octroi, les profils scoped, la révocation, le statut, l’inventaire et l’observation backend.
+
+Le trente-septième incrément étend ce même contrôle aux réponses VFS de fichiers, répertoires, pagination, observation de répertoire, métadonnées et montages. Toutes les commandes VFS corrélées du shell exigent maintenant le PID du médiateur résolu avant le décodage de leur réponse. Aucun syscall, format IPC ni droit supplémentaire n’est introduit.
 
 ### IA locale, GGUF et BPE
 

--- a/docs/mohhos_foundation_increment_37_vfs_reply_sender_full.md
+++ b/docs/mohhos_foundation_increment_37_vfs_reply_sender_full.md
@@ -1,0 +1,22 @@
+# Lot Foundation 37 — Émetteur de toutes les réponses VFS corrélées
+
+## Objet
+
+Ce lot étend le contrôle d’émetteur livré pour les capacités backend à l’ensemble des commandes VFS corrélées du shell. Chaque commande résout le PID public de `vfs` avant l’envoi, puis n’analyse une réponse différée ou directe que si son `sender_pid` correspond à ce PID.
+
+| Famille couverte | Commandes |
+|---|---|
+| Fichiers | `vfs-read`, `vfs-write`, `vfs-remove`, `vfs-rename`, `vfs-stat` |
+| Répertoires | `vfs-mkdir`, `vfs-rmdir`, `vfs-list`, `vfs-list-page`, `vfs-list-observe` |
+| Montages | `vfs-mount-add`, `vfs-mount-remove` |
+| Capacités backend | octroi complet ou scoped, révocation, statut, inventaire, observation |
+
+Un message du bon type et du bon `request_id` issu d’un autre PID ne peut donc pas être décodé comme une réponse VFS valide. Le helper des montages reçoit explicitement le PID attendu ; tous les autres chemins de réception appliquent le même contrôle avant le codec de réponse.
+
+> Le mécanisme vérifie l’origine locale déclarée par le noyau IPC. Il n’est pas une identité cryptographique, une capability non forgeable, ni une protection contre un noyau compromis.
+
+## Vérification
+
+La compilation Ring 3 et `make test-all` sont verts avec **217/217** tests. Le contrat QEMU VFS complet termine avec `rc ok 0` après les opérations de lecture, écriture, métadonnées, listage, pagination, observation, montages, capacité backend, transfert et purge.
+
+Le lot ne modifie ni l’ABI, ni le protocole IPC, ni les droits backend. Les réponses non corrélées et les notifications best-effort conservent leur sémantique existante.

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -1941,13 +1941,14 @@ static void cmd_vfs_write(shell_context_t* ctx, char args[][128], int arg_count)
     }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_WRITE_REPLY,
                                        request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_write_reply(&message, &reply, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved;
         yield();
         rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_WRITE_REPLY && message.request_id == request_id) {
+            if (message.type == OS_IPC_VFS_WRITE_REPLY && message.request_id == request_id && message.sender_pid == pid) {
                 rc = os_vfs_parse_write_reply(&message, &reply, request_id);
             } else {
                 saved = os_ipc_deferred_push(&ipc_deferred, &message);
@@ -2007,13 +2008,14 @@ static void cmd_vfs_remove(shell_context_t* ctx, char args[][128], int arg_count
     }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_REMOVE_REPLY,
                                        request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_remove_reply(&message, &reply, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved;
         yield();
         rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_REMOVE_REPLY && message.request_id == request_id) {
+            if (message.type == OS_IPC_VFS_REMOVE_REPLY && message.request_id == request_id && message.sender_pid == pid) {
                 rc = os_vfs_parse_remove_reply(&message, &reply, request_id);
             } else {
                 saved = os_ipc_deferred_push(&ipc_deferred, &message);
@@ -2073,13 +2075,14 @@ static void cmd_vfs_rename(shell_context_t* ctx, char args[][128], int arg_count
     }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_RENAME_REPLY,
                                        request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_rename_reply(&message, &reply, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved;
         yield();
         rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_RENAME_REPLY && message.request_id == request_id) {
+            if (message.type == OS_IPC_VFS_RENAME_REPLY && message.request_id == request_id && message.sender_pid == pid) {
                 rc = os_vfs_parse_rename_reply(&message, &reply, request_id);
             } else {
                 saved = os_ipc_deferred_push(&ipc_deferred, &message);
@@ -2106,19 +2109,20 @@ static void cmd_vfs_rename(shell_context_t* ctx, char args[][128], int arg_count
     print_string("\n");
 }
 
-static int wait_vfs_mount_reply(uint32_t type, uint32_t request_id,
+static int wait_vfs_mount_reply(int expected_sender, uint32_t type, uint32_t request_id,
                                 os_vfs_mount_reply_t* reply) {
     os_ipc_message_t message;
     int rc;
     int attempts;
     rc = os_ipc_deferred_take_matching(&ipc_deferred, type, request_id, &message);
+    if (rc == 0 && message.sender_pid != expected_sender) rc = OS_IPC_EMPTY;
     if (rc == 0) return os_vfs_parse_mount_reply(&message, type, reply, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved;
         yield();
         rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == type && message.request_id == request_id) {
+            if (message.type == type && message.request_id == request_id && message.sender_pid == expected_sender) {
                 return os_vfs_parse_mount_reply(&message, type, reply, request_id);
             }
             saved = os_ipc_deferred_push(&ipc_deferred, &message);
@@ -2160,7 +2164,7 @@ static void cmd_vfs_mount_add(shell_context_t* ctx, char args[][128], int arg_co
         ctx->last_rc = rc;
         return;
     }
-    rc = wait_vfs_mount_reply(OS_IPC_VFS_MOUNT_ADD_REPLY, request_id, &reply);
+    rc = wait_vfs_mount_reply(pid, OS_IPC_VFS_MOUNT_ADD_REPLY, request_id, &reply);
     if (rc != 0) {
         print_error("vfs-mount-add: reponse VFS absente ou invalide");
         ctx->last_rc = rc;
@@ -2202,7 +2206,7 @@ static void cmd_vfs_mount_remove(shell_context_t* ctx, char args[][128], int arg
         ctx->last_rc = rc;
         return;
     }
-    rc = wait_vfs_mount_reply(OS_IPC_VFS_MOUNT_REMOVE_REPLY, request_id, &reply);
+    rc = wait_vfs_mount_reply(pid, OS_IPC_VFS_MOUNT_REMOVE_REPLY, request_id, &reply);
     if (rc != 0) {
         print_error("vfs-mount-remove: reponse VFS absente ou invalide");
         ctx->last_rc = rc;
@@ -2253,13 +2257,14 @@ static void cmd_vfs_read(shell_context_t* ctx, char args[][128], int arg_count) 
     }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_READ_REPLY,
                                        request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_read_reply(&message, &reply, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved;
         yield();
         rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_READ_REPLY && message.request_id == request_id) {
+            if (message.type == OS_IPC_VFS_READ_REPLY && message.request_id == request_id && message.sender_pid == pid) {
                 rc = os_vfs_parse_read_reply(&message, &reply, request_id);
             } else {
                 saved = os_ipc_deferred_push(&ipc_deferred, &message);
@@ -2301,11 +2306,12 @@ static void cmd_vfs_mkdir(shell_context_t* ctx, char args[][128], int arg_count)
     rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-mkdir: service indisponible"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_MKDIR_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_mkdir_reply(&message, &status, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved; yield(); rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_MKDIR_REPLY && message.request_id == request_id)
+            if (message.type == OS_IPC_VFS_MKDIR_REPLY && message.request_id == request_id && message.sender_pid == pid)
                 rc = os_vfs_parse_mkdir_reply(&message, &status, request_id);
             else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; }
         }
@@ -2328,11 +2334,12 @@ static void cmd_vfs_rmdir(shell_context_t* ctx, char args[][128], int arg_count)
     rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-rmdir: service indisponible"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_RMDIR_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_rmdir_reply(&message, &status, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved; yield(); rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_RMDIR_REPLY && message.request_id == request_id)
+            if (message.type == OS_IPC_VFS_RMDIR_REPLY && message.request_id == request_id && message.sender_pid == pid)
                 rc = os_vfs_parse_rmdir_reply(&message, &status, request_id);
             else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; }
         }
@@ -2379,13 +2386,14 @@ static void cmd_vfs_list(shell_context_t* ctx, char args[][128], int arg_count) 
     }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_LIST_REPLY,
                                        request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_list_reply(&message, &reply, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved;
         yield();
         rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_LIST_REPLY && message.request_id == request_id) {
+            if (message.type == OS_IPC_VFS_LIST_REPLY && message.request_id == request_id && message.sender_pid == pid) {
                 rc = os_vfs_parse_list_reply(&message, &reply, request_id);
             } else {
                 saved = os_ipc_deferred_push(&ipc_deferred, &message);
@@ -2442,13 +2450,14 @@ static void cmd_vfs_list_page(shell_context_t* ctx, char args[][128], int arg_co
     rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-list-page: service indisponible"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_LIST_PAGE_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_list_page_reply(&message, &reply, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved;
         yield();
         rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_LIST_PAGE_REPLY && message.request_id == request_id) {
+            if (message.type == OS_IPC_VFS_LIST_PAGE_REPLY && message.request_id == request_id && message.sender_pid == pid) {
                 rc = os_vfs_parse_list_page_reply(&message, &reply, request_id);
             } else {
                 saved = os_ipc_deferred_push(&ipc_deferred, &message);
@@ -2488,11 +2497,12 @@ static void cmd_vfs_list_observe(shell_context_t* ctx, char args[][128], int arg
     rc = sys_ipc_send(pid, &request);
     if (rc != 0) { print_error("vfs-list-observe: service indisponible"); ctx->last_rc = rc; return; }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_LIST_OBSERVE_REPLY, request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_list_observe_reply(&message, &reply, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved; yield(); rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_LIST_OBSERVE_REPLY && message.request_id == request_id)
+            if (message.type == OS_IPC_VFS_LIST_OBSERVE_REPLY && message.request_id == request_id && message.sender_pid == pid)
                 rc = os_vfs_parse_list_observe_reply(&message, &reply, request_id);
             else { saved = os_ipc_deferred_push(&ipc_deferred, &message); rc = saved == 0 ? OS_IPC_EMPTY : saved; }
         }
@@ -2546,13 +2556,14 @@ static void cmd_vfs_stat(shell_context_t* ctx, char args[][128], int arg_count) 
     }
     rc = os_ipc_deferred_take_matching(&ipc_deferred, OS_IPC_VFS_STAT_REPLY,
                                        request_id, &message);
+    if (rc == 0 && message.sender_pid != pid) rc = OS_IPC_EMPTY;
     if (rc == 0) rc = os_vfs_parse_stat_reply(&message, &reply, request_id);
     for (attempts = 0; attempts < 3 && rc == OS_IPC_EMPTY; attempts++) {
         int saved;
         yield();
         rc = sys_ipc_receive(&message);
         if (rc == 0) {
-            if (message.type == OS_IPC_VFS_STAT_REPLY && message.request_id == request_id) {
+            if (message.type == OS_IPC_VFS_STAT_REPLY && message.request_id == request_id && message.sender_pid == pid) {
                 rc = os_vfs_parse_stat_reply(&message, &reply, request_id);
             } else {
                 saved = os_ipc_deferred_push(&ipc_deferred, &message);


### PR DESCRIPTION
## Lot Foundation 37

Étend la vérification du PID émetteur à toutes les réponses IPC VFS corrélées du shell.

- fichiers : lecture, écriture, suppression, renommage, métadonnées ;
- répertoires : création, suppression, listage, pagination, observation ;
- montages : ajout et retrait ;
- capacités backend : octroi, révocation, statut, inventaire et observation.

Une réponse du bon type et du bon `request_id` issue d’un PID différent du médiateur `vfs` résolu ne peut pas être décodée comme valide.

Validation exécutée : compilation Ring 3, 217/217 tests Unity et contrat QEMU VFS complet terminé sur `rc ok 0`.

Aucun syscall, format IPC ni droit supplémentaire n’est ajouté.