### PR TITLE
Lot 69: index GGUF et mapping des rôles GPT-2

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -24,9 +24,11 @@ AI-OS démarre sans OS préinstallé dans QEMU, charge une archive initrd TAR, l
 
 ### GGUF et kernels de quantification
 
-Le runtime possède désormais des produits scalaires freestanding pour les super-blocs GGML **Q3_K**, **Q4_K** et **Q6_K**, en plus de Q8_0. Les blocs sont contrôlés sur 256 valeurs et leurs tailles binaires sont explicites : 110, 144 et 210 octets. Le parseur GGUF classe séparément les tenseurs Q3_K, Q4_K et Q6_K au lieu de les signaler comme types quantifiés inconnus. La suite `make test-all` atteint 261 tests réussis et compare chaque kernel à un super-bloc synthétique déterministe. `gpt2_gguf_find_tensor` permet en outre de retrouver un tenseur par nom et de vérifier sa forme, son type, sa taille de bloc et sa plage dans le blob avant utilisation.
+Le runtime possède des produits scalaires freestanding pour les super-blocs GGML **Q3_K**, **Q4_K** et **Q6_K**, en plus de Q8_0. Les blocs sont contrôlés sur 256 valeurs et leurs tailles binaires sont explicites : 110, 144 et 210 octets. Le parseur GGUF classe séparément les tenseurs Q3_K, Q4_K et Q6_K au lieu de les signaler comme types quantifiés inconnus. `gpt2_gguf_find_tensor` vérifie la forme, le type, la taille de bloc et la plage avant utilisation.
 
-Cette livraison ne constitue pas encore une génération GPT-2 à partir d’un fichier GGUF réel : la recherche bornée existe, mais `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3` et ne possèdent pas de table persistante de mapping utilisable par le forward. La prochaine étape doit ajouter cette table, le mapping GPT-2 et un chemin de sélection contrôlée ; elle ne doit pas annoncer une latence inférieure à une seconde sans mesure native ou KVM reproductible.
+Le lot 69 ajoute `gpt2_gguf_build_index`, une table caller-owned bornée à 512 tenseurs, puis `gpt2_gguf_index_find` pour les recherches répétées sans rescanner les métadonnées. `gpt2_gguf_map_role` associe les cinq tenseurs structurants GPT-2 (`token_embd`, `position_embd`, `output_norm` et `output`) à des rôles stables pour le futur forward quantifié. La suite `make test-all` atteint désormais **262 tests réussis**, dont la nouvelle fixture d’index et de mapping.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un fichier GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et le chargement depuis FAT16 ainsi que le mapping des blocs d’attention restent à faire. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_69_gguf_index_gpt2_mapping.md
+++ b/docs/mohhos_foundation_increment_69_gguf_index_gpt2_mapping.md
@@ -1,0 +1,41 @@
+# MOHHOS Foundation — Incrément 69 : index GGUF et mapping GPT-2
+
+**État :** implémenté sur la branche de travail du lot 69.
+
+## Objectif
+
+Cet incrément transforme la vue ponctuelle de tenseurs GGUF en index réutilisable. `gpt2_gguf_build_index` valide d’abord l’enveloppe GGUF GPT-2 v3 existante, puis construit dans une structure fournie par l’appelant la table bornée de tous les descripteurs de tenseurs. Les noms restent des vues dans le blob source : aucune allocation dynamique, aucune copie de modèle et aucun pointeur de données non contrôlé ne sont introduits dans le noyau i386.
+
+La nouvelle recherche `gpt2_gguf_index_find` permet de retrouver un tenseur sans rescanner les métadonnées et les descripteurs du conteneur. Chaque entrée conserve la forme, le type, l’offset relatif à la zone de données et la taille calculée selon F32, F16, Q8_0, Q3_K, Q4_K ou Q6_K. Les contrôles de dimension, d’alignement, de taille de bloc et de plage sont identiques à ceux de la primitive de lecture existante.
+
+## Mapping sémantique GPT-2
+
+Le format GGUF emploie des noms stables pour les tenseurs structurants du modèle GPT-2. `gpt2_gguf_map_role` les expose sous forme d’un enum noyau afin que le futur runtime ne dépende pas de chaînes dispersées dans son chemin d’inférence.
+
+| Rôle | Nom GGUF exact |
+| --- | --- |
+| Embedding des tokens | `token_embd.weight` |
+| Embedding des positions | `position_embd.weight` |
+| Poids de normalisation de sortie | `output_norm.weight` |
+| Biais de normalisation de sortie | `output_norm.bias` |
+| Projection de sortie | `output.weight` |
+
+Le mapping ne prétend pas encore exécuter le forward GPT-2 complet. Il fournit la base bornée nécessaire pour sélectionner les tenseurs avant l’ajout progressif des blocs d’attention, des projections QKV et des couches feed-forward.
+
+## Validation
+
+La suite `make test-all` atteint **262 tests réussis**, sans échec ni test ignoré. La fixture ajoute cinq descripteurs Q4_K et vérifie la construction de l’index, la recherche de `output.weight`, les cinq rôles GPT-2 et le rejet d’un rôle invalide. Les tests précédents de parse GGUF, de kernels Q3_K/Q4_K/Q6_K, de robustesse et de FAT16 restent verts.
+
+| Contrôle | Résultat |
+| --- | --- |
+| Compilation des tests i386 (`-m32`) | Réussie |
+| Tests unitaires kernel | 13/13 suites vertes |
+| Tests userspace | 2/2 suites vertes |
+| Test de robustesse GGUF | Vert |
+| Total Unity | 262 réussis, 0 échec |
+
+## Limites et suite
+
+La structure est volontairement bornée à `GPT2_GGUF_MAX_TENSORS` entrées et doit être fournie par l’appelant. Le lot ne charge pas encore un fichier depuis FAT16, ne mappe pas les 149 tenseurs d’un checkpoint GPT-2 réel et ne réalise pas de multiplication quantifiée dans un forward complet. Ces étapes sont réservées au prochain groupe cohérent, après validation CI et smoke QEMU de cette tranche.
+
+Le blob GGUF reste une donnée non fiable. Toute utilisation de l’index doit conserver le blob vivant et ne dériver une adresse de données qu’après les validations de plage déjà effectuées. Cette discipline est particulièrement importante pour un noyau i386 sans protection mémoire complète entre toutes les étapes du runtime LLM.

