### PR TITLE
Lot 78: validation des lignes GGUF 2D

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -44,7 +44,9 @@ Le lot 76 ajoute `gpt2_gguf_dot_quant_tensor_fat16`, qui lit et accumule plusieu
 
 Le lot 77 ajoute `gpt2_gguf_dot_quant_row_fat16`, qui valide une forme 1D/2D, exige `count == shape[0]`, calcule l’offset de ligne en 64-bit et accumule les super-blocs depuis FAT16. La fixture Q4_K valide une ligne 1D de 512 valeurs et rejette une seconde ligne; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : la façade ne traite qu’une ligne à la fois et ne réalise pas encore le parcours complet des matrices, des biais, des batches ou un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 78 valide une forme GGUF 2D pour `output.weight` (`shape[0]=512`, `shape[1]=1`). `gpt2_gguf_dot_quant_row_fat16` contrôle `row_index`, calcule l’offset de ligne borné et réutilise l’accumulation Q4_K; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : la fixture 2D ne contient encore qu’une ligne et le chemin ne réalise pas le parcours complet des matrices, des biais, des batches ou un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_78_gguf_2d_rows.md
+++ b/docs/mohhos_foundation_increment_78_gguf_2d_rows.md
@@ -1,0 +1,25 @@
+# MOHHOS Foundation — Incrément 78 : sélection de lignes GGUF 2D
+
+**État :** implémenté sur la branche de travail du lot 78.
+
+## Objectif
+
+Le lot 78 vérifie la représentation 2D des tenseurs GGUF utilisés par les poids GPT-2. La façade `gpt2_gguf_dot_quant_row_fat16` interprète `shape[0]` comme la largeur de ligne et `shape[1]` comme le nombre de lignes. Elle calcule le premier super-bloc de la ligne en 64-bit, refuse les lignes inexistantes et réutilise le dispatch quantifié sans charger la matrice entière.
+
+La fixture `output.weight` encode désormais deux dimensions (`512 × 1`) tout en conservant deux super-blocs Q4_K dans le fichier FAT16. Cette forme minimale exerce le contrat 2D sans augmenter artificiellement la chaîne de clusters; une prochaine fixture pourra ajouter plusieurs lignes réelles lorsque le générateur disque sera étendu.
+
+| Contrôle | Résultat attendu |
+| --- | --- |
+| dimensions 2D | `shape[0]` devient la largeur d’activation |
+| nombre de lignes | `row_index < shape[1]` |
+| offset | multiplication bornée avant conversion i386 |
+| calcul | accumulation Q4_K par super-bloc |
+| stockage | lecture progressive FAT16 |
+
+## Validation
+
+Le test charge `GPT2.GGU`, mappe `output.weight`, vérifie `dimensions == 2`, calcule la ligne zéro sur 512 activations nulles et rejette `row_index = 1` puisque la forme ne contient qu’une ligne. La suite `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Limites et suite
+
+Le chemin valide déjà les formes jusqu’à deux dimensions, mais le test disque ne contient encore qu’une ligne. Cette étape ne réalise pas le forward GPT-2, la sélection de batch ou les biais; elle fournit le contrat de forme nécessaire à un futur mapping des rôles GPT-2 vers des lignes réellement multi-rangées.

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -89,7 +89,8 @@ static void make_gguf_file(void) {
     put64_at(p, 2U); p += 8U;
     put_text_at(&p, "general.architecture"); put32(p, GPT2_GGUF_VALUE_STRING); p += 4U; put_text_at(&p, "gpt2");
     put_text_at(&p, "general.alignment"); put32(p, GPT2_GGUF_VALUE_UINT32); p += 4U; put32(p, 32U); p += 4U;
-    put_text_at(&p, "output.weight"); put32(p, 1U); p += 4U; put64_at(p, GPT2_QK_K * 2U); p += 8U;
+    put_text_at(&p, "output.weight"); put32(p, 2U); p += 4U; put64_at(p, GPT2_QK_K * 2U); p += 8U;
+    put64_at(p, 1U); p += 8U;
     put32(p, GPT2_GGUF_TENSOR_Q4_K); p += 4U; put64_at(p, 0U); p += 8U;
     end = data + 512U + 480U;
     while (p < end) disk[p++] = 0U;
@@ -106,6 +107,7 @@ static void test_loads_gpt2_from_fat16(void) {
     TEST_ASSERT_EQUAL(480, (int)model.bytes_loaded);
     TEST_ASSERT_EQUAL(1, model.index.tensor_count);
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&model.index, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));
+    TEST_ASSERT_EQUAL(2, (int)tensor.dimensions);
     TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
     {
         uint8_t tensor_bytes[4] = {0xFFU, 0xFFU, 0xFFU, 0xFFU};


### PR DESCRIPTION
## Résumé

- encode `output.weight` en forme GGUF 2D `512 x 1`;
- vérifie `dimensions == 2` après mapping;
- valide la sélection de ligne et l’offset borné;
- rejette la ligne 1 hors plage;
- documente les limites avant matrices multi-lignes.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot ne réalise pas encore le forward GPT-2 complet.