### PR TITLE
Lot 71: lecture par plages FAT16

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -30,7 +30,9 @@ Le lot 69 ajoute `gpt2_gguf_build_index`, une table caller-owned bornée à 512 
 
 Le lot 70 ajoute `gpt2_gguf_load_fat16`, qui lit un profil GGUF dans un buffer caller-owned depuis le volume FAT16, puis construit l’index et vérifie le rôle `output.weight`. La fixture de bout en bout utilise le nom FAT16 8.3 `gpt2.ggu`, charge 320 octets et traverse le montage, la chaîne de clusters, le parseur et le mapping sans allocation dynamique.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et les tenseurs ne sont pas encore lus à la demande par plages depuis FAT16. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 71 ajoute `fat16_read_file_range`, qui saute jusqu’au cluster demandé et copie uniquement la fenêtre utile dans un buffer caller-owned. Le test lit `ell` au milieu de `FATOK.TXT` et rejette un offset hors taille; `make test-all` atteint désormais **264 tests réussis**, sans échec ni test ignoré. Cette primitive prépare la lecture paginée des tenseurs GGUF, mais le forward GPT-2 réel n’est toujours pas annoncé.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et les descripteurs GGUF ne sont pas encore servis par un curseur persistant ou une lecture de tenseur directe. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_71_fat16_range_reader.md
+++ b/docs/mohhos_foundation_increment_71_fat16_range_reader.md
@@ -1,0 +1,29 @@
+# MOHHOS Foundation — Incrément 71 : lecture par plages FAT16
+
+**État :** implémenté sur la branche de travail du lot 71.
+
+## Objectif
+
+Cet incrément ajoute `fat16_read_file_range`, une primitive de lecture partielle adaptée aux profils GGUF qui ne doivent pas être copiés intégralement en mémoire noyau. L’appelant fournit un offset, un buffer et une capacité; le backend parcourt la chaîne FAT16 jusqu’au cluster concerné, lit uniquement les secteurs nécessaires et retourne le nombre exact d’octets copiés.
+
+La primitive reste compatible avec le volume lecture seule et le format 8.3 existant. Elle ne modifie ni la FAT ni le répertoire racine, ne crée aucune allocation et conserve les contrôles de borne sur les clusters, les secteurs, les offsets et les tailles. Un offset strictement supérieur à la taille du fichier est refusé; une lecture en fin de fichier peut retourner zéro octet sans dépasser le volume.
+
+## Contrat pour GGUF
+
+Le loader complet du lot 70 continue d’être utile pour les petits profils de validation. La lecture par plages prépare désormais un chargeur GGUF paginé: l’en-tête et les descripteurs pourront être lus dans une petite fenêtre, puis les données d’un tenseur pourront être demandées à la position exacte sans charger le checkpoint entier.
+
+| Paramètre | Garantie |
+| --- | --- |
+| `offset` | doit être inférieur ou égal à la taille du fichier |
+| `buffer` / `max` | mémoire fournie par l’appelant et taille strictement contrôlée |
+| chaîne FAT | saut de clusters borné par `cluster_count` |
+| retour | `out_read` contient le nombre réellement copié |
+| erreurs | volume, chemin, corruption et capacité restent distingués |
+
+## Validation
+
+Le test FAT16 lit `hello` à partir du deuxième octet de `FATOK.TXT`, vérifie la copie de `ell` et rejette un offset situé au-delà de la taille. La suite globale `make test-all` atteint **264 tests réussis, 0 échec et 0 test ignoré**. Les tests GGUF, le loader FAT16→GGUF du lot 70, la robustesse et les modules historiques restent verts.
+
+## Limites et suite
+
+La lecture par plages ne fournit pas encore un descripteur de fichier persistant ni une lecture sectorielle asynchrone. Chaque appel retrouve l’entrée racine et reparcourt la chaîne depuis le début; cette simplicité est volontaire pour le premier contrat sûr. Le prochain groupe pourra ajouter un curseur de fichier ou une API de lecture de tenseur directement adossée à l’index GGUF, tout en conservant les limites i386 et l’absence d’allocation non contrôlée.