--- a/kernel/llm/gpt2_gguf.c
+++ b/kernel/llm/gpt2_gguf.c
@@ -336,3 +336,85 @@ int gpt2_gguf_find_tensor(const uint8_t* blob, uint32_t blob_size,
     }
     return -8;
 }
+
+
+int gpt2_gguf_build_index(const uint8_t* blob, uint32_t blob_size,
+                          gpt2_gguf_index_t* out) {
+    uint32_t offset = 0U;
+    uint32_t magic;
+    uint32_t version;
+    uint64_t tensor_count64;
+    uint64_t metadata_count64;
+    uint32_t tensor_count;
+    uint32_t metadata_count;
+    uint32_t i;
+    int status;
+
+    if (!blob || !out) return -1;
+    status = gpt2_gguf_probe_blob(blob, blob_size, &out->info);
+    if (status != 0) return status;
+    out->blob = blob;
+    out->blob_size = blob_size;
+    out->tensor_count = 0U;
+    if (gguf_read_u32(blob, blob_size, &offset, &magic) != 0 ||
+        gguf_read_u32(blob, blob_size, &offset, &version) != 0 ||
+        gguf_read_u64(blob, blob_size, &offset, &tensor_count64) != 0 ||
+        gguf_read_u64(blob, blob_size, &offset, &metadata_count64) != 0 ||
+        tensor_count64 > GPT2_GGUF_MAX_TENSORS || metadata_count64 > GGUF_MAX_METADATA) return -2;
+    tensor_count = (uint32_t)tensor_count64;
+    metadata_count = (uint32_t)metadata_count64;
+    for (i = 0U; i < metadata_count; i++) {
+        uint32_t key_length;
+        uint32_t type;
+        if (gguf_read_string(blob, blob_size, &offset, 0, &key_length) != 0 ||
+            gguf_read_u32(blob, blob_size, &offset, &type) != 0 ||
+            gguf_skip_value(blob, blob_size, &offset, type, 0U) != 0) return -3;
+    }
+    for (i = 0U; i < tensor_count; i++) {
+        gpt2_gguf_tensor_t* tensor = &out->tensors[i];
+        uint64_t data_offset64;
+        uint32_t j;
+        if (gguf_read_string(blob, blob_size, &offset, &tensor->name, &tensor->name_length) != 0 ||
+            gguf_read_u32(blob, blob_size, &offset, &tensor->dimensions) != 0 ||
+            tensor->dimensions == 0U || tensor->dimensions > GGUF_MAX_DIMS) return -4;
+        for (j = 0U; j < GGUF_MAX_DIMS; j++) tensor->shape[j] = 0U;
+        for (j = 0U; j < tensor->dimensions; j++) {
+            if (gguf_read_u64(blob, blob_size, &offset, &tensor->shape[j]) != 0) return -5;
+        }
+        if (gguf_read_u32(blob, blob_size, &offset, &tensor->type) != 0 ||
+            gguf_read_u64(blob, blob_size, &offset, &data_offset64) != 0 ||
+            data_offset64 > 0xffffffffULL ||
+            gguf_tensor_byte_size(tensor->type, tensor->shape, tensor->dimensions, &tensor->byte_size) != 0) return -6;
+        if (data_offset64 > (uint64_t)(blob_size - out->info.tensor_data_offset) ||
+            tensor->byte_size > blob_size - out->info.tensor_data_offset - (uint32_t)data_offset64) return -7;
+        tensor->data_offset = (uint32_t)data_offset64;
+    }
+    out->tensor_count = tensor_count;
+    return 0;
+}
+
+int gpt2_gguf_index_find(const gpt2_gguf_index_t* index, const char* name,
+                         gpt2_gguf_tensor_t* out) {
+    uint32_t i;
+    if (!index || !name || !out || index->tensor_count > GPT2_GGUF_MAX_TENSORS) return -1;
+    for (i = 0U; i < index->tensor_count; i++) {
+        if (gguf_name_equals_cstr(index->tensors[i].name, index->tensors[i].name_length, name)) {
+            *out = index->tensors[i];
+            return 0;
+        }
+    }
+    return -8;
+}
+
+int gpt2_gguf_map_role(const gpt2_gguf_index_t* index, gpt2_gguf_role_t role,
+                       gpt2_gguf_tensor_t* out) {
+    static const char* const names[] = {
+        "token_embd.weight",
+        "position_embd.weight",
+        "output_norm.weight",
+        "output_norm.bias",
+        "output.weight"
+    };
+    if ((uint32_t)role >= (uint32_t)(sizeof(names) / sizeof(names[0]))) return -1;
+    return gpt2_gguf_index_find(index, names[(uint32_t)role], out);
+}

