### PR TITLE
Lot 75: pont GGUF vers kernels quantifiés

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -38,7 +38,9 @@ Le lot 73 ajoute `gpt2_gguf_read_tensor_fat16`, qui calcule l’offset absolu d�
 
 Le lot 74 ajoute `gpt2_gguf_read_quant_block_fat16`, qui refuse les types non K-quant, calcule les tailles Q3_K/Q4_K/Q6_K et lit un super-bloc complet avec une capacité vérifiée. La fixture Q4_K valide 144 octets depuis `GPT2.GGU` et rejette une capacité insuffisante; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : les blocs lus ne sont pas encore décodés ni remis aux kernels dans un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 75 ajoute `gpt2_gguf_dot_quant_block_fat16`, qui lit un super-bloc Q3_K/Q4_K/Q6_K dans un scratch caller-owned puis appelle le kernel quantifié avec exactement 256 activations. Le test Q4_K vérifie un produit nul sur `GPT2.GGU` et rejette une longueur invalide; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : le pont traite un super-bloc à la fois et ne réalise pas encore d’accumulation multi-blocs ni de forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_75_gguf_quant_kernel_bridge.md
+++ b/docs/mohhos_foundation_increment_75_gguf_quant_kernel_bridge.md
@@ -1,0 +1,23 @@
+# MOHHOS Foundation — Incrément 75 : pont GGUF vers kernels quantifiés
+
+**État :** implémenté sur la branche de travail du lot 75.
+
+## Objectif
+
+Le lot 75 ajoute `gpt2_gguf_dot_quant_block_fat16`. Cette API lit un super-bloc Q3_K, Q4_K ou Q6_K depuis FAT16 dans un scratch fourni par l’appelant, vérifie qu’il contient exactement 256 valeurs et appelle le kernel quantifié correspondant avec le vecteur d’activation caller-owned.
+
+Le pont ne crée aucune allocation et ne modifie pas les kernels mathématiques déjà validés. Il impose une capacité de scratch au moins égale à la taille du format, contrôle le type GGUF et refuse les appels dont la longueur n’est pas exactement `GPT2_QK_K`. Le résultat est écrit dans un `float` fourni par l’appelant.
+
+| Type | Taille scratch minimale | Kernel appelé |
+| --- | ---: | --- |
+| Q3_K | 110 octets | `gpt2_q3_k_dot_f32` |
+| Q4_K | 144 octets | `gpt2_q4_k_dot_f32` |
+| Q6_K | 210 octets | `gpt2_q6_k_dot_f32` |
+
+## Validation
+
+La fixture `GPT2.GGU` est chargée puis indexée comme tenseur Q4_K. Le test lit son super-bloc de 144 octets, exécute le kernel avec 256 activations nulles et vérifie un produit nul; une longueur de 32 valeurs est rejetée. Le runner global et la cible Makefile lient explicitement `gpt2_quant.c` au test FAT16 afin d’exercer le chemin complet. La suite `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Limites et suite
+
+Le pont traite un seul super-bloc à la fois et ne réalise pas encore une ligne complète de matrice, une accumulation multi-blocs ou un forward GPT-2. La prochaine étape pourra ajouter un accumulateur borné sur plusieurs blocs et connecter les métadonnées de forme GGUF aux dimensions d’activation, sans charger tout le checkpoint en mémoire.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -55,3 +55,31 @@ int gpt2_gguf_read_quant_block_fat16(const fat16_volume_t* volume, const char* f
     return gpt2_gguf_read_tensor_fat16(volume, filename, model, tensor,
                                        block_offset, buffer, block_bytes, out_read);
 }
+
+
+int gpt2_gguf_dot_quant_block_fat16(const fat16_volume_t* volume, const char* filename,
+                                    const gpt2_gguf_loaded_model_t* model,
+                                    const gpt2_gguf_tensor_t* tensor,
+                                    uint32_t block_index, const float* input,
+                                    uint32_t count, uint8_t* scratch,
+                                    uint32_t scratch_capacity, float* out_dot) {
+    uint32_t block_bytes;
+    uint32_t read = 0U;
+    int status;
+    if (!input || !scratch || !out_dot) return -1;
+    if (count != GPT2_QK_K) return -7;
+    if (!tensor) return -1;
+    if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) block_bytes = GPT2_Q3_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) block_bytes = GPT2_Q4_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q6_K) block_bytes = GPT2_Q6_K_BLOCK_BYTES;
+    else return -4;
+    if (scratch_capacity < block_bytes) return -6;
+    status = gpt2_gguf_read_quant_block_fat16(volume, filename, model, tensor,
+                                               block_index, scratch, scratch_capacity, &read);
+    if (status != 0) return status;
+    if (read != block_bytes) return -8;
+    if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) *out_dot = gpt2_q3_k_dot_f32(input, scratch, count);
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) *out_dot = gpt2_q4_k_dot_f32(input, scratch, count);
+    else *out_dot = gpt2_q6_k_dot_f32(input, scratch, count);
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -26,5 +26,12 @@ int gpt2_gguf_read_quant_block_fat16(const fat16_volume_t* volume, const char* f
                                      const gpt2_gguf_tensor_t* tensor,
                                      uint32_t block_index, uint8_t* buffer,
                                      uint32_t capacity, uint32_t* out_read);
+/* Lit puis exécute un super-bloc quantifié avec un scratch caller-owned. */
+int gpt2_gguf_dot_quant_block_fat16(const fat16_volume_t* volume, const char* filename,
+                                    const gpt2_gguf_loaded_model_t* model,
+                                    const gpt2_gguf_tensor_t* tensor,
+                                    uint32_t block_index, const float* input,
+                                    uint32_t count, uint8_t* scratch,
+                                    uint32_t scratch_capacity, float* out_dot);
 
 #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -97,9 +97,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_gguf: $(UNIT_DIR)/kernel/test_gpt2_ggu
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_fat16: $(UNIT_DIR)/kernel/test_fat16.c ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_fat16: $(UNIT_DIR)/kernel/test_fat16.c ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_quant: $(UNIT_DIR)/kernel/test_gpt2_quant.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -112,7 +112,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_quant.c"
     fi
     if [ "$(basename "$test_file")" = "test_fat16.c" ]; then
-        extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c"
+        extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c $BASE_DIR/kernel/llm/gpt2_quant.c"
     fi
     if [ "$(basename "$test_file")" = "test_ipc.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/ipc.c"

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -123,6 +123,13 @@ static void test_loads_gpt2_from_fat16(void) {
         TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, block, sizeof(block), &block_read));
         TEST_ASSERT_EQUAL(GPT2_Q4_K_BLOCK_BYTES, (int)block_read);
         TEST_ASSERT_EQUAL(-6, gpt2_gguf_read_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, block, 1U, &block_read));
+        {
+            float input[GPT2_QK_K] = {0.0f};
+            float dot = 1.0f;
+            TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, input, GPT2_QK_K, block, sizeof(block), &dot));
+            TEST_ASSERT_EQUAL(0, (int)dot);
+            TEST_ASSERT_EQUAL(-7, gpt2_gguf_dot_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, input, 32U, block, sizeof(block), &dot));
+        }
     }
 }
 


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_dot_quant_block_fat16`;
- lit un super-bloc Q3_K/Q4_K/Q6_K dans un scratch caller-owned;
- appelle le kernel quantifié avec exactement 256 activations;
- aligne Makefile et runner CI pour lier `gpt2_quant.c`;
- valide un produit scalaire Q4_K depuis `GPT2.GGU`;
- documente les limites avant accumulation multi-blocs.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot ne réalise pas encore le forward GPT-2 complet.