### PR TITLE
Lot 79: validation GGUF multi-lignes

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -46,7 +46,9 @@ Le lot 77 ajoute `gpt2_gguf_dot_quant_row_fat16`, qui valide une forme 1D/2D, ex
 
 Le lot 78 valide une forme GGUF 2D pour `output.weight` (`shape[0]=512`, `shape[1]=1`). `gpt2_gguf_dot_quant_row_fat16` contrôle `row_index`, calcule l’offset de ligne borné et réutilise l’accumulation Q4_K; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
 
-Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : la fixture 2D ne contient encore qu’une ligne et le chemin ne réalise pas le parcours complet des matrices, des biais, des batches ou un forward complet. Aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
+Le lot 79 transforme la fixture en matrice Q4_K multi-lignes `shape[0]=256`, `shape[1]=2`. Les lignes 0 et 1 sont lues depuis FAT16, la ligne 2 est rejetée et l’accumulation des deux blocs reste validée; la suite reste à **265 tests réussis**, sans échec ni test ignoré.
+
+Cette livraison ne constitue toujours pas une génération GPT-2 à partir d’un checkpoint GGUF réel : le chemin ne réalise pas le parcours complet des matrices, des biais, des batches ou un forward autoregressif. Les valeurs de fixture sont nulles et aucune latence inférieure à une seconde n’est annoncée sans mesure native ou KVM reproductible.
 
 
 ### Noyau, stockage et tâches

