### PR TITLE
Lot 82: descripteur caller-owned de couche GPT-2

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -252,3 +252,6 @@ Le lot 80 ajoute une preuve différentielle de sélection disque dans la fixture
 
 
 Le lot 81 étend le mapping GGUF aux rôles répétés des blocs GPT-2 via `gpt2_gguf_map_layer_role`. L’API construit dans un buffer caller-owned les noms `blk.<layer>.attn_norm`, `attn_qkv`, `attn_output`, `ffn_norm`, `ffn_up` et `ffn_down`, avec poids et biais lorsque la convention est définie, puis résout le tenseur dans l’index sans allocation dynamique. La fixture vérifie deux noms de couche, une couche absente et un buffer trop petit. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. Ce mapping ne branche pas encore les matrices à un forward GPT-2 réel.
+
+
+Le lot 82 ajoute `gpt2_gguf_layer_t` et `gpt2_gguf_map_layer`, qui regroupent les dix descripteurs d’un bloc GPT-2 dans une structure caller-owned et renseignent le masque `present_mask = 0x3FF`. Le buffer de nom est réutilisé séquentiellement, aucune allocation noyau n’est introduite, et une couche absente est rejetée. La fixture contient les quinze tenseurs globaux et de couche; `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. Le descripteur ne réalise pas encore le forward GPT-2 ni la validation sémantique des dimensions par matrice.

--- a/docs/mohhos_foundation_increment_82_gpt2_layer_descriptor.md
+++ b/docs/mohhos_foundation_increment_82_gpt2_layer_descriptor.md
@@ -1,0 +1,33 @@
+# MOHHOS Foundation — Incrément 82 : descripteur complet de couche GPT-2
+
+**État :** implémenté sur la branche de travail du lot 82.
+
+## Objectif
+
+Le lot 81 savait résoudre individuellement les dix rôles d’un bloc Transformer, mais le futur forward devait encore répéter ces résolutions et gérer lui-même leur présence. Le lot 82 introduit `gpt2_gguf_layer_t`, une structure caller-owned qui regroupe les dix descripteurs de tenseurs d’une couche, son index de couche et un masque de présence.
+
+`gpt2_gguf_map_layer` réutilise le buffer de nom fourni par l’appelant, appelle la résolution bornée de chaque rôle et remplit le descripteur sans allocation dynamique. Une résolution réussie positionne les dix bits du masque `present_mask` à `0x3FF`; une couche absente ou un buffer invalide est rejeté sans exposer de pointeur non vérifié.
+
+## Contrat
+
+| Élément | Contrat |
+| --- | --- |
+| descripteurs | 10 tenseurs par bloc |
+| familles | attention, normalisations et MLP |
+| stockage | structure caller-owned |
+| buffer de noms | caller-owned, réutilisé séquentiellement |
+| masque complet | `0x3FF` |
+| allocation noyau | aucune |
+| erreur couche absente | `-8` via l’index |
+
+Les cinq rôles globaux historiques demeurent inchangés. Les rôles de couche restent basés sur les noms GGUF `blk.<layer>.*` et conservent les contrôles de capacité du lot 81.
+
+## Tests
+
+La fixture GGUF contient les cinq tenseurs globaux et les dix noms de couche du bloc zéro. Le test vérifie que `gpt2_gguf_map_layer` remplit les dix entrées et le masque `0x3FF`, que l’index de couche vaut zéro et qu’une couche un absente est rejetée. Les tests de nom exact et de buffer trop petit du lot 81 restent actifs.
+
+La suite `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**. Les kernels FAT16, GGUF, Q-K et les scénarios de bornes restent verts.
+
+## Limites et suite
+
+Le descripteur ne valide pas encore les dimensions sémantiques propres à chaque matrice, le nombre de couches du modèle ou la compatibilité des types entre matrices. Il ne charge pas le checkpoint complet et n’exécute pas le forward. La prochaine étape peut utiliser ce descripteur pour construire un contexte de forward caller-owned, en conservant la lecture paginée FAT16 et les contrôles de débordement.

--- a/kernel/llm/gpt2_gguf.c
+++ b/kernel/llm/gpt2_gguf.c
@@ -461,3 +461,20 @@ int gpt2_gguf_map_layer_role(const gpt2_gguf_index_t* index, uint32_t layer,
     name[position] = '\0';
     return gpt2_gguf_index_find(index, name, out);
 }