--- a/kernel/fs/fat16.c
+++ b/kernel/fs/fat16.c
@@ -230,3 +230,64 @@ int fat16_read_file(const fat16_volume_t* v, const char* name, char* buffer, uin
 const char* fat16_status(void) {
     return status_text;
 }
+
+
+int fat16_read_file_range(const fat16_volume_t* v, const char* name,
+                          uint32_t offset, uint8_t* buffer, uint32_t max,
+                          uint32_t* out_read) {
+    uint8_t short_name[11];
+    uint8_t entry[FAT16_ENTRY_SIZE];
+    uint32_t i;
+    uint32_t size;
+    uint32_t cluster_bytes;
+    uint32_t skip_clusters;
+    uint32_t intra;
+    uint32_t copied = 0U;
+    uint16_t cluster;
+    uint32_t guard = 0U;
+    if (out_read) *out_read = 0U;
+    if (!fat16_is_mounted(v)) return OS_FAT16_NOT_MOUNTED;
+    if (!buffer || max == 0U || !out_read) return OS_FAT16_BUFFER_SMALL;
+    if (make_short_name(name, short_name) != 0) return OS_FAT16_BAD_PATH;
+    for (i = 0U; i < v->root_entries; i++) {
+        if (read_root_entry(v, i, entry) != 0) return OS_FAT16_CORRUPT;
+        if (entry[0] == 0x00U) break;
+        if (entry[0] == 0xE5U || entry[11] == 0x0FU || (entry[11] & 0x08U)) continue;
+        if (!entry_matches(entry, short_name)) continue;
+        if (entry[11] & 0x10U) return OS_FAT16_BAD_PATH;
+        size = le32(entry + 28U);
+        if (offset > size) return OS_FAT16_BAD_PATH;
+        cluster = le16(entry + 26U);
+        cluster_bytes = (uint32_t)v->sectors_per_cluster * FAT16_SECTOR_SIZE;
+        if (cluster_bytes == 0U) return OS_FAT16_CORRUPT;
+        skip_clusters = offset / cluster_bytes;
+        intra = offset % cluster_bytes;
+        while (skip_clusters-- > 0U) {
+            if (cluster < 2U || cluster >= FAT16_EOC_MIN ||
+                cluster - 2U >= v->cluster_count || guard++ > v->cluster_count ||
+                read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
+        }
+        while (copied < max && offset + copied < size) {
+            uint32_t sector_in_cluster = intra / FAT16_SECTOR_SIZE;
+            uint32_t sector_offset = intra % FAT16_SECTOR_SIZE;
+            uint32_t lba;
+            uint32_t take = FAT16_SECTOR_SIZE - sector_offset;
+            if (cluster < 2U || cluster >= FAT16_EOC_MIN ||
+                cluster - 2U >= v->cluster_count || guard++ > v->cluster_count) return OS_FAT16_CORRUPT;
+            lba = v->data_lba + (uint32_t)(cluster - 2U) * v->sectors_per_cluster + sector_in_cluster;
+            if (read_at(v, lba, sector2) != 0) return OS_FAT16_CORRUPT;
+            if (take > max - copied) take = max - copied;
+            if (take > size - offset - copied) take = size - offset - copied;
+            for (i = 0U; i < take; i++) buffer[copied + i] = sector2[sector_offset + i];
+            copied += take;
+            intra += take;
+            if (intra >= cluster_bytes && copied < max && offset + copied < size) {
+                if (read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
+                intra = 0U;
+            }
+        }
+        *out_read = copied;
+        return 0;
+    }
+    return OS_FAT16_NOT_FOUND;
+}

--- a/kernel/fs/fat16.h
+++ b/kernel/fs/fat16.h
@@ -31,6 +31,10 @@ int fat16_list_root(const fat16_volume_t* volume, os_fat16_dirent_t* out,
                     uint32_t capacity);
 int fat16_read_file(const fat16_volume_t* volume, const char* name,
                     char* buffer, uint32_t max);
+/* Lit au plus max octets à partir d’un offset sans charger tout le fichier. */
+int fat16_read_file_range(const fat16_volume_t* volume, const char* name,
+                          uint32_t offset, uint8_t* buffer, uint32_t max,
+                          uint32_t* out_read);
 const char* fat16_status(void);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -123,6 +123,21 @@ static void test_mount_list_and_read(void) {
     TEST_ASSERT_EQUAL_STRING("hello", content);
 }
 
+static void test_reads_bounded_file_range(void) {
+    fat16_volume_t volume;
+    uint8_t content[4] = {0U, 0U, 0U, 0U};
+    uint32_t read = 0U;
+    make_volume();
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, fat16_read_file_range(&volume, "fatok.txt", 1U, content, 3U, &read));
+    TEST_ASSERT_EQUAL(3, (int)read);
+    TEST_ASSERT_EQUAL('e', content[0]);
+    TEST_ASSERT_EQUAL('l', content[1]);
+    TEST_ASSERT_EQUAL('l', content[2]);
+    TEST_ASSERT_EQUAL(OS_FAT16_BAD_PATH, fat16_read_file_range(&volume, "fatok.txt", 6U, content, 1U, &read));
+    TEST_ASSERT_EQUAL(0, (int)read);
+}
+
 static void test_rejects_bad_bpb(void) {
     fat16_volume_t volume;
     make_volume();
@@ -144,6 +159,7 @@ int main(void) {
     unity_init();
     RUN_TEST(test_mount_list_and_read);
     RUN_TEST(test_loads_gpt2_from_fat16);
+    RUN_TEST(test_reads_bounded_file_range);
     RUN_TEST(test_rejects_bad_bpb);
     RUN_TEST(test_rejects_bad_name_and_small_buffer);
     unity_print_results();


### PR DESCRIPTION
## Résumé

- ajoute `fat16_read_file_range` pour lire une fenêtre sans charger tout le fichier;
- borne le saut de clusters et les copies secteur par secteur;
- teste la lecture partielle et les offsets hors taille;
- documente la préparation de la lecture paginée GGUF.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **264 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot ne prétend pas encore exécuter le forward GPT-2 GGUF complet.