### PR TITLE
Lot 83: contexte de forward GGUF caller-owned

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -255,3 +255,6 @@ Le lot 81 étend le mapping GGUF aux rôles répétés des blocs GPT-2 via `gpt2
 
 
 Le lot 82 ajoute `gpt2_gguf_layer_t` et `gpt2_gguf_map_layer`, qui regroupent les dix descripteurs d’un bloc GPT-2 dans une structure caller-owned et renseignent le masque `present_mask = 0x3FF`. Le buffer de nom est réutilisé séquentiellement, aucune allocation noyau n’est introduite, et une couche absente est rejetée. La fixture contient les quinze tenseurs globaux et de couche; `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. Le descripteur ne réalise pas encore le forward GPT-2 ni la validation sémantique des dimensions par matrice.
+
+
+Le lot 83 ajoute `gpt2_gguf_forward_context_t` et `gpt2_gguf_forward_context_init`. Le contexte conserve une référence vers le modèle GGUF, le descripteur complet d’une couche, un scratch caller-owned, `channels` et `position`; il refuse les pointeurs, capacités ou dimensions invalides sans allocation dynamique. Les tests FAT16 vérifient les gardes de contexte et la suite reste à **265 tests réussis, 0 échec et 0 test ignoré**. Aucune attention, normalisation, MLP ou génération autoregressive n’est encore exécutée par ce contexte.

--- a/docs/mohhos_foundation_increment_83_gpt2_forward_context.md
+++ b/docs/mohhos_foundation_increment_83_gpt2_forward_context.md
@@ -1,0 +1,28 @@
+# MOHHOS Foundation — Incrément 83 : contexte de forward GGUF caller-owned
+
+**État :** implémenté sur la branche de travail du lot 83.
+
+## Objectif
+
+Les lots 81 et 82 fournissaient les rôles et le descripteur complet d’une couche GPT-2. Le lot 83 introduit `gpt2_gguf_forward_context_t`, un contexte minimal destiné au futur forward quantifié. Il conserve une référence vers le modèle indexé, le descripteur de couche, un scratch caller-owned, la dimension de canal et la position séquentielle.
+
+`gpt2_gguf_forward_context_init` valide les pointeurs, les capacités, la dimension de canal et l’index GGUF, puis résout la couche complète sans copier le checkpoint et sans allocation dynamique. Le contexte ne prend possession d’aucun buffer; sa durée de vie dépend des objets fournis par l’appelant.
+
+## Contrat
+
+| Élément | Contrat |
+| --- | --- |
+| modèle | référence vers `gpt2_gguf_loaded_model_t` |
+| couche | `gpt2_gguf_layer_t` caller-owned dans le contexte |
+| scratch | pointeur et capacité fournis par l’appelant |
+| état séquentiel | `position` bornée par l’appelant, initialisée explicitement |
+| dimensions | `channels` non nul |
+| allocation noyau | aucune |
+
+## Tests
+
+Le test FAT16 conserve le chargement GGUF et vérifie que le contexte refuse les canaux nuls ainsi qu’un scratch nul avant toute lecture de bloc. Les tests de mapping et de descripteur des lots 81 et 82 restent actifs. La suite `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Limites et suite
+
+Ce contexte prépare le branchement d’une opération de couche, mais n’exécute encore ni attention, ni normalisation, ni MLP, ni lecture paginée des matrices depuis FAT16. La prochaine étape devra consommer `gpt2_gguf_layer_t` avec des dimensions validées, des scratch séparés et une primitive de produit quantifié bornée.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -156,3 +156,22 @@ int gpt2_gguf_dot_quant_row_fat16(const fat16_volume_t* volume, const char* file
     *out_dot = total;
     return 0;
 }
+
+
+int gpt2_gguf_forward_context_init(const gpt2_gguf_loaded_model_t* model,
+                                   uint32_t layer_index, uint32_t channels,
+                                   uint32_t position, char* name, uint32_t name_capacity,
+                                   uint8_t* scratch, uint32_t scratch_capacity,
+                                   gpt2_gguf_forward_context_t* out) {
+    int status;
+    if (!model || !model->index.info.is_valid || channels == 0U || !name ||
+        name_capacity == 0U || !scratch || scratch_capacity == 0U || !out) return -1;
+    status = gpt2_gguf_map_layer(&model->index, layer_index, name, name_capacity, &out->layer);
+    if (status != 0) return status;
+    out->model = model;
+    out->scratch = scratch;
+    out->scratch_capacity = scratch_capacity;
+    out->channels = channels;
+    out->position = position;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -10,6 +10,22 @@ typedef struct {
     uint32_t bytes_loaded;
 } gpt2_gguf_loaded_model_t;
 
+typedef struct {
+    const gpt2_gguf_loaded_model_t* model;
+    gpt2_gguf_layer_t layer;
+    uint8_t* scratch;
+    uint32_t scratch_capacity;
+    uint32_t channels;
+    uint32_t position;
+} gpt2_gguf_forward_context_t;
+
+/* Prépare une couche pour le futur forward sans prendre possession des buffers. */
+int gpt2_gguf_forward_context_init(const gpt2_gguf_loaded_model_t* model,
+                                   uint32_t layer_index, uint32_t channels,
+                                   uint32_t position, char* name, uint32_t name_capacity,
+                                   uint8_t* scratch, uint32_t scratch_capacity,
+                                   gpt2_gguf_forward_context_t* out);
+
 /* Lit un fichier FAT16 8.3 dans le buffer fourni puis indexe son GGUF. */
 int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,
                          uint8_t* buffer, uint32_t capacity,

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -109,6 +109,17 @@ static void test_loads_gpt2_from_fat16(void) {
     make_gguf_file();
     TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
     TEST_ASSERT_EQUAL(0, gpt2_gguf_load_fat16(&volume, "gpt2.ggu", buffer, sizeof(buffer), &model));
+    {
+        gpt2_gguf_forward_context_t context;
+        uint8_t context_scratch[GPT2_Q4_K_BLOCK_BYTES];
+        char context_name[40];
+        TEST_ASSERT_EQUAL(-1, gpt2_gguf_forward_context_init(&model, 0U, 0U, 0U,
+                                                               context_name, sizeof(context_name),
+                                                               context_scratch, sizeof(context_scratch), &context));
+        TEST_ASSERT_EQUAL(-1, gpt2_gguf_forward_context_init(&model, 0U, 256U, 0U,
+                                                               context_name, sizeof(context_name),
+                                                               0, sizeof(context_scratch), &context));
+    }
     TEST_ASSERT_EQUAL(480, (int)model.bytes_loaded);
     TEST_ASSERT_EQUAL(1, model.index.tensor_count);
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&model.index, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_forward_context_t`;
- initialise une couche complète depuis l’index GGUF sans charger le checkpoint;
- conserve scratch, channels et position fournis par l’appelant;
- refuse les pointeurs, capacités et dimensions invalides;
- documente le contrat et les limites avant attention/MLP.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le contexte prépare le forward quantifié mais n’exécute pas encore attention, normalisation ou MLP.