--- a/kernel/llm/gpt2_gguf.h
+++ b/kernel/llm/gpt2_gguf.h
@@ -30,6 +30,8 @@
 #define GPT2_GGUF_TENSOR_Q4_K 12U
 #define GPT2_GGUF_TENSOR_Q6_K 14U
 
+#define GPT2_GGUF_MAX_TENSORS 512U
+
 /* A structural report. No pointer from an untrusted blob is exposed. */
 typedef struct {
     const uint8_t* name;
@@ -40,6 +42,14 @@ typedef struct {
     uint32_t data_offset;
     uint32_t byte_size;
 } gpt2_gguf_tensor_t;
+
+typedef enum {
+    GPT2_GGUF_ROLE_TOKEN_EMBEDDING = 0U,
+    GPT2_GGUF_ROLE_POSITION_EMBEDDING = 1U,
+    GPT2_GGUF_ROLE_OUTPUT_NORM_WEIGHT = 2U,
+    GPT2_GGUF_ROLE_OUTPUT_NORM_BIAS = 3U,
+    GPT2_GGUF_ROLE_OUTPUT_WEIGHT = 4U
+} gpt2_gguf_role_t;
 
 typedef struct {
     uint32_t version;
@@ -57,6 +67,14 @@ typedef struct {
     uint8_t is_valid;
 } gpt2_gguf_info_t;
 
+typedef struct {
+    gpt2_gguf_info_t info;
+    const uint8_t* blob;
+    uint32_t blob_size;
+    uint32_t tensor_count;
+    gpt2_gguf_tensor_t tensors[GPT2_GGUF_MAX_TENSORS];
+} gpt2_gguf_index_t;
+
 /* Returns 0 only for a bounded, structurally valid GPT-2 GGUF v3 blob.
  * The function does not allocate and does not execute model data. */
 int gpt2_gguf_probe_blob(const uint8_t* blob, uint32_t blob_size,
@@ -68,5 +86,14 @@ const char* gpt2_gguf_probe_status(int status);
 /* Find one descriptor and validate its data range without copying the blob. */
 int gpt2_gguf_find_tensor(const uint8_t* blob, uint32_t blob_size,
                           const char* name, gpt2_gguf_tensor_t* out);
+
+/* Builds a caller-owned table so repeated lookups do not rescan the blob. */
+int gpt2_gguf_build_index(const uint8_t* blob, uint32_t blob_size,
+                          gpt2_gguf_index_t* out);
+int gpt2_gguf_index_find(const gpt2_gguf_index_t* index, const char* name,
+                         gpt2_gguf_tensor_t* out);
+/* Maps the stable GPT-2 GGUF names to semantic model roles. */
+int gpt2_gguf_map_role(const gpt2_gguf_index_t* index, gpt2_gguf_role_t role,
+                       gpt2_gguf_tensor_t* out);
 
 #endif

--- a/tests/unit/kernel/test_gpt2_gguf.c
+++ b/tests/unit/kernel/test_gpt2_gguf.c
@@ -4,7 +4,7 @@
 #include "../../../kernel/llm/gpt2_gguf.h"
 #include "../../../kernel/llm/gpt2_quant.h"
 
-#define BUF_SIZE 512U
+#define BUF_SIZE 4096U
 
 static uint8_t blob[BUF_SIZE];
 static uint32_t cursor;
@@ -88,6 +88,28 @@ static uint32_t make_small_tensor(uint32_t type, uint64_t data_offset) {
     return cursor;
 }
 
+static uint32_t make_role_tensors(void) {
+    static const char* const names[] = {
+        "token_embd.weight", "position_embd.weight", "output_norm.weight",
+        "output_norm.bias", "output.weight"
+    };
+    uint32_t i;
+    uint32_t padded;
+    reset_blob();
+    put_u32(GPT2_GGUF_MAGIC);
+    put_u32(GPT2_GGUF_VERSION);
+    put_u64(5U);
+    put_u64(2U);
+    put_metadata_string("general.architecture", "gpt2");
+    put_metadata_u32("general.alignment", 32U);
+    for (i = 0U; i < 5U; i++) {
+        put_tensor(names[i], 1U, GPT2_QK_K, 0U, GPT2_GGUF_TENSOR_Q4_K, (uint64_t)(i * 160U));
+    }
+    padded = 1280U;
+    while (cursor < padded) blob[cursor++] = 0U;
+    return cursor;
+}
+
 static void test_accepts_gpt2_q8_0_envelope(void) {
     gpt2_gguf_info_t info;
     uint32_t size = make_valid_gpt2(GPT2_GGUF_TENSOR_Q8_0, 0U);
@@ -132,6 +154,23 @@ static void test_finds_bounded_q4_tensor(void) {
     TEST_ASSERT_EQUAL(-7, gpt2_gguf_find_tensor(blob, size, "blk.0.weight", &tensor));
 }
 
+static void test_builds_index_and_maps_gpt2_roles(void) {
+    gpt2_gguf_index_t index;
+    gpt2_gguf_tensor_t tensor;
+    uint32_t size = make_role_tensors();
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_build_index(blob, size, &index));
+    TEST_ASSERT_EQUAL(5, index.tensor_count);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_index_find(&index, "output.weight", &tensor));
+    TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
+    TEST_ASSERT_EQUAL(4 * 160, (int)tensor.data_offset);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_TOKEN_EMBEDDING, &tensor));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_POSITION_EMBEDDING, &tensor));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_OUTPUT_NORM_WEIGHT, &tensor));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_OUTPUT_NORM_BIAS, &tensor));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));
+    TEST_ASSERT_EQUAL(-1, gpt2_gguf_map_role(&index, (gpt2_gguf_role_t)99, &tensor));
+}
+
 static void test_rejects_non_gpt2_architecture(void) {
     gpt2_gguf_info_t info;
     uint32_t size;
@@ -164,6 +203,7 @@ int main(void) {
     RUN_TEST(test_accepts_gpt2_q8_0_envelope);
     RUN_TEST(test_reports_supported_k_quantized_tensors);
     RUN_TEST(test_finds_bounded_q4_tensor);
+    RUN_TEST(test_builds_index_and_maps_gpt2_roles);
     RUN_TEST(test_rejects_non_gpt2_architecture);
     RUN_TEST(test_rejects_unaligned_tensor_offset);
     RUN_TEST(test_rejects_bad_magic_and_truncation);


### PR DESCRIPTION
## Résumé

- ajoute un index GGUF caller-owned borné à 512 tenseurs;
- évite les rescans pour les recherches répétées;
- mappe les cinq tenseurs structurants GPT-2 vers des rôles stables;
- documente le lot en français et actualise l’état réel.

## Validation

- `make all` ✅
- `make test-all` ✅ 262 tests, 0 échec
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot conserve les contrôles de bornes, d’alignement, de dimensions et de tailles de blocs; il ne prétend pas encore exécuter un forward GPT-2 GGUF complet.