+
+int gpt2_gguf_map_layer(const gpt2_gguf_index_t* index, uint32_t layer,
+                        char* name, uint32_t capacity, gpt2_gguf_layer_t* out) {
+    uint32_t i;
+    int status;
+    if (!index || !name || !out || capacity == 0U) return -1;
+    out->layer_index = layer;
+    out->present_mask = 0U;
+    for (i = 0U; i < 10U; i++) {
+        status = gpt2_gguf_map_layer_role(index, layer,
+            (gpt2_gguf_role_t)(GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT + i),
+            name, capacity, &out->tensors[i]);
+        if (status != 0) return status;
+        out->present_mask |= (1U << i);
+    }
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf.h
+++ b/kernel/llm/gpt2_gguf.h
@@ -78,6 +78,12 @@ typedef struct {
 } gpt2_gguf_info_t;
 
 typedef struct {
+    gpt2_gguf_tensor_t tensors[10];
+    uint32_t layer_index;
+    uint32_t present_mask;
+} gpt2_gguf_layer_t;
+
+typedef struct {
     gpt2_gguf_info_t info;
     const uint8_t* blob;
     uint32_t blob_size;
@@ -109,5 +115,8 @@ int gpt2_gguf_map_role(const gpt2_gguf_index_t* index, gpt2_gguf_role_t role,
 int gpt2_gguf_map_layer_role(const gpt2_gguf_index_t* index, uint32_t layer,
                              gpt2_gguf_role_t role, char* name, uint32_t capacity,
                              gpt2_gguf_tensor_t* out);
+/* Résout les dix rôles d’une couche dans un descripteur caller-owned. */
+int gpt2_gguf_map_layer(const gpt2_gguf_index_t* index, uint32_t layer,
+                        char* name, uint32_t capacity, gpt2_gguf_layer_t* out);
 
 #endif

--- a/tests/unit/kernel/test_gpt2_gguf.c
+++ b/tests/unit/kernel/test_gpt2_gguf.c
@@ -92,21 +92,25 @@ static uint32_t make_role_tensors(void) {
     static const char* const names[] = {
         "token_embd.weight", "position_embd.weight", "output_norm.weight",
         "output_norm.bias", "output.weight",
-        "blk.0.attn_norm.weight", "blk.0.attn_qkv.weight"
+        "blk.0.attn_norm.weight", "blk.0.attn_norm.bias",
+        "blk.0.attn_qkv.weight", "blk.0.attn_qkv.bias",
+        "blk.0.attn_output.weight", "blk.0.attn_output.bias",
+        "blk.0.ffn_norm.weight", "blk.0.ffn_norm.bias",
+        "blk.0.ffn_up.weight", "blk.0.ffn_down.weight"
     };
     uint32_t i;
     uint32_t padded;
     reset_blob();
     put_u32(GPT2_GGUF_MAGIC);
     put_u32(GPT2_GGUF_VERSION);
-    put_u64(7U);
+    put_u64(15U);
     put_u64(2U);
     put_metadata_string("general.architecture", "gpt2");
     put_metadata_u32("general.alignment", 32U);
-    for (i = 0U; i < 7U; i++) {
+    for (i = 0U; i < 15U; i++) {
         put_tensor(names[i], 1U, GPT2_QK_K, 0U, GPT2_GGUF_TENSOR_Q4_K, (uint64_t)(i * 160U));
     }
-    padded = 2048U;
+    padded = 4096U;
     while (cursor < padded) blob[cursor++] = 0U;
     return cursor;
 }
@@ -161,7 +165,7 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
     uint32_t size = make_role_tensors();
     TEST_ASSERT_EQUAL(0, gpt2_gguf_build_index(blob, size, &index));
     char name[40];
-    TEST_ASSERT_EQUAL(7, index.tensor_count);
+    TEST_ASSERT_EQUAL(15, index.tensor_count);
     TEST_ASSERT_EQUAL(0, gpt2_gguf_index_find(&index, "output.weight", &tensor));
     TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
     TEST_ASSERT_EQUAL(4 * 160, (int)tensor.data_offset);
@@ -177,6 +181,13 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
     TEST_ASSERT_EQUAL_STRING("blk.0.attn_qkv.weight", name);
     TEST_ASSERT_EQUAL(-8, gpt2_gguf_map_layer_role(&index, 1U, GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT, name, sizeof(name), &tensor));
     TEST_ASSERT_EQUAL(-2, gpt2_gguf_map_layer_role(&index, 0U, GPT2_GGUF_ROLE_LAYER_ATTN_QKV_WEIGHT, name, 8U, &tensor));
+    {
+        gpt2_gguf_layer_t layer;
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_map_layer(&index, 0U, name, sizeof(name), &layer));
+        TEST_ASSERT_EQUAL(0x3FF, (int)layer.present_mask);
+        TEST_ASSERT_EQUAL(0, (int)layer.layer_index);
+        TEST_ASSERT_EQUAL(-8, gpt2_gguf_map_layer(&index, 1U, name, sizeof(name), &layer));
+    }
 }
 
 static void test_rejects_non_gpt2_architecture(void) {


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_layer_t` avec dix descripteurs de couche;
- ajoute `gpt2_gguf_map_layer` et le masque complet `present_mask = 0x3FF`;
- réutilise un buffer de nom caller-owned sans allocation dynamique;
- étend la fixture à quinze tenseurs et vérifie la couche absente;
- documente le contrat et les limites avant forward.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le lot prépare le forward mais ne l’exécute pas encore.