### PR TITLE
Lot 72: curseur FAT16 réutilisable

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -32,7 +32,9 @@ Le lot 70 ajoute `gpt2_gguf_load_fat16`, qui lit un profil GGUF dans un buffer c
 
 Le lot 71 ajoute `fat16_read_file_range`, qui saute jusqu’au cluster demandé et copie uniquement la fenêtre utile dans un buffer caller-owned. Le test lit `ell` au milieu de `FATOK.TXT` et rejette un offset hors taille; `make test-all` atteint désormais **264 tests réussis**, sans échec ni test ignoré. Cette primitive prépare la lecture paginée des tenseurs GGUF, mais le forward GPT-2 réel n’est toujours pas annoncé.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et les descripteurs GGUF ne sont pas encore servis par un curseur persistant ou une lecture de tenseur directe. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 72 ajoute `fat16_open_file` et `fat16_file_read`, un curseur caller-owned qui conserve cluster, position et garde FAT entre lectures successives. Le test lit `hel`, puis `lo`, puis la fin de `FATOK.TXT`; `make test-all` atteint désormais **265 tests réussis**, sans échec ni test ignoré. Le curseur prépare la lecture progressive des fenêtres GGUF, mais ne fournit pas encore de seek ou de forward GPT-2 complet.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et les descripteurs GGUF ne sont pas encore reliés à un lecteur de tenseur vérifié. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_72_fat16_cursor.md
+++ b/docs/mohhos_foundation_increment_72_fat16_cursor.md
@@ -1,0 +1,29 @@
+# MOHHOS Foundation — Incrément 72 : curseur FAT16 réutilisable
+
+**État :** implémenté sur la branche de travail du lot 72.
+
+## Objectif
+
+Cet incrément ajoute `fat16_open_file` et `fat16_file_read`. Le premier résout une entrée 8.3 et initialise un état caller-owned; le second lit séquentiellement des fenêtres successives en conservant le cluster courant, la position dans le fichier et la garde de parcours FAT16. Une suite de petites lectures ne rescane donc plus le répertoire ni la chaîne depuis le début.
+
+Le curseur ne possède aucune mémoire dynamique et reste invalide après une ouverture échouée. Les contrôles vérifient le montage, le type fichier, la position, la taille des secteurs, le nombre de clusters et les marqueurs de fin FAT16 avant chaque accès. Lorsque la fin du fichier est atteinte, la lecture retourne zéro octet avec un statut de succès; un appel avec buffer nul ou capacité nulle est refusé.
+
+## Usage GGUF
+
+Le curseur constitue la base d’une lecture progressive des métadonnées et des données de tenseurs GGUF depuis FAT16. Le loader complet du lot 70 reste adapté aux petits profils, tandis que le futur runtime pourra conserver un curseur par fichier et demander les fenêtres correspondant aux offsets des tenseurs indexés.
+
+| Élément | Garantie |
+| --- | --- |
+| état | entièrement fourni par l’appelant dans `fat16_file_t` |
+| progression | `position` et `cluster_offset` avancent après chaque lecture |
+| FAT | lecture du prochain cluster uniquement à la frontière nécessaire |
+| mémoire | aucune allocation ni copie du fichier complet |
+| fin | `out_read == 0` quand la position atteint la taille |
+
+## Validation
+
+Le test ouvre `FATOK.TXT`, lit successivement `hel`, puis `lo`, puis vérifie la fin de fichier. Les tests précédents de lecture par plage, de loader GGUF depuis FAT16, de bornes et de corruption restent actifs. La suite `make test-all` atteint **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Limites et suite
+
+Le curseur est séquentiel et ne propose pas encore de seek; un accès aléatoire continue d’utiliser `fat16_read_file_range`. La prochaine étape pourra associer un curseur à un descripteur de tenseur GGUF et exposer une lecture vérifiée par type, offset et taille de bloc quantifié, avant tout branchement au forward GPT-2.

--- a/kernel/fs/fat16.c
+++ b/kernel/fs/fat16.c
@@ -291,3 +291,63 @@ int fat16_read_file_range(const fat16_volume_t* v, const char* name,
     }
     return OS_FAT16_NOT_FOUND;
 }
