### PR TITLE
Lot 70: loader GGUF borné depuis FAT16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 # Liste des fichiers objets - MISE À JOUR avec tous les nouveaux fichiers
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
-          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
+          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
           build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
@@ -177,8 +177,12 @@ build/gpt2_model.o: kernel/llm/gpt2_model.c kernel/llm/gpt2_model.h fs/initrd.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-# Sonde GGUF v3 et kernels quantifiés bornés ; le chargeur runtime complet reste séparé.
+# Sonde GGUF v3 et index borné ; le loader lit un fichier FAT16 dans un buffer caller-owned.
 build/gpt2_gguf.o: kernel/llm/gpt2_gguf.c kernel/llm/gpt2_gguf.h kernel/llm/gpt2_quant.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/gpt2_gguf_loader.o: kernel/llm/gpt2_gguf_loader.c kernel/llm/gpt2_gguf_loader.h kernel/llm/gpt2_gguf.h kernel/fs/fat16.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -26,9 +26,11 @@ AI-OS démarre sans OS préinstallé dans QEMU, charge une archive initrd TAR, l
 
 Le runtime possède des produits scalaires freestanding pour les super-blocs GGML **Q3_K**, **Q4_K** et **Q6_K**, en plus de Q8_0. Les blocs sont contrôlés sur 256 valeurs et leurs tailles binaires sont explicites : 110, 144 et 210 octets. Le parseur GGUF classe séparément les tenseurs Q3_K, Q4_K et Q6_K au lieu de les signaler comme types quantifiés inconnus. `gpt2_gguf_find_tensor` vérifie la forme, le type, la taille de bloc et la plage avant utilisation.
 
