### PR TITLE
Lot 73: lecture de tenseur GGUF depuis FAT16

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -34,7 +34,9 @@ Le lot 71 ajoute `fat16_read_file_range`, qui saute jusqu’au cluster demandé 
 
 Le lot 72 ajoute `fat16_open_file` et `fat16_file_read`, un curseur caller-owned qui conserve cluster, position et garde FAT entre lectures successives. Le test lit `hel`, puis `lo`, puis la fin de `FATOK.TXT`; `make test-all` atteint désormais **265 tests réussis**, sans échec ni test ignoré. Le curseur prépare la lecture progressive des fenêtres GGUF, mais ne fournit pas encore de seek ou de forward GPT-2 complet.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et les descripteurs GGUF ne sont pas encore reliés à un lecteur de tenseur vérifié. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 73 ajoute `gpt2_gguf_read_tensor_fat16`, qui calcule l’offset absolu d’un tenseur indexé, contrôle les additions 32-bit et lit une fenêtre plafonnée via FAT16. La fixture Q4_K vérifie la lecture de quatre octets depuis `GPT2.GGU`; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et les octets lus ne sont pas encore remis aux kernels dans un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_73_gguf_tensor_fat16_read.md
+++ b/docs/mohhos_foundation_increment_73_gguf_tensor_fat16_read.md
@@ -1,0 +1,27 @@
+# MOHHOS Foundation — Incrément 73 : lecture de tenseur GGUF depuis FAT16
+
+**État :** implémenté sur la branche de travail du lot 73.
+
+## Objectif
+
+Le lot 73 relie l’index GGUF et le backend FAT16 par `gpt2_gguf_read_tensor_fat16`. L’appelant fournit un modèle déjà chargé, un descripteur de tenseur, un offset relatif et un buffer. L’API calcule l’offset absolu dans la zone `tensor_data`, vérifie les additions 32-bit et délègue la lecture au chemin FAT16 borné.
+
+La capacité demandée est automatiquement plafonnée à la taille restante du tenseur. Les arguments invalides, les offsets hors descripteurs et les débordements d’offset sont refusés avant tout accès disque. La fonction ne décode pas les valeurs quantifiées et ne prétend pas encore exécuter le forward; elle fournit uniquement une fenêtre binaire sûre pour le futur kernel Q4_K/Q6_K.
+
+## Chaîne d’accès
+
+| Étape | Contrôle |
+| --- | --- |
+| index GGUF | modèle marqué valide et tenseur déjà décrit |
+| adresse | `tensor_data_offset + data_offset + tensor_offset` sans overflow |
+| capacité | limitée à `byte_size - tensor_offset` |
+| stockage | `fat16_read_file_range` et chaîne FAT bornée |
+| résultat | `out_read` donne les octets réellement copiés |
+
+## Validation
+
+La fixture disque GGUF Q4_K du lot 70 est réutilisée. Après chargement et mapping de `output.weight`, le test lit quatre octets à l’offset du tenseur depuis `GPT2.GGU` et vérifie le contenu retourné. La suite `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**, avec le build des modules GGUF, FAT16, quantification et robustesse.
+
+## Limites et suite
+
+Le descripteur doit encore être fourni par un index GGUF conservé en mémoire; l’API ne possède pas de handle persistant et ne valide pas la cohérence sémantique du rôle au-delà du descripteur fourni. Un prochain incrément pourra introduire un handle modèle compact et une lecture de blocs quantifiés directement vers les kernels, sans charger l’intégralité du checkpoint.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -15,3 +15,21 @@ int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,
     out->bytes_loaded = (uint32_t)bytes;
     return 0;
 }
+
+
+int gpt2_gguf_read_tensor_fat16(const fat16_volume_t* volume, const char* filename,
+                                const gpt2_gguf_loaded_model_t* model,
+                                const gpt2_gguf_tensor_t* tensor,
+                                uint32_t tensor_offset, uint8_t* buffer,
+                                uint32_t capacity, uint32_t* out_read) {
+    uint32_t absolute;
+    if (out_read) *out_read = 0U;
+    if (!volume || !filename || !model || !tensor || !buffer || capacity == 0U || !out_read) return -1;
+    if (!model->index.info.is_valid || tensor_offset > tensor->byte_size) return -3;
+    if (capacity > tensor->byte_size - tensor_offset) capacity = tensor->byte_size - tensor_offset;
+    if (model->index.info.tensor_data_offset > 0xFFFFFFFFU - tensor->data_offset) return -3;
+    absolute = model->index.info.tensor_data_offset + tensor->data_offset;
+    if (absolute > 0xFFFFFFFFU - tensor_offset) return -3;
+    absolute += tensor_offset;
+    return fat16_read_file_range(volume, filename, absolute, buffer, capacity, out_read);
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -13,5 +13,11 @@ typedef struct {
 int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,
                          uint8_t* buffer, uint32_t capacity,
                          gpt2_gguf_loaded_model_t* out);
+/* Lit une fenêtre relative aux données d’un tenseur déjà indexé. */
+int gpt2_gguf_read_tensor_fat16(const fat16_volume_t* volume, const char* filename,
+                                const gpt2_gguf_loaded_model_t* model,
+                                const gpt2_gguf_tensor_t* tensor,
+                                uint32_t tensor_offset, uint8_t* buffer,
+                                uint32_t capacity, uint32_t* out_read);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -107,6 +107,16 @@ static void test_loads_gpt2_from_fat16(void) {
     TEST_ASSERT_EQUAL(1, model.index.tensor_count);
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&model.index, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));
     TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
+    {
+        uint8_t tensor_bytes[4] = {0xFFU, 0xFFU, 0xFFU, 0xFFU};
+        uint32_t tensor_read = 0U;
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_read_tensor_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, tensor_bytes, sizeof(tensor_bytes), &tensor_read));
+        TEST_ASSERT_EQUAL(4, (int)tensor_read);
+        TEST_ASSERT_EQUAL(0, tensor_bytes[0]);
+        TEST_ASSERT_EQUAL(0, tensor_bytes[1]);
+        TEST_ASSERT_EQUAL(0, tensor_bytes[2]);
+        TEST_ASSERT_EQUAL(0, tensor_bytes[3]);
+    }
 }
 
 static void test_mount_list_and_read(void) {


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_read_tensor_fat16`;
- calcule l’offset absolu sans overflow 32-bit;
- plafonne la fenêtre à `tensor.byte_size`;
- valide une lecture Q4_K réelle depuis `GPT2.GGU`;
- documente les limites et la suite vers les kernels quantifiés.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot ne lance pas encore le forward GPT-2 GGUF complet.