+
+
+int fat16_open_file(const fat16_volume_t* v, const char* name, fat16_file_t* out) {
+    uint8_t short_name[11];
+    uint8_t entry[FAT16_ENTRY_SIZE];
+    uint32_t i;
+    if (!fat16_is_mounted(v) || !out) return OS_FAT16_NOT_MOUNTED;
+    if (make_short_name(name, short_name) != 0) return OS_FAT16_BAD_PATH;
+    out->open = 0U;
+    for (i = 0U; i < v->root_entries; i++) {
+        if (read_root_entry(v, i, entry) != 0) return OS_FAT16_CORRUPT;
+        if (entry[0] == 0x00U) break;
+        if (entry[0] == 0xE5U || entry[11] == 0x0FU || (entry[11] & 0x08U)) continue;
+        if (!entry_matches(entry, short_name)) continue;
+        if (entry[11] & 0x10U) return OS_FAT16_BAD_PATH;
+        out->volume = v;
+        out->cluster = le16(entry + 26U);
+        out->size = le32(entry + 28U);
+        out->position = 0U;
+        out->cluster_offset = 0U;
+        out->guard = 0U;
+        out->open = 1U;
+        return 0;
+    }
+    return OS_FAT16_NOT_FOUND;
+}
+
+int fat16_file_read(fat16_file_t* file, uint8_t* buffer, uint32_t max,
+                    uint32_t* out_read) {
+    const fat16_volume_t* v;
+    uint32_t cluster_bytes;
+    uint32_t copied = 0U;
+    if (out_read) *out_read = 0U;
+    if (!file || !file->open || !file->volume || !buffer || max == 0U || !out_read) return OS_FAT16_BUFFER_SMALL;
+    v = file->volume;
+    cluster_bytes = (uint32_t)v->sectors_per_cluster * FAT16_SECTOR_SIZE;
+    if (cluster_bytes == 0U || file->position > file->size) return OS_FAT16_CORRUPT;
+    while (copied < max && file->position < file->size) {
+        uint32_t sector_in_cluster = file->cluster_offset / FAT16_SECTOR_SIZE;
+        uint32_t sector_offset = file->cluster_offset % FAT16_SECTOR_SIZE;
+        uint32_t take = FAT16_SECTOR_SIZE - sector_offset;
+        uint32_t lba;
+        if (file->cluster < 2U || file->cluster >= FAT16_EOC_MIN ||
+            file->cluster - 2U >= v->cluster_count || file->guard++ > v->cluster_count) return OS_FAT16_CORRUPT;
+        lba = v->data_lba + (uint32_t)(file->cluster - 2U) * v->sectors_per_cluster + sector_in_cluster;
+        if (read_at(v, lba, sector2) != 0) return OS_FAT16_CORRUPT;
+        if (take > max - copied) take = max - copied;
+        if (take > file->size - file->position) take = file->size - file->position;
+        for (uint32_t i = 0U; i < take; i++) buffer[copied + i] = sector2[sector_offset + i];
+        copied += take;
+        file->position += take;
+        file->cluster_offset += take;
+        if (file->cluster_offset >= cluster_bytes && file->position < file->size) {
+            if (read_fat_entry(v, file->cluster, &file->cluster) != 0) return OS_FAT16_CORRUPT;
+            file->cluster_offset = 0U;
+        }
+    }
+    *out_read = copied;
+    return 0;
+}

--- a/kernel/fs/fat16.h
+++ b/kernel/fs/fat16.h
@@ -23,6 +23,16 @@ typedef struct {
     uint8_t mounted;
 } fat16_volume_t;
 
+typedef struct {
+    const fat16_volume_t* volume;
+    uint16_t cluster;
+    uint32_t size;
+    uint32_t position;
+    uint32_t cluster_offset;
+    uint32_t guard;
+    uint8_t open;
+} fat16_file_t;
+
 fat16_volume_t* fat16_root(void);
 int fat16_mount(fat16_volume_t* volume, fat16_read_sector_fn read_sector,
                 uint32_t base_lba);
@@ -35,6 +45,10 @@ int fat16_read_file(const fat16_volume_t* volume, const char* name,
 int fat16_read_file_range(const fat16_volume_t* volume, const char* name,
                           uint32_t offset, uint8_t* buffer, uint32_t max,
                           uint32_t* out_read);
+int fat16_open_file(const fat16_volume_t* volume, const char* name,
+                    fat16_file_t* out);
+int fat16_file_read(fat16_file_t* file, uint8_t* buffer, uint32_t max,
+                    uint32_t* out_read);
 const char* fat16_status(void);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -138,6 +138,28 @@ static void test_reads_bounded_file_range(void) {
     TEST_ASSERT_EQUAL(0, (int)read);
 }
 
+static void test_cursor_reads_successive_windows(void) {
+    fat16_volume_t volume;
+    fat16_file_t file;
+    uint8_t first[3] = {0U, 0U, 0U};
+    uint8_t second[3] = {0U, 0U, 0U};
+    uint32_t read = 0U;
+    make_volume();
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, fat16_open_file(&volume, "fatok.txt", &file));
+    TEST_ASSERT_EQUAL(0, fat16_file_read(&file, first, sizeof(first), &read));
+    TEST_ASSERT_EQUAL(3, (int)read);
+    TEST_ASSERT_EQUAL('h', first[0]);
+    TEST_ASSERT_EQUAL('e', first[1]);
+    TEST_ASSERT_EQUAL('l', first[2]);
+    TEST_ASSERT_EQUAL(0, fat16_file_read(&file, second, sizeof(second), &read));
+    TEST_ASSERT_EQUAL(2, (int)read);
+    TEST_ASSERT_EQUAL('l', second[0]);
+    TEST_ASSERT_EQUAL('o', second[1]);
+    TEST_ASSERT_EQUAL(0, fat16_file_read(&file, second, sizeof(second), &read));
+    TEST_ASSERT_EQUAL(0, (int)read);
+}
+
 static void test_rejects_bad_bpb(void) {
     fat16_volume_t volume;
     make_volume();
@@ -160,6 +182,7 @@ int main(void) {
     RUN_TEST(test_mount_list_and_read);
     RUN_TEST(test_loads_gpt2_from_fat16);
     RUN_TEST(test_reads_bounded_file_range);
+    RUN_TEST(test_cursor_reads_successive_windows);
     RUN_TEST(test_rejects_bad_bpb);
     RUN_TEST(test_rejects_bad_name_and_small_buffer);
     unity_print_results();


### PR DESCRIPTION
## Résumé

- ajoute `fat16_open_file` et `fat16_file_read`;
- conserve cluster, position et garde FAT entre lectures;
- couvre les lectures successives et la fin de fichier;
- documente l’usage préparatoire pour les fenêtres GGUF.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot ne fournit pas encore de seek ni de forward GPT-2 GGUF complet.