-Le lot 69 ajoute `gpt2_gguf_build_index`, une table caller-owned bornée à 512 tenseurs, puis `gpt2_gguf_index_find` pour les recherches répétées sans rescanner les métadonnées. `gpt2_gguf_map_role` associe les cinq tenseurs structurants GPT-2 (`token_embd`, `position_embd`, `output_norm` et `output`) à des rôles stables pour le futur forward quantifié. La suite `make test-all` atteint désormais **262 tests réussis**, dont la nouvelle fixture d’index et de mapping.
+Le lot 69 ajoute `gpt2_gguf_build_index`, une table caller-owned bornée à 512 tenseurs, puis `gpt2_gguf_index_find` pour les recherches répétées sans rescanner les métadonnées. `gpt2_gguf_map_role` associe les cinq tenseurs structurants GPT-2 (`token_embd`, `position_embd`, `output_norm` et `output`) à des rôles stables pour le futur forward quantifié. La suite `make test-all` atteint désormais **263 tests réussis**, dont les fixtures d’index, de mapping et de chargement FAT16.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un fichier GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et le chargement depuis FAT16 ainsi que le mapping des blocs d’attention restent à faire. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 70 ajoute `gpt2_gguf_load_fat16`, qui lit un profil GGUF dans un buffer caller-owned depuis le volume FAT16, puis construit l’index et vérifie le rôle `output.weight`. La fixture de bout en bout utilise le nom FAT16 8.3 `gpt2.ggu`, charge 320 octets et traverse le montage, la chaîne de clusters, le parseur et le mapping sans allocation dynamique.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et les tenseurs ne sont pas encore lus à la demande par plages depuis FAT16. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_70_gguf_fat16_loader.md
+++ b/docs/mohhos_foundation_increment_70_gguf_fat16_loader.md
@@ -1,0 +1,30 @@
+# MOHHOS Foundation — Incrément 70 : loader GGUF depuis FAT16
+
+**État :** implémenté sur la branche de travail du lot 70.
+
+## Objectif
+
+Cet incrément relie le volume FAT16 lecture seule au parseur GGUF déjà validé. `gpt2_gguf_load_fat16` lit un fichier dans un buffer fourni par l’appelant, vérifie le retour du backend FAT16, puis construit immédiatement l’index GGUF et le mapping des rôles GPT-2. Le chemin ne fait aucune allocation dynamique, ne conserve aucun pointeur vers un buffer temporaire et ne modifie pas le contenu du volume.
+
+La capacité du buffer est contrôlée avant lecture. Un fichier absent, un nom invalide, un volume non monté, une capacité insuffisante ou un fichier GGUF structurellement incorrect renvoie une erreur explicite au lieu de lancer une interprétation partielle. Les erreurs FAT16 restent distinctes des erreurs de validation GGUF, ce qui permet au shell ou au futur runtime de produire un diagnostic utile.
+
+## Convention de stockage
+
+Le backend FAT16 actuel traite les noms courts 8.3. Le nom logique `gpt2.gguf` ne peut donc pas être utilisé tel quel dans cette première tranche, car son extension contient quatre caractères. Le profil disque de test est nommé `GPT2.GGU`; cette contrainte devra être levée dans un lot ultérieur avec une résolution de chemins ou des noms longs dédiés.
+
+| Étape | Contrat |
+| --- | --- |
+| Montage | `fat16_mount` valide le BPB et les limites du volume |
+| Lecture | `fat16_read_file` copie dans un buffer fourni, sans allocation |
+| Parse | `gpt2_gguf_build_index` vérifie GGUF v3, GPT-2, alignement et tailles |
+| Sélection | `gpt2_gguf_map_role` retrouve les rôles structurants |
+
+## Validation
+
+La fixture Unity construit un petit fichier GGUF Q4_K dans un cluster FAT16 séparé, le lit sous le nom `gpt2.ggu`, vérifie les 320 octets chargés et retrouve le rôle `output.weight`. Le test couvre ainsi le montage, la résolution 8.3, la chaîne FAT, la copie bornée, l’index GGUF et le mapping GPT-2 dans une seule exécution i386.
+
+La suite `make test-all` est verte avec **263 tests réussis, 0 échec et 0 test ignoré**. Le test de chargement rejoint les suites FAT16, GGUF, quantification, robustesse et les autres modules sans régression; aucun forward GPT-2 quantifié complet n’est annoncé par ce lot.
+
+## Limites et suite
+
+Le loader ne charge pas encore les centaines de mégaoctets d’un checkpoint GPT-2 réel dans une représentation paginée et ne lit pas les tenseurs à la demande depuis FAT16. Il fournit la première jonction sûre entre stockage persistant et métadonnées de modèle. La suite cohérente consiste à ajouter une lecture par plages ou par secteurs, puis à connecter progressivement les tenseurs de configuration, d’embedding et de blocs au runtime quantifié sans dépasser les bornes mémoire du noyau i386.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -1,0 +1,17 @@
+#include "gpt2_gguf_loader.h"
+
+int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,
+                         uint8_t* buffer, uint32_t capacity,
+                         gpt2_gguf_loaded_model_t* out) {
+    int bytes;
+    int status;
+    if (!volume || !filename || !buffer || capacity == 0U || !out) return -1;
+    if (!fat16_is_mounted(volume)) return OS_FAT16_NOT_MOUNTED;
+    bytes = fat16_read_file(volume, filename, (char*)buffer, capacity);
+    if (bytes < 0) return bytes;
+    if (bytes == 0) return -2;
+    status = gpt2_gguf_build_index(buffer, (uint32_t)bytes, &out->index);
+    if (status != 0) return -100 + status;
+    out->bytes_loaded = (uint32_t)bytes;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -1,0 +1,17 @@
+#ifndef AIOS_GPT2_GGUF_LOADER_H
+#define AIOS_GPT2_GGUF_LOADER_H
+
+#include "gpt2_gguf.h"
+#include "../fs/fat16.h"
+
+typedef struct {
+    gpt2_gguf_index_t index;
+    uint32_t bytes_loaded;
+} gpt2_gguf_loaded_model_t;
+
+/* Lit un fichier FAT16 8.3 dans le buffer fourni puis indexe son GGUF. */
+int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,
+                         uint8_t* buffer, uint32_t capacity,
+                         gpt2_gguf_loaded_model_t* out);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -97,9 +97,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_gguf: $(UNIT_DIR)/kernel/test_gpt2_ggu
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_fat16: $(UNIT_DIR)/kernel/test_fat16.c ../kernel/fs/fat16.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_fat16: $(UNIT_DIR)/kernel/test_fat16.c ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_quant: $(UNIT_DIR)/kernel/test_gpt2_quant.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)

--- a/tests/scripts/ci_qemu_exec.py
+++ b/tests/scripts/ci_qemu_exec.py
@@ -16,7 +16,8 @@ LOG = os.environ.get("EXEC_LOG", os.path.join(LOG_DIR, "ci-qemu-exec-serial.log"
 QEMU_ERR = os.environ.get("EXEC_ERR", os.path.join(LOG_DIR, "ci-qemu-exec-stderr.log"))
 MON_SOCK = os.environ.get("EXEC_MON_SOCK", os.path.join(LOG_DIR, "qemu-exec-monitor.sock"))
 BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "40"))
-CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "20"))
+CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "30"))
+KEY_DELAY = float(os.environ.get("KEY_DELAY", "0.25"))
 
 
 def say(message):
@@ -86,7 +87,7 @@ def send_command(client, command):
     for char in command:
         client.sendall(("sendkey %s\n" % aliases.get(char, char.lower())).encode("ascii"))
         drain_monitor(client)
-        time.sleep(0.20)
+        time.sleep(KEY_DELAY)
     client.sendall(b"sendkey ret\n")
     drain_monitor(client)
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -112,7 +112,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_quant.c"
     fi
     if [ "$(basename "$test_file")" = "test_fat16.c" ]; then
