### PR TITLE
Lot 76: accumulation GGUF multi-blocs

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -40,7 +40,9 @@ Le lot 74 ajoute `gpt2_gguf_read_quant_block_fat16`, qui refuse les types non K-
 
 Le lot 75 ajoute `gpt2_gguf_dot_quant_block_fat16`, qui lit un super-bloc Q3_K/Q4_K/Q6_K dans un scratch caller-owned puis appelle le kernel quantifié avec exactement 256 activations. Le test Q4_K vérifie un produit nul sur `GPT2.GGU` et rejette une longueur invalide; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : le pont traite un super-bloc à la fois et ne réalise pas encore d’accumulation multi-blocs ni de forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 76 ajoute `gpt2_gguf_dot_quant_tensor_fat16`, qui lit et accumule plusieurs super-blocs Q3_K/Q4_K/Q6_K avec un scratch caller-owned. La fixture Q4_K contient deux blocs pour 512 valeurs et vérifie une accumulation nulle; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : l’accumulation porte sur une ligne bornée et ne réalise pas encore le parcours des matrices, des biais ou un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_76_gguf_quant_multiblock.md
+++ b/docs/mohhos_foundation_increment_76_gguf_quant_multiblock.md
@@ -1,0 +1,25 @@
+# MOHHOS Foundation — Incrément 76 : accumulation GGUF multi-blocs
+
+**État :** implémenté sur la branche de travail du lot 76.
+
+## Objectif
+
+Le lot 76 ajoute `gpt2_gguf_dot_quant_tensor_fat16`, qui accumule plusieurs super-blocs quantifiés d’un tenseur GGUF sans charger le tenseur complet. L’API conserve un scratch caller-owned, lit chaque bloc avec le contrat du lot 75 et appelle le kernel Q3_K, Q4_K ou Q6_K sur la tranche d’activations correspondante.
+
+La longueur d’activation doit être un multiple non nul de 256. Chaque bloc est validé séparément par l’API mono-bloc, ce qui maintient les contrôles de type, de taille, d’offset et de capacité. L’accumulation FP32 est réalisée dans un scalaire fourni par l’implémentation; aucune allocation dynamique ni modification de l’ABI noyau n’est introduite.
+
+| Contrôle | Garantie |
+| --- | --- |
+| dimensions | `count` strictement positif et multiple de 256 |
+| mémoire | un seul scratch fourni par l’appelant |
+| stockage | lecture FAT16 d’un bloc à la fois |
+| calcul | dispatch vers le kernel quantifié correspondant |
+| résultat | somme FP32 des produits partiels |
+
+## Validation
+
+La fixture disque contient désormais un tenseur Q4_K de 512 valeurs, soit deux super-blocs de 144 octets et 480 octets de fichier. Le test accumule les deux blocs avec 512 activations nulles et vérifie un résultat nul; les tests mono-bloc et de longueur invalide restent actifs. La suite `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Limites et suite
+
+Le chemin reste une primitive de ligne de poids: il ne réalise pas encore le parcours des matrices GPT-2, les biais, les dimensions de batch ou les accumulations de plusieurs lignes. Un prochain lot pourra ajouter un descripteur de ligne borné et relier cette accumulation au mapping des rôles GPT-2.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -83,3 +83,30 @@ int gpt2_gguf_dot_quant_block_fat16(const fat16_volume_t* volume, const char* fi
     else *out_dot = gpt2_q6_k_dot_f32(input, scratch, count);
     return 0;
 }
+
+
+int gpt2_gguf_dot_quant_tensor_fat16(const fat16_volume_t* volume, const char* filename,
+                                     const gpt2_gguf_loaded_model_t* model,
+                                     const gpt2_gguf_tensor_t* tensor,
+                                     const float* input, uint32_t count,
+                                     uint8_t* scratch, uint32_t scratch_capacity,
+                                     float* out_dot) {
+    uint32_t blocks;
+    uint32_t block;
+    float total = 0.0f;
+    int status;
+    if (!input || !scratch || !out_dot || !tensor) return -1;
+    if (count == 0U || (count % GPT2_QK_K) != 0U) return -7;
+    blocks = count / GPT2_QK_K;
+    for (block = 0U; block < blocks; block++) {
+        float partial = 0.0f;
+        status = gpt2_gguf_dot_quant_block_fat16(volume, filename, model, tensor,
+                                                  block, input + block * GPT2_QK_K,
+                                                  GPT2_QK_K, scratch, scratch_capacity,
+                                                  &partial);
+        if (status != 0) return status;
+        total += partial;
+    }
+    *out_dot = total;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -33,5 +33,12 @@ int gpt2_gguf_dot_quant_block_fat16(const fat16_volume_t* volume, const char* fi
                                     uint32_t block_index, const float* input,
                                     uint32_t count, uint8_t* scratch,
                                     uint32_t scratch_capacity, float* out_dot);
+/* Accumule plusieurs super-blocs sans charger le tenseur complet. */
+int gpt2_gguf_dot_quant_tensor_fat16(const fat16_volume_t* volume, const char* filename,
+                                     const gpt2_gguf_loaded_model_t* model,
+                                     const gpt2_gguf_tensor_t* tensor,
+                                     const float* input, uint32_t count,
+                                     uint8_t* scratch, uint32_t scratch_capacity,
+                                     float* out_dot);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -82,16 +82,16 @@ static void make_gguf_file(void) {
     disk[root + 36U] = ' '; disk[root + 37U] = ' '; disk[root + 38U] = ' '; disk[root + 39U] = ' ';
     disk[root + 40U] = 'G'; disk[root + 41U] = 'G'; disk[root + 42U] = 'U'; disk[root + 43U] = 0x20U;
     put16(root + 32U + 26U, 3U);
-    put32(root + 32U + 28U, 320U);
+    put32(root + 32U + 28U, 480U);
     put32(p, GPT2_GGUF_MAGIC); p += 4U;
     put32(p, GPT2_GGUF_VERSION); p += 4U;
     put64_at(p, 1U); p += 8U;
     put64_at(p, 2U); p += 8U;
     put_text_at(&p, "general.architecture"); put32(p, GPT2_GGUF_VALUE_STRING); p += 4U; put_text_at(&p, "gpt2");
     put_text_at(&p, "general.alignment"); put32(p, GPT2_GGUF_VALUE_UINT32); p += 4U; put32(p, 32U); p += 4U;
-    put_text_at(&p, "output.weight"); put32(p, 1U); p += 4U; put64_at(p, GPT2_QK_K); p += 8U;
+    put_text_at(&p, "output.weight"); put32(p, 1U); p += 4U; put64_at(p, GPT2_QK_K * 2U); p += 8U;
     put32(p, GPT2_GGUF_TENSOR_Q4_K); p += 4U; put64_at(p, 0U); p += 8U;
-    end = data + 512U + 320U;
+    end = data + 512U + 480U;
     while (p < end) disk[p++] = 0U;
 }
 
@@ -103,7 +103,7 @@ static void test_loads_gpt2_from_fat16(void) {
     make_gguf_file();
     TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
     TEST_ASSERT_EQUAL(0, gpt2_gguf_load_fat16(&volume, "gpt2.ggu", buffer, sizeof(buffer), &model));
-    TEST_ASSERT_EQUAL(320, (int)model.bytes_loaded);
+    TEST_ASSERT_EQUAL(480, (int)model.bytes_loaded);
     TEST_ASSERT_EQUAL(1, model.index.tensor_count);
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&model.index, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));
     TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
@@ -129,6 +129,11 @@ static void test_loads_gpt2_from_fat16(void) {
             TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, input, GPT2_QK_K, block, sizeof(block), &dot));
             TEST_ASSERT_EQUAL(0, (int)dot);
             TEST_ASSERT_EQUAL(-7, gpt2_gguf_dot_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, input, 32U, block, sizeof(block), &dot));
+            {
+                float row[GPT2_QK_K * 2U] = {0.0f};
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_tensor_fat16(&volume, "gpt2.ggu", &model, &tensor, row, GPT2_QK_K * 2U, block, sizeof(block), &dot));
+                TEST_ASSERT_EQUAL(0, (int)dot);
+            }
         }
     }
 }


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_dot_quant_tensor_fat16`;
- accumule plusieurs super-blocs Q3_K/Q4_K/Q6_K sans charger le tenseur complet;
- réutilise un scratch caller-owned et les contrôles mono-bloc;
- étend la fixture Q4_K à deux blocs et 512 valeurs;
- documente les limites avant parcours complet des matrices.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot ne réalise pas encore le forward GPT-2 complet.