--- a/docs/mohhos_foundation_increment_79_gguf_multiline_rows.md
+++ b/docs/mohhos_foundation_increment_79_gguf_multiline_rows.md
@@ -1,0 +1,28 @@
+# MOHHOS Foundation — Incrément 79 : matrice GGUF multi-lignes
+
+**État :** implémenté sur la branche de travail du lot 79.
+
+## Objectif
+
+Le lot 79 transforme la fixture GGUF en matrice quantifiée Q4_K réellement multi-lignes. `output.weight` possède maintenant la forme `256 × 2`: chaque ligne contient un super-bloc de 256 valeurs et les deux lignes occupent deux blocs Q4_K consécutifs dans le fichier FAT16.
+
+Cette fixture vérifie que la façade `gpt2_gguf_dot_quant_row_fat16` sélectionne correctement la ligne zéro et la ligne un, tandis qu’une demande de ligne deux est rejetée. L’accumulation tensorielle sur 512 activations reste également testée, ce qui couvre le parcours des deux blocs depuis le stockage disque.
+
+| Élément | Valeur de test |
+| --- | --- |
+| forme GGUF | `shape[0]=256`, `shape[1]=2` |
+| type quantifié | Q4_K |
+| blocs par ligne | 1 |
+| blocs totaux | 2 |
+| stockage | FAT16, fichier court `GPT2.GGU` |
+| calcul | produit scalaire FP32 borné |
+
+## Validation
+
+Le test charge le fichier depuis FAT16, mappe `output.weight`, vérifie la forme 2D, calcule les lignes 0 et 1 avec des activations nulles et refuse `row_index = 2`. La suite `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+Le scénario QEMU shell extras a également été stabilisé: sa cadence de frappe par défaut passe de 0,80 s à 0,15 s et son délai de commande à 12 s. Les marqueurs fonctionnels, les retries et les assertions restent inchangés; le scénario local passe sous 90 s.
+
+## Limites et suite
+
+Le chemin traite maintenant une vraie forme multi-lignes mais ne réalise pas encore le parcours de toutes les matrices GPT-2, les biais, le batch ou le forward autoregressif. Les valeurs de fixture sont nulles; la validation mathématique des kernels est couverte séparément, tandis que le raccord disque vérifie ici les offsets et les bornes.

--- a/tests/scripts/ci_qemu_shell_extras.py
+++ b/tests/scripts/ci_qemu_shell_extras.py
@@ -20,8 +20,8 @@ LOG = os.environ.get("EXTRAS_LOG", os.path.join(LOG_DIR, "ci-qemu-extras-serial.
 QEMU_ERR = os.environ.get("EXTRAS_ERR", os.path.join(LOG_DIR, "ci-qemu-extras-stderr.log"))
 MON_SOCK = os.environ.get("EXTRAS_MON_SOCK", os.path.join(LOG_DIR, "qemu-extras-monitor.sock"))
 BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "18"))
-CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "8"))
-KEY_DELAY = float(os.environ.get("KEY_DELAY", "0.80"))
+CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "12"))
+KEY_DELAY = float(os.environ.get("KEY_DELAY", "0.15"))
 
 
 def say(msg):

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -89,8 +89,8 @@ static void make_gguf_file(void) {
     put64_at(p, 2U); p += 8U;
     put_text_at(&p, "general.architecture"); put32(p, GPT2_GGUF_VALUE_STRING); p += 4U; put_text_at(&p, "gpt2");
     put_text_at(&p, "general.alignment"); put32(p, GPT2_GGUF_VALUE_UINT32); p += 4U; put32(p, 32U); p += 4U;
-    put_text_at(&p, "output.weight"); put32(p, 2U); p += 4U; put64_at(p, GPT2_QK_K * 2U); p += 8U;
-    put64_at(p, 1U); p += 8U;
+    put_text_at(&p, "output.weight"); put32(p, 2U); p += 4U; put64_at(p, GPT2_QK_K); p += 8U;
+    put64_at(p, 2U); p += 8U;
     put32(p, GPT2_GGUF_TENSOR_Q4_K); p += 4U; put64_at(p, 0U); p += 8U;
     end = data + 512U + 480U;
     while (p < end) disk[p++] = 0U;
@@ -132,12 +132,15 @@ static void test_loads_gpt2_from_fat16(void) {
             TEST_ASSERT_EQUAL(0, (int)dot);
             TEST_ASSERT_EQUAL(-7, gpt2_gguf_dot_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, input, 32U, block, sizeof(block), &dot));
             {
-                float row[GPT2_QK_K * 2U] = {0.0f};
-                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_tensor_fat16(&volume, "gpt2.ggu", &model, &tensor, row, GPT2_QK_K * 2U, block, sizeof(block), &dot));
+                float row[GPT2_QK_K] = {0.0f};
+                float tensor_input[GPT2_QK_K * 2U] = {0.0f};
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_tensor_fat16(&volume, "gpt2.ggu", &model, &tensor, tensor_input, GPT2_QK_K * 2U, block, sizeof(block), &dot));
                 TEST_ASSERT_EQUAL(0, (int)dot);
-                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, row, GPT2_QK_K * 2U, block, sizeof(block), &dot));
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, row, GPT2_QK_K, block, sizeof(block), &dot));
                 TEST_ASSERT_EQUAL(0, (int)dot);
-                TEST_ASSERT_EQUAL(-9, gpt2_gguf_dot_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 1U, row, GPT2_QK_K * 2U, block, sizeof(block), &dot));
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 1U, row, GPT2_QK_K, block, sizeof(block), &dot));
+                TEST_ASSERT_EQUAL(0, (int)dot);
+                TEST_ASSERT_EQUAL(-9, gpt2_gguf_dot_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 2U, row, GPT2_QK_K, block, sizeof(block), &dot));
             }
         }
     }


### PR DESCRIPTION
## Résumé

- transforme la fixture `output.weight` en matrice Q4_K `256 x 2`;
- valide les lignes 0 et 1 depuis FAT16;
- rejette `row_index = 2`;
- conserve le test d’accumulation sur 512 valeurs;
- stabilise la cadence du smoke shell extras sans modifier marqueurs ni assertions;
- documente les limites avant forward GPT-2 complet.

## Validation locale

- `make all -j2` ✅
- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec
- extras seul ✅ sous 90 s

Le lot ne réalise pas encore le forward GPT-2 complet.