### PR TITLE
Lot 81: mapping des rôles GPT-2 GGUF par couche

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -249,3 +249,6 @@ AI-OS ne fournit pas encore de volume FAT sur le disque IDE, de pilote réseau, 
 
 
 Le lot 80 ajoute une preuve différentielle de sélection disque dans la fixture GGUF/FAT16. Après alignement dynamique sur `general.alignment`, le premier super-bloc Q4_K commence par `0x11` et le second par `0x77`; les lectures de tenseur, de bloc 0 et de bloc 1 vérifient ces valeurs distinctes. La capacité insuffisante et les bornes de ligne restent rejetées. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. Cette preuve porte sur l’offset physique FAT16 et ne constitue toujours pas un forward GPT-2 complet.
+
+
+Le lot 81 étend le mapping GGUF aux rôles répétés des blocs GPT-2 via `gpt2_gguf_map_layer_role`. L’API construit dans un buffer caller-owned les noms `blk.<layer>.attn_norm`, `attn_qkv`, `attn_output`, `ffn_norm`, `ffn_up` et `ffn_down`, avec poids et biais lorsque la convention est définie, puis résout le tenseur dans l’index sans allocation dynamique. La fixture vérifie deux noms de couche, une couche absente et un buffer trop petit. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. Ce mapping ne branche pas encore les matrices à un forward GPT-2 réel.

