### PR TITLE
Lot 80: preuve de sélection des blocs GGUF sur FAT16

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -246,3 +246,6 @@ AI-OS ne fournit pas encore de volume FAT sur le disque IDE, de pilote réseau, 
 ## Références
 
 [1] [QEMU, *Network emulation*](https://www.qemu.org/docs/master/system/devices/net.html)
+
+
+Le lot 80 ajoute une preuve différentielle de sélection disque dans la fixture GGUF/FAT16. Après alignement dynamique sur `general.alignment`, le premier super-bloc Q4_K commence par `0x11` et le second par `0x77`; les lectures de tenseur, de bloc 0 et de bloc 1 vérifient ces valeurs distinctes. La capacité insuffisante et les bornes de ligne restent rejetées. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. Cette preuve porte sur l’offset physique FAT16 et ne constitue toujours pas un forward GPT-2 complet.

--- a/docs/mohhos_foundation_increment_80_disk_selection_markers.md
+++ b/docs/mohhos_foundation_increment_80_disk_selection_markers.md
@@ -1,0 +1,36 @@
+# MOHHOS Foundation — Incrément 80 : preuve de sélection des blocs disque
+
+**État :** implémenté sur la branche de travail du lot 80.
+
+## Objectif
+
+Le lot 79 démontrait qu’une matrice GGUF Q4_K pouvait contenir deux lignes et que les bornes de `row_index` étaient respectées. Toutefois, une fixture entièrement nulle ne permettait pas de distinguer une lecture correcte du bloc zéro d’une lecture accidentellement répétée du même emplacement physique. Le lot 80 rend cette preuve observable en plaçant des marqueurs distincts au début des deux super-blocs Q4_K.
+
+La fixture calcule le début des données depuis la fin réelle des métadonnées GGUF, puis applique `general.alignment = 32`. Elle écrit `0x11` au premier octet du bloc zéro et `0x77` au premier octet du bloc un, séparé par exactement `GPT2_Q4_K_BLOCK_BYTES` octets. Aucun buffer dynamique n’est introduit dans le noyau ou dans le test d’intégration.
+
+## Contrat vérifié
+
+| Élément | Valeur vérifiée |
+| --- | --- |
+| fichier | `GPT2.GGU` via nom FAT16 8.3 |
+| type | Q4_K |
+| forme | `shape[0]=256`, `shape[1]=2` |
+| taille d’un super-bloc | `GPT2_Q4_K_BLOCK_BYTES` = 144 octets |
+| marqueur bloc 0 | `0x11` |
+| marqueur bloc 1 | `0x77` |
+| sélection | bloc 0 puis bloc 1 |
+| invalidité | capacité d’un octet refusée |
+
+## Preuve d’intégration
+
+`gpt2_gguf_read_tensor_fat16` lit le premier octet de la matrice et retourne `0x11`. `gpt2_gguf_read_quant_block_fat16` lit ensuite le bloc zéro et retrouve `0x11`, puis lit explicitement le bloc un et retrouve `0x77`. Le second marqueur étant placé à la distance exacte d’un super-bloc Q4_K, cette assertion prouve que l’indexation de bloc et la sélection de l’offset physique ne réutilisent pas silencieusement le premier bloc.
+
+La vérification de capacité reste active : une demande de lecture avec un buffer d’un seul octet est rejetée. Les tests de ligne 2D et de rejet de `row_index = 2` du lot 79 sont conservés. Les valeurs restantes de la fixture demeurent nulles; ce lot prouve la sélection des données sur FAT16, mais ne prétend pas valider le forward GPT-2 complet.
+
+## Validation
+
+La suite `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**. La compilation des exécutables Unity et les tests FAT16, GGUF, quantification et bornes restent verts. Les avertissements historiques du framework 32-bit ne changent pas le résultat fonctionnel.
+
+## Limites et suite
+
+Le chemin couvre désormais l’indexation, le mapping de rôle, la lecture par plage, le curseur, l’accumulation de super-blocs et la sélection de lignes GGUF depuis FAT16. Il ne réalise toujours pas le parcours complet des matrices GPT-2, l’application des biais, le batch, le cache KV intégré au forward ni la génération autoregressive complète. La prochaine étape doit rester caller-owned et conserver la validation Unity/QEMU avant toute intégration plus large.

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -76,6 +76,7 @@ static void make_gguf_file(void) {
     uint32_t fat;
     uint32_t p = data + 512U;
     uint32_t end;
+    uint32_t tensor_data;
     make_volume();
     for (fat = 1U; fat <= 2U; fat++) put16(fat * 17U * 512U + 6U, 0xFFFFU);
     disk[root + 32U] = 'G'; disk[root + 33U] = 'P'; disk[root + 34U] = 'T'; disk[root + 35U] = '2';
@@ -93,7 +94,11 @@ static void make_gguf_file(void) {
     put64_at(p, 2U); p += 8U;
     put32(p, GPT2_GGUF_TENSOR_Q4_K); p += 4U; put64_at(p, 0U); p += 8U;
     end = data + 512U + 480U;
+    tensor_data = p;
+    while ((tensor_data & 31U) != 0U) tensor_data++;
     while (p < end) disk[p++] = 0U;
+    disk[tensor_data] = 0x11U;
+    disk[tensor_data + GPT2_Q4_K_BLOCK_BYTES] = 0x77U;
 }
 
 static void test_loads_gpt2_from_fat16(void) {
@@ -114,7 +119,7 @@ static void test_loads_gpt2_from_fat16(void) {
         uint32_t tensor_read = 0U;
         TEST_ASSERT_EQUAL(0, gpt2_gguf_read_tensor_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, tensor_bytes, sizeof(tensor_bytes), &tensor_read));
         TEST_ASSERT_EQUAL(4, (int)tensor_read);
-        TEST_ASSERT_EQUAL(0, tensor_bytes[0]);
+        TEST_ASSERT_EQUAL(0x11, tensor_bytes[0]);
         TEST_ASSERT_EQUAL(0, tensor_bytes[1]);
         TEST_ASSERT_EQUAL(0, tensor_bytes[2]);
         TEST_ASSERT_EQUAL(0, tensor_bytes[3]);
@@ -124,6 +129,10 @@ static void test_loads_gpt2_from_fat16(void) {
         uint32_t block_read = 0U;
         TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, block, sizeof(block), &block_read));
         TEST_ASSERT_EQUAL(GPT2_Q4_K_BLOCK_BYTES, (int)block_read);
+        TEST_ASSERT_EQUAL(0x11, block[0]);
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 1U, block, sizeof(block), &block_read));
+        TEST_ASSERT_EQUAL(GPT2_Q4_K_BLOCK_BYTES, (int)block_read);
+        TEST_ASSERT_EQUAL(0x77, block[0]);
         TEST_ASSERT_EQUAL(-6, gpt2_gguf_read_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, block, 1U, &block_read));
         {
             float input[GPT2_QK_K] = {0.0f};


### PR DESCRIPTION
## Résumé

- aligne dynamiquement les données GGUF selon `general.alignment`;
- écrit `0x11` dans le super-bloc Q4_K 0 et `0x77` dans le super-bloc 1;
- vérifie les deux valeurs via lecture de tenseur et lecture de blocs FAT16;
- conserve les bornes de capacité et de ligne 2D;
- ajoute la documentation française et met à jour `docs/ETAT_REEL.md`.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Cette PR prouve la sélection d’offset physique; elle ne prétend pas livrer le forward GPT-2 complet.