### PR TITLE
Lot 84: accès borné aux rôles de couche GPT-2

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -258,3 +258,6 @@ Le lot 82 ajoute `gpt2_gguf_layer_t` et `gpt2_gguf_map_layer`, qui regroupent le
 
 
 Le lot 83 ajoute `gpt2_gguf_forward_context_t` et `gpt2_gguf_forward_context_init`. Le contexte conserve une référence vers le modèle GGUF, le descripteur complet d’une couche, un scratch caller-owned, `channels` et `position`; il refuse les pointeurs, capacités ou dimensions invalides sans allocation dynamique. Les tests FAT16 vérifient les gardes de contexte et la suite reste à **265 tests réussis, 0 échec et 0 test ignoré**. Aucune attention, normalisation, MLP ou génération autoregressive n’est encore exécutée par ce contexte.
+
+
+Le lot 84 ajoute `gpt2_gguf_layer_get`, un accès borné aux dix rôles déjà résolus dans `gpt2_gguf_layer_t`. Les rôles globaux, rôles hors intervalle et bits absents du masque sont refusés; le descripteur retourné reste caller-owned. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. La validation dimensionnelle sémantique à partir de `channels`, `num_heads` et `num_layers` reste à réaliser avant le branchement aux kernels quantifiés.

--- a/docs/mohhos_foundation_increment_84_layer_role_accessor.md
+++ b/docs/mohhos_foundation_increment_84_layer_role_accessor.md
@@ -1,0 +1,29 @@
+# MOHHOS Foundation — Incrément 84 : accès borné aux rôles de couche
+
+**État :** implémenté sur la branche de travail du lot 84.
+
+## Objectif
+
+Le lot 83 prépare un contexte de forward contenant un `gpt2_gguf_layer_t`. Le lot 84 ajoute `gpt2_gguf_layer_get`, un accesseur borné qui transforme un rôle GPT-2 de couche en entrée du tableau, exige le bit correspondant dans `present_mask` et copie le descripteur vers un buffer caller-owned.
+
+L’accesseur refuse les rôles globaux, les rôles hors de l’intervalle des dix familles de couche et les entrées absentes. Cette étape sépare la résolution GGUF du futur code d’exécution et évite au forward de manipuler directement un index de tableau non contrôlé.
+
+## Contrat
+
+| Cas | Résultat |
+| --- | --- |
+| rôle de couche présent | copie du descripteur, retour `0` |
+| rôle global | retour `-1` |
+| rôle hors intervalle | retour `-1` |
+| bit absent du masque | retour `-8` |
+| pointeur nul | retour `-1` |
+
+La validation dimensionnelle sémantique complète reste différée: les fixtures actuelles couvrent surtout le raccord d’indexation et les bornes, tandis que le contrat legacy fournit les dimensions attendues pour un prochain lot.
+
+## Validation
+
+Le test GGUF vérifie l’accès au rôle `ffn_down`, le rejet d’un rôle global, le rejet d’un masque vide et le rejet d’une couche absente. `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**. Aucun buffer global ou allocation dynamique n’est introduit.
+
+## Suite
+
+Le prochain incrément peut valider les formes et types par rôle à partir de `gpt2_config_t` (`channels`, `num_heads`, `num_layers`) avant de connecter les lectures paginées FAT16 aux kernels quantifiés.

--- a/kernel/llm/gpt2_gguf.c
+++ b/kernel/llm/gpt2_gguf.c
@@ -478,3 +478,15 @@ int gpt2_gguf_map_layer(const gpt2_gguf_index_t* index, uint32_t layer,
     }
     return 0;
 }
+
+
+int gpt2_gguf_layer_get(const gpt2_gguf_layer_t* layer, gpt2_gguf_role_t role,
+                        gpt2_gguf_tensor_t* out) {
+    uint32_t index;
+    if (!layer || !out || (uint32_t)role < GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT ||
+        (uint32_t)role > GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT) return -1;
+    index = (uint32_t)role - GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT;
+    if ((layer->present_mask & (1U << index)) == 0U) return -8;
+    *out = layer->tensors[index];
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf.h
+++ b/kernel/llm/gpt2_gguf.h
@@ -118,5 +118,8 @@ int gpt2_gguf_map_layer_role(const gpt2_gguf_index_t* index, uint32_t layer,
 /* Résout les dix rôles d’une couche dans un descripteur caller-owned. */
 int gpt2_gguf_map_layer(const gpt2_gguf_index_t* index, uint32_t layer,
                         char* name, uint32_t capacity, gpt2_gguf_layer_t* out);
+/* Retourne une vue bornée d’un rôle déjà résolu dans une couche. */
+int gpt2_gguf_layer_get(const gpt2_gguf_layer_t* layer, gpt2_gguf_role_t role,
+                        gpt2_gguf_tensor_t* out);
 
 #endif

--- a/tests/unit/kernel/test_gpt2_gguf.c
+++ b/tests/unit/kernel/test_gpt2_gguf.c
@@ -186,6 +186,10 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
         TEST_ASSERT_EQUAL(0, gpt2_gguf_map_layer(&index, 0U, name, sizeof(name), &layer));
         TEST_ASSERT_EQUAL(0x3FF, (int)layer.present_mask);
         TEST_ASSERT_EQUAL(0, (int)layer.layer_index);
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT, &tensor));
+        TEST_ASSERT_EQUAL(-1, gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));
+        layer.present_mask = 0U;
+        TEST_ASSERT_EQUAL(-8, gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT, &tensor));
         TEST_ASSERT_EQUAL(-8, gpt2_gguf_map_layer(&index, 1U, name, sizeof(name), &layer));
     }
 }


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_layer_get`;
- vérifie l’intervalle des dix rôles et le `present_mask`;
- rejette les rôles globaux, rôles absents et pointeurs invalides;
- conserve l’architecture caller-owned et les API des lots 81–83;
- documente la limite avant validation dimensionnelle sémantique.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

La validation stricte des formes GPT-2 par `channels/heads/layers` reste le prochain incrément.