### PR TITLE
Lot 74: lecture vérifiée des blocs GGUF quantifiés

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -36,7 +36,9 @@ Le lot 72 ajoute `fat16_open_file` et `fat16_file_read`, un curseur caller-owned
 
 Le lot 73 ajoute `gpt2_gguf_read_tensor_fat16`, qui calcule l’offset absolu d’un tenseur indexé, contrôle les additions 32-bit et lit une fenêtre plafonnée via FAT16. La fixture Q4_K vérifie la lecture de quatre octets depuis `GPT2.GGU`; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : `gpt2_model.c` et `gpt2_infer.c` utilisent encore le checkpoint FP32 `llm.c v3`, et les octets lus ne sont pas encore remis aux kernels dans un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 74 ajoute `gpt2_gguf_read_quant_block_fat16`, qui refuse les types non K-quant, calcule les tailles Q3_K/Q4_K/Q6_K et lit un super-bloc complet avec une capacité vérifiée. La fixture Q4_K valide 144 octets depuis `GPT2.GGU` et rejette une capacité insuffisante; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : les blocs lus ne sont pas encore décodés ni remis aux kernels dans un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_74_gguf_quant_block_read.md
+++ b/docs/mohhos_foundation_increment_74_gguf_quant_block_read.md
@@ -1,0 +1,23 @@
+# MOHHOS Foundation — Incrément 74 : lecture vérifiée des blocs quantifiés GGUF
+
+**État :** implémenté sur la branche de travail du lot 74.
+
+## Objectif
+
+Le lot 74 ajoute `gpt2_gguf_read_quant_block_fat16`. Cette primitive reçoit un tenseur déjà indexé, vérifie qu’il appartient aux familles Q3_K, Q4_K ou Q6_K, calcule l’offset du super-bloc demandé et lit exactement son enveloppe binaire depuis FAT16.
+
+Chaque super-bloc représente 256 valeurs et possède une taille connue par le kernel: 110 octets pour Q3_K, 144 octets pour Q4_K et 210 octets pour Q6_K. L’API refuse un type non supporté, un index au-delà de `byte_size`, une capacité insuffisante ou un dépassement arithmétique avant l’accès disque. Elle ne décode pas encore les échelles et sous-blocs; le résultat est une fenêtre binaire prête à être remise au kernel quantifié.
+
+| Type | Valeurs par super-bloc | Taille contrôlée |
+| --- | ---: | ---: |
+| Q3_K | 256 | 110 octets |
+| Q4_K | 256 | 144 octets |
+| Q6_K | 256 | 210 octets |
+
+## Validation
+
+La fixture FAT16 du lot 70 est chargée puis indexée. Le test retrouve `output.weight` en Q4_K, lit son premier super-bloc de 144 octets depuis `GPT2.GGU`, vérifie le nombre retourné et rejette une capacité d’un seul octet. La suite `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Limites et suite
+
+La primitive ne convertit pas le bloc en valeurs FP32 et ne lance pas de produit scalaire. Le prochain jalon pourra connecter cette lecture aux kernels Q4_K/Q6_K en imposant un buffer d’activation caller-owned et des contrôles de dimensions, sans modifier l’ABI syscall ni charger un checkpoint complet.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -33,3 +33,25 @@ int gpt2_gguf_read_tensor_fat16(const fat16_volume_t* volume, const char* filena
     absolute += tensor_offset;
     return fat16_read_file_range(volume, filename, absolute, buffer, capacity, out_read);
 }
+
+
+int gpt2_gguf_read_quant_block_fat16(const fat16_volume_t* volume, const char* filename,
+                                     const gpt2_gguf_loaded_model_t* model,
+                                     const gpt2_gguf_tensor_t* tensor,
+                                     uint32_t block_index, uint8_t* buffer,
+                                     uint32_t capacity, uint32_t* out_read) {
+    uint32_t block_bytes;
+    uint32_t block_offset;
+    if (out_read) *out_read = 0U;
+    if (!volume || !filename || !model || !tensor || !buffer || !out_read) return -1;
+    if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) block_bytes = GPT2_Q3_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) block_bytes = GPT2_Q4_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q6_K) block_bytes = GPT2_Q6_K_BLOCK_BYTES;
+    else return -4;
+    if (block_index > 0xFFFFFFFFU / block_bytes) return -5;
+    block_offset = block_index * block_bytes;
+    if (block_offset > tensor->byte_size || block_bytes > tensor->byte_size - block_offset) return -5;
+    if (capacity < block_bytes) return -6;
+    return gpt2_gguf_read_tensor_fat16(volume, filename, model, tensor,
+                                       block_offset, buffer, block_bytes, out_read);
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -2,6 +2,7 @@
 #define AIOS_GPT2_GGUF_LOADER_H
 
 #include "gpt2_gguf.h"
+#include "gpt2_quant.h"
 #include "../fs/fat16.h"
 
 typedef struct {
@@ -19,5 +20,11 @@ int gpt2_gguf_read_tensor_fat16(const fat16_volume_t* volume, const char* filena
                                 const gpt2_gguf_tensor_t* tensor,
                                 uint32_t tensor_offset, uint8_t* buffer,
                                 uint32_t capacity, uint32_t* out_read);
+/* Lit un super-bloc complet d’un tenseur Q3_K/Q4_K/Q6_K. */
+int gpt2_gguf_read_quant_block_fat16(const fat16_volume_t* volume, const char* filename,
+                                     const gpt2_gguf_loaded_model_t* model,
+                                     const gpt2_gguf_tensor_t* tensor,
+                                     uint32_t block_index, uint8_t* buffer,
+                                     uint32_t capacity, uint32_t* out_read);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -117,6 +117,13 @@ static void test_loads_gpt2_from_fat16(void) {
         TEST_ASSERT_EQUAL(0, tensor_bytes[2]);
         TEST_ASSERT_EQUAL(0, tensor_bytes[3]);
     }
+    {
+        uint8_t block[GPT2_Q4_K_BLOCK_BYTES];
+        uint32_t block_read = 0U;
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, block, sizeof(block), &block_read));
+        TEST_ASSERT_EQUAL(GPT2_Q4_K_BLOCK_BYTES, (int)block_read);
+        TEST_ASSERT_EQUAL(-6, gpt2_gguf_read_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, block, 1U, &block_read));
+    }
 }
 
 static void test_mount_list_and_read(void) {


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_read_quant_block_fat16`;
- valide Q3_K, Q4_K et Q6_K avec leurs tailles de super-bloc;
- refuse type non quantifié, index hors tenseur et capacité insuffisante;
- teste un bloc Q4_K de 144 octets depuis `GPT2.GGU`;
- documente les limites avant branchement aux kernels.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot ne décode pas encore les blocs et ne lance pas le forward GPT-2 complet.