-        extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c"
+        extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c"
     fi
     if [ "$(basename "$test_file")" = "test_ipc.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/ipc.c"

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -1,5 +1,7 @@
 #include "../../framework/unity.h"
 #include "../../../kernel/fs/fat16.h"
+#include "../../../kernel/llm/gpt2_gguf_loader.h"
+#include "../../../kernel/llm/gpt2_quant.h"
 
 #define TEST_SECTORS 4224U
 static uint8_t disk[TEST_SECTORS * 512U];
@@ -55,6 +57,58 @@ static void make_volume(void) {
     disk[data + 0U] = 'h'; disk[data + 1U] = 'e'; disk[data + 2U] = 'l'; disk[data + 3U] = 'l'; disk[data + 4U] = 'o';
 }
 
+static void put64_at(uint32_t off, uint64_t value) {
+    put32(off, (uint32_t)value);
+    put32(off + 4U, (uint32_t)(value >> 32));
+}
+
+static void put_text_at(uint32_t* cursor, const char* text) {
+    uint32_t i = 0U;
+    while (text[i]) i++;
+    put64_at(*cursor, i);
+    *cursor += 8U;
+    while (*text) disk[(*cursor)++] = (uint8_t)*text++;
+}
+
+static void make_gguf_file(void) {
+    uint32_t root = (1U + 2U * 17U) * 512U;
+    uint32_t data = (root / 512U + 2U) * 512U;
+    uint32_t fat;
+    uint32_t p = data + 512U;
+    uint32_t end;
+    make_volume();
+    for (fat = 1U; fat <= 2U; fat++) put16(fat * 17U * 512U + 6U, 0xFFFFU);
+    disk[root + 32U] = 'G'; disk[root + 33U] = 'P'; disk[root + 34U] = 'T'; disk[root + 35U] = '2';
+    disk[root + 36U] = ' '; disk[root + 37U] = ' '; disk[root + 38U] = ' '; disk[root + 39U] = ' ';
+    disk[root + 40U] = 'G'; disk[root + 41U] = 'G'; disk[root + 42U] = 'U'; disk[root + 43U] = 0x20U;
+    put16(root + 32U + 26U, 3U);
+    put32(root + 32U + 28U, 320U);
+    put32(p, GPT2_GGUF_MAGIC); p += 4U;
+    put32(p, GPT2_GGUF_VERSION); p += 4U;
+    put64_at(p, 1U); p += 8U;
+    put64_at(p, 2U); p += 8U;
+    put_text_at(&p, "general.architecture"); put32(p, GPT2_GGUF_VALUE_STRING); p += 4U; put_text_at(&p, "gpt2");
+    put_text_at(&p, "general.alignment"); put32(p, GPT2_GGUF_VALUE_UINT32); p += 4U; put32(p, 32U); p += 4U;
+    put_text_at(&p, "output.weight"); put32(p, 1U); p += 4U; put64_at(p, GPT2_QK_K); p += 8U;
+    put32(p, GPT2_GGUF_TENSOR_Q4_K); p += 4U; put64_at(p, 0U); p += 8U;
+    end = data + 512U + 320U;
+    while (p < end) disk[p++] = 0U;
+}
+
+static void test_loads_gpt2_from_fat16(void) {
+    fat16_volume_t volume;
+    gpt2_gguf_loaded_model_t model;
+    gpt2_gguf_tensor_t tensor;
+    uint8_t buffer[512];
+    make_gguf_file();
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_load_fat16(&volume, "gpt2.ggu", buffer, sizeof(buffer), &model));
+    TEST_ASSERT_EQUAL(320, (int)model.bytes_loaded);
+    TEST_ASSERT_EQUAL(1, model.index.tensor_count);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&model.index, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));
+    TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
+}
+
 static void test_mount_list_and_read(void) {
     fat16_volume_t volume;
     os_fat16_dirent_t entries[4];
@@ -89,6 +143,7 @@ static void test_rejects_bad_name_and_small_buffer(void) {
 int main(void) {
     unity_init();
     RUN_TEST(test_mount_list_and_read);
+    RUN_TEST(test_loads_gpt2_from_fat16);
     RUN_TEST(test_rejects_bad_bpb);
     RUN_TEST(test_rejects_bad_name_and_small_buffer);
     unity_print_results();


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_load_fat16` avec buffer caller-owned et propagation d’erreurs;
- lie le loader au noyau i386;
- couvre le chemin FAT16 8.3 `gpt2.ggu` vers index GGUF et rôle GPT-2;
- corrige le runner global pour compiler réellement le test FAT16 enrichi;
- documente le lot en français.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **263 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot reste préparatoire: il ne lance pas encore le forward GPT-2 GGUF complet et n’alloue pas de mémoire pour un gros checkpoint.