--- a/docs/mohhos_foundation_increment_81_gpt2_layer_roles.md
+++ b/docs/mohhos_foundation_increment_81_gpt2_layer_roles.md
@@ -1,0 +1,30 @@
+# MOHHOS Foundation — Incrément 81 : rôles GPT-2 par couche
+
+**État :** implémenté sur la branche de travail du lot 81.
+
+## Objectif
+
+Les lots précédents associaient les cinq tenseurs globaux GPT-2 aux rôles `token_embd`, `position_embd`, `output_norm` et `output`. Le lot 81 étend cette abstraction aux familles répétées de chaque bloc Transformer, sans charger le checkpoint complet et sans allouer de mémoire dans le noyau.
+
+La nouvelle API `gpt2_gguf_map_layer_role` reçoit un index GGUF caller-owned, un numéro de couche, un rôle, un buffer de nom caller-owned et sa capacité. Elle construit le nom `blk.<layer>.<suffix>` dans ce buffer, puis réutilise `gpt2_gguf_index_find` pour résoudre le descripteur déjà indexé.
+
+## Rôles couverts
+
+| Famille | Rôles GGUF |
+| --- | --- |
+| normalisation attention | `attn_norm.weight`, `attn_norm.bias` |
+| projection attention | `attn_qkv.weight`, `attn_qkv.bias`, `attn_output.weight`, `attn_output.bias` |
+| normalisation MLP | `ffn_norm.weight`, `ffn_norm.bias` |
+| MLP | `ffn_up.weight`, `ffn_down.weight` |
+
+Les cinq rôles globaux historiques restent inchangés et `gpt2_gguf_map_role` continue de rejeter les rôles qui ne sont pas globaux. La conversion du numéro de couche est bornée à dix chiffres et le nom refuse explicitement un buffer trop petit.
+
+## Tests
+
+La fixture GGUF caller-owned contient désormais sept tenseurs: les cinq tenseurs globaux historiques, `blk.0.attn_norm.weight` et `blk.0.attn_qkv.weight`. Les tests vérifient la construction exacte des deux noms, leur résolution dans l’index, le rejet de `blk.1` absent et le rejet d’une capacité de huit octets.
+
+La suite `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**. Les taux de couverture rapportés restent de 85 % pour le noyau, 72 % pour l’espace utilisateur et 78 % global; l’avertissement de cible 70–79 % est inchangé.
+
+## Limites et suite
+
+Ce lot établit le mapping sémantique des familles par couche, mais ne parcourt pas encore les `n_layer` couches d’un checkpoint réel, ne valide pas les formes propres à chaque matrice et ne branche pas encore ces descripteurs au forward quantifié. Les biais ne disposent pas encore d’une primitive de lecture/dot dédiée, et le forward autoregressif complet reste hors périmètre.

--- a/kernel/llm/gpt2_gguf.c
+++ b/kernel/llm/gpt2_gguf.c
@@ -415,6 +415,49 @@ int gpt2_gguf_map_role(const gpt2_gguf_index_t* index, gpt2_gguf_role_t role,
         "output_norm.bias",
         "output.weight"
     };
-    if ((uint32_t)role >= (uint32_t)(sizeof(names) / sizeof(names[0]))) return -1;
+    if ((uint32_t)role >= 5U) return -1;
     return gpt2_gguf_index_find(index, names[(uint32_t)role], out);
+}
+
+static int gguf_append_name(char* name, uint32_t capacity, uint32_t* position,
+                            const char* suffix) {
+    uint32_t i = 0U;
+    if (!name || !position || !suffix) return -1;
+    while (suffix[i]) {
+        if (*position + 1U >= capacity) return -2;
+        name[(*position)++] = suffix[i++];
+    }
+    return 0;
+}
+
+int gpt2_gguf_map_layer_role(const gpt2_gguf_index_t* index, uint32_t layer,
+                             gpt2_gguf_role_t role, char* name, uint32_t capacity,
+                             gpt2_gguf_tensor_t* out) {
+    static const char* const suffixes[] = {
+        "attn_norm.weight", "attn_norm.bias", "attn_qkv.weight", "attn_qkv.bias",
+        "attn_output.weight", "attn_output.bias", "ffn_norm.weight", "ffn_norm.bias",
+        "ffn_up.weight", "ffn_down.weight"
+    };
+    uint32_t digits[10];
+    uint32_t count = 0U;
+    uint32_t position = 0U;
+    uint32_t i;
+    if (!index || !name || !out || capacity == 0U || (uint32_t)role < 5U ||
+        (uint32_t)role >= 15U) return -1;
+    if (gguf_append_name(name, capacity, &position, "blk." ) != 0) return -2;
+    do {
+        digits[count++] = layer % 10U;
+        layer /= 10U;
+    } while (layer != 0U && count < 10U);
+    if (layer != 0U) return -2;
+    for (i = count; i > 0U; i--) {
+        if (position + 1U >= capacity) return -2;
+        name[position++] = (char)('0' + digits[i - 1U]);
+    }
+    if (position + 1U >= capacity) return -2;
+    name[position++] = '.';
+    if (gguf_append_name(name, capacity, &position, suffixes[(uint32_t)role - 5U]) != 0) return -2;
+    if (position >= capacity) return -2;
+    name[position] = '\0';
+    return gpt2_gguf_index_find(index, name, out);
 }

--- a/kernel/llm/gpt2_gguf.h
+++ b/kernel/llm/gpt2_gguf.h
@@ -48,7 +48,17 @@ typedef enum {
     GPT2_GGUF_ROLE_POSITION_EMBEDDING = 1U,
     GPT2_GGUF_ROLE_OUTPUT_NORM_WEIGHT = 2U,
     GPT2_GGUF_ROLE_OUTPUT_NORM_BIAS = 3U,
-    GPT2_GGUF_ROLE_OUTPUT_WEIGHT = 4U
+    GPT2_GGUF_ROLE_OUTPUT_WEIGHT = 4U,
+    GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT = 5U,
+    GPT2_GGUF_ROLE_LAYER_ATTN_NORM_BIAS = 6U,
+    GPT2_GGUF_ROLE_LAYER_ATTN_QKV_WEIGHT = 7U,
+    GPT2_GGUF_ROLE_LAYER_ATTN_QKV_BIAS = 8U,
+    GPT2_GGUF_ROLE_LAYER_ATTN_OUTPUT_WEIGHT = 9U,
+    GPT2_GGUF_ROLE_LAYER_ATTN_OUTPUT_BIAS = 10U,
+    GPT2_GGUF_ROLE_LAYER_FFN_NORM_WEIGHT = 11U,
+    GPT2_GGUF_ROLE_LAYER_FFN_NORM_BIAS = 12U,
+    GPT2_GGUF_ROLE_LAYER_FFN_UP_WEIGHT = 13U,
+    GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT = 14U
 } gpt2_gguf_role_t;
 
 typedef struct {
@@ -95,5 +105,9 @@ int gpt2_gguf_index_find(const gpt2_gguf_index_t* index, const char* name,
 /* Maps the stable GPT-2 GGUF names to semantic model roles. */
 int gpt2_gguf_map_role(const gpt2_gguf_index_t* index, gpt2_gguf_role_t role,
                        gpt2_gguf_tensor_t* out);
+/* Construit le nom GGUF d’une couche dans le buffer fourni puis la résout. */
+int gpt2_gguf_map_layer_role(const gpt2_gguf_index_t* index, uint32_t layer,
+                             gpt2_gguf_role_t role, char* name, uint32_t capacity,
+                             gpt2_gguf_tensor_t* out);
 
 #endif

--- a/tests/unit/kernel/test_gpt2_gguf.c
+++ b/tests/unit/kernel/test_gpt2_gguf.c
@@ -91,21 +91,22 @@ static uint32_t make_small_tensor(uint32_t type, uint64_t data_offset) {
 static uint32_t make_role_tensors(void) {
     static const char* const names[] = {
         "token_embd.weight", "position_embd.weight", "output_norm.weight",
-        "output_norm.bias", "output.weight"
+        "output_norm.bias", "output.weight",
+        "blk.0.attn_norm.weight", "blk.0.attn_qkv.weight"
     };
     uint32_t i;
     uint32_t padded;
     reset_blob();
     put_u32(GPT2_GGUF_MAGIC);
     put_u32(GPT2_GGUF_VERSION);
-    put_u64(5U);
+    put_u64(7U);
     put_u64(2U);
     put_metadata_string("general.architecture", "gpt2");
     put_metadata_u32("general.alignment", 32U);
-    for (i = 0U; i < 5U; i++) {
+    for (i = 0U; i < 7U; i++) {
         put_tensor(names[i], 1U, GPT2_QK_K, 0U, GPT2_GGUF_TENSOR_Q4_K, (uint64_t)(i * 160U));
     }
-    padded = 1280U;
+    padded = 2048U;
     while (cursor < padded) blob[cursor++] = 0U;
     return cursor;
 }
@@ -159,7 +160,8 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
     gpt2_gguf_tensor_t tensor;
     uint32_t size = make_role_tensors();
     TEST_ASSERT_EQUAL(0, gpt2_gguf_build_index(blob, size, &index));
-    TEST_ASSERT_EQUAL(5, index.tensor_count);
+    char name[40];
+    TEST_ASSERT_EQUAL(7, index.tensor_count);
     TEST_ASSERT_EQUAL(0, gpt2_gguf_index_find(&index, "output.weight", &tensor));
     TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
     TEST_ASSERT_EQUAL(4 * 160, (int)tensor.data_offset);
@@ -169,6 +171,12 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_OUTPUT_NORM_BIAS, &tensor));
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));
     TEST_ASSERT_EQUAL(-1, gpt2_gguf_map_role(&index, (gpt2_gguf_role_t)99, &tensor));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_map_layer_role(&index, 0U, GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT, name, sizeof(name), &tensor));
+    TEST_ASSERT_EQUAL_STRING("blk.0.attn_norm.weight", name);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_map_layer_role(&index, 0U, GPT2_GGUF_ROLE_LAYER_ATTN_QKV_WEIGHT, name, sizeof(name), &tensor));
+    TEST_ASSERT_EQUAL_STRING("blk.0.attn_qkv.weight", name);
+    TEST_ASSERT_EQUAL(-8, gpt2_gguf_map_layer_role(&index, 1U, GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT, name, sizeof(name), &tensor));
+    TEST_ASSERT_EQUAL(-2, gpt2_gguf_map_layer_role(&index, 0U, GPT2_GGUF_ROLE_LAYER_ATTN_QKV_WEIGHT, name, 8U, &tensor));
 }
 
 static void test_rejects_non_gpt2_architecture(void) {


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_map_layer_role` sans allocation dynamique;
- couvre `attn_norm`, `attn_qkv`, `attn_output`, `ffn_norm`, `ffn_up` et `ffn_down`;
- construit `blk.<layer>.<suffix>` dans un buffer caller-owned;
- teste deux rôles de couche, couche absente et buffer trop petit;
- conserve les cinq rôles globaux et documente les limites avant forward.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot ne branche pas encore les matrices à un forward GPT-2 complet.