### PR TITLE
Lot 77: API de ligne GGUF bornée

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -42,7 +42,9 @@ Le lot 75 ajoute `gpt2_gguf_dot_quant_block_fat16`, qui lit un super-bloc Q3_K/Q
 
 Le lot 76 ajoute `gpt2_gguf_dot_quant_tensor_fat16`, qui lit et accumule plusieurs super-blocs Q3_K/Q4_K/Q6_K avec un scratch caller-owned. La fixture Q4_K contient deux blocs pour 512 valeurs et vérifie une accumulation nulle; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : l’accumulation porte sur une ligne bornée et ne réalise pas encore le parcours des matrices, des biais ou un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 77 ajoute `gpt2_gguf_dot_quant_row_fat16`, qui valide une forme 1D/2D, exige `count == shape[0]`, calcule l’offset de ligne en 64-bit et accumule les super-blocs depuis FAT16. La fixture Q4_K valide une ligne 1D de 512 valeurs et rejette une seconde ligne; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : la façade ne traite qu’une ligne à la fois et ne réalise pas encore le parcours complet des matrices, des biais, des batches ou un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_77_gguf_tensor_row.md
+++ b/docs/mohhos_foundation_increment_77_gguf_tensor_row.md
@@ -1,0 +1,23 @@
+# MOHHOS Foundation — Incrément 77 : ligne de tenseur GGUF bornée
+
+**État :** implémenté sur la branche de travail du lot 77.
+
+## Objectif
+
+Le lot 77 ajoute `gpt2_gguf_dot_quant_row_fat16`, une façade orientée ligne qui relie la forme GGUF à l’accumulation multi-blocs. Pour un tenseur 1D, la seule ligne est `row_index = 0`. Pour un tenseur 2D, `shape[0]` est la largeur d’une ligne et `shape[1]` le nombre de lignes. L’appel exige que `count` corresponde exactement à `shape[0]` et soit un multiple de 256.
+
+L’offset du premier super-bloc est calculé en 64-bit puis borné avant d’être converti en offset i386. Chaque bloc de la ligne est ensuite lu depuis FAT16 et accumulé avec le scratch caller-owned. Les dimensions supérieures à 2, les lignes absentes, les largeurs nulles ou non supportées et les tailles incompatibles sont refusées avant le calcul.
+
+| Forme | Interprétation |
+| --- | --- |
+| 1 dimension | une ligne de largeur `shape[0]` |
+| 2 dimensions | `shape[1]` lignes, chacune de largeur `shape[0]` |
+| plus de 2 dimensions | refusé par le contrat Foundation |
+
+## Validation
+
+La fixture Q4_K contient deux super-blocs et représente une ligne 1D de 512 valeurs. Le test calcule la ligne zéro avec 512 activations nulles et rejette `row_index = 1`. Les tests d’accumulation multi-blocs, de super-bloc unique et de longueur invalide restent actifs. La suite `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Limites et suite
+
+La façade ne traite encore qu’une ligne à la fois et ne relie pas les dimensions à un batch ou à une matrice GPT-2 complète. La prochaine étape pourra tester une vraie forme 2D et préparer la sélection de lignes pour les rôles GPT-2, tout en conservant le chargement progressif depuis FAT16.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -110,3 +110,49 @@ int gpt2_gguf_dot_quant_tensor_fat16(const fat16_volume_t* volume, const char* f
     *out_dot = total;
     return 0;
 }
+
+
+int gpt2_gguf_dot_quant_row_fat16(const fat16_volume_t* volume, const char* filename,
+                                  const gpt2_gguf_loaded_model_t* model,
+                                  const gpt2_gguf_tensor_t* tensor,
+                                  uint32_t row_index, const float* input,
+                                  uint32_t count, uint8_t* scratch,
+                                  uint32_t scratch_capacity, float* out_dot) {
+    uint64_t width;
+    uint64_t rows = 1U;
+    uint32_t block_bytes;
+    uint64_t row_bytes;
+    uint64_t row_offset;
+    uint32_t first_block;
+    uint32_t blocks;
+    uint32_t block;
+    float total = 0.0f;
+    int status;
+    if (!tensor || tensor->dimensions == 0U || tensor->dimensions > 2U) return -9;
+    width = tensor->shape[0];
+    if (tensor->dimensions == 2U) rows = tensor->shape[1];
+    if (width == 0U || width > 0xFFFFFFFFU || rows == 0U || row_index >= rows) return -9;
+    if (count != (uint32_t)width || (count % GPT2_QK_K) != 0U) return -7;
+    if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) block_bytes = GPT2_Q3_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) block_bytes = GPT2_Q4_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q6_K) block_bytes = GPT2_Q6_K_BLOCK_BYTES;
+    else return -4;
+    row_bytes = (width / GPT2_QK_K) * block_bytes;
+    row_offset = row_bytes * row_index;
+    if (row_offset > 0xFFFFFFFFU) return -9;
+    first_block = (uint32_t)(row_offset / block_bytes);
+    blocks = (uint32_t)(width / GPT2_QK_K);
+    for (block = 0U; block < blocks; block++) {
+        float partial = 0.0f;
+        if (first_block > 0xFFFFFFFFU - block) return -9;
+        status = gpt2_gguf_dot_quant_block_fat16(volume, filename, model, tensor,
+                                                  first_block + block,
+                                                  input + block * GPT2_QK_K,
+                                                  GPT2_QK_K, scratch,
+                                                  scratch_capacity, &partial);
+        if (status != 0) return status;
+        total += partial;
+    }
+    *out_dot = total;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -40,5 +40,12 @@ int gpt2_gguf_dot_quant_tensor_fat16(const fat16_volume_t* volume, const char* f
                                      const float* input, uint32_t count,
                                      uint8_t* scratch, uint32_t scratch_capacity,
                                      float* out_dot);
+/* Calcule une ligne `shape[0]` d’un tenseur 1D ou 2D. */
+int gpt2_gguf_dot_quant_row_fat16(const fat16_volume_t* volume, const char* filename,
+                                  const gpt2_gguf_loaded_model_t* model,
+                                  const gpt2_gguf_tensor_t* tensor,
+                                  uint32_t row_index, const float* input,
+                                  uint32_t count, uint8_t* scratch,
+                                  uint32_t scratch_capacity, float* out_dot);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -133,6 +133,9 @@ static void test_loads_gpt2_from_fat16(void) {
                 float row[GPT2_QK_K * 2U] = {0.0f};
                 TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_tensor_fat16(&volume, "gpt2.ggu", &model, &tensor, row, GPT2_QK_K * 2U, block, sizeof(block), &dot));
                 TEST_ASSERT_EQUAL(0, (int)dot);
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, row, GPT2_QK_K * 2U, block, sizeof(block), &dot));
+                TEST_ASSERT_EQUAL(0, (int)dot);
+                TEST_ASSERT_EQUAL(-9, gpt2_gguf_dot_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 1U, row, GPT2_QK_K * 2U, block, sizeof(block), &dot));
             }
         }
     }


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_dot_quant_row_fat16`;
- valide les formes 1D/2D et `count == shape[0]`;
- calcule l’offset de ligne en 64-bit;
- accumule les blocs quantifiés depuis FAT16;
- teste une ligne Q4_K 1D de 512 valeurs et un index hors forme;
- documente les limites avant parcours complet des matrices.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot ne réalise pas encore le forward GPT-2 complet.