### PR TITLE
Lot 85: validation des formes de couche GGUF

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -261,3 +261,6 @@ Le lot 83 ajoute `gpt2_gguf_forward_context_t` et `gpt2_gguf_forward_context_ini
 
 
 Le lot 84 ajoute `gpt2_gguf_layer_get`, un accès borné aux dix rôles déjà résolus dans `gpt2_gguf_layer_t`. Les rôles globaux, rôles hors intervalle et bits absents du masque sont refusés; le descripteur retourné reste caller-owned. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. La validation dimensionnelle sémantique à partir de `channels`, `num_heads` et `num_layers` reste à réaliser avant le branchement aux kernels quantifiés.
+
+
+Le lot 85 ajoute `gpt2_gguf_validate_layer`, qui exige les dix rôles présents, des canaux multiples de `GPT2_QK_K`, des rangs 1/2 non vides et des tailles de données valides; les tenseurs Q3_K/Q4_K/Q6_K doivent avoir une première dimension alignée sur `GPT2_QK_K`. La fonction est caller-owned, sans lecture de poids ni allocation. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. Les relations d’axes complètes QKV/MLP en matrices 2D restent le prochain incrément.

--- a/docs/mohhos_foundation_increment_85_layer_shape_validation.md
+++ b/docs/mohhos_foundation_increment_85_layer_shape_validation.md
@@ -1,0 +1,28 @@
+# MOHHOS Foundation — Incrément 85 : validation des formes de couche GGUF
+
+**État :** implémenté sur la branche de travail du lot 85.
+
+## Objectif
+
+Le lot 84 sécurisait l’accès aux rôles d’une couche. Le lot 85 ajoute `gpt2_gguf_validate_layer`, qui vérifie les invariants nécessaires avant d’envoyer une couche vers les kernels quantifiés: les dix rôles doivent être présents, `channels` doit être non nul et multiple de `GPT2_QK_K`, chaque tenseur doit avoir un rang 1 ou 2, une première dimension non nulle et une taille de données non nulle.
+
+Pour les tenseurs Q3_K, Q4_K et Q6_K, la première dimension doit également être alignée sur `GPT2_QK_K`. La fonction reste purement structurelle et caller-owned; elle ne lit pas de données de poids, ne charge pas le checkpoint et n’alloue aucune mémoire.
+
+## Contrat d’erreur
+
+| Condition | Retour |
+| --- | ---: |
+| couche ou pointeur invalide | `-1` |
+| masque incomplet | `-8` |
+| canaux non alignés, rang ou forme invalides | `-9` |
+| couche complète et structure valide | `0` |
+
+Cette validation ne prétend pas encore prouver l’ordre sémantique exact des axes pour QKV, attention et MLP. Cette étape nécessite une fixture GGUF à formes 2D complètes et sera traitée avant le branchement du forward.
+
+## Tests et non-régression
+
+Le test GGUF accepte une couche Q4_K de 256 éléments, rejette `channels = 255`, rejette une forme quantifiée de 255 éléments et rejette un masque absent. La suite `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**, avec les tests de bornes GGUF toujours verts.
+
+## Suite
+
+Le prochain lot pourra ajouter une fixture de matrices 2D GPT-2 et vérifier les relations `channels`, `3 × channels` et `4 × channels` avant de connecter la lecture FAT16 paginée au calcul quantifié.

--- a/kernel/llm/gpt2_gguf.c
+++ b/kernel/llm/gpt2_gguf.c
@@ -490,3 +490,21 @@ int gpt2_gguf_layer_get(const gpt2_gguf_layer_t* layer, gpt2_gguf_role_t role,
     *out = layer->tensors[index];
     return 0;
 }
+
+
+int gpt2_gguf_validate_layer(const gpt2_gguf_layer_t* layer, uint32_t channels) {
+    uint32_t i;
+    if (!layer) return -1;
+    if (layer->present_mask != 0x3FFU) return -8;
+    if (channels == 0U || (channels % GPT2_QK_K) != 0U) return -9;
+    for (i = 0U; i < 10U; i++) {
+        const gpt2_gguf_tensor_t* tensor = &layer->tensors[i];
+        if (tensor->dimensions == 0U || tensor->dimensions > 2U ||
+            tensor->shape[0] == 0U || tensor->byte_size == 0U) return -9;
+        if ((tensor->type == GPT2_GGUF_TENSOR_Q3_K ||
+             tensor->type == GPT2_GGUF_TENSOR_Q4_K ||
+             tensor->type == GPT2_GGUF_TENSOR_Q6_K) &&
+            (tensor->shape[0] % GPT2_QK_K) != 0U) return -9;
+    }
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf.h
+++ b/kernel/llm/gpt2_gguf.h
@@ -121,5 +121,7 @@ int gpt2_gguf_map_layer(const gpt2_gguf_index_t* index, uint32_t layer,
 /* Retourne une vue bornée d’un rôle déjà résolu dans une couche. */
 int gpt2_gguf_layer_get(const gpt2_gguf_layer_t* layer, gpt2_gguf_role_t role,
                         gpt2_gguf_tensor_t* out);
+/* Valide les invariants de forme nécessaires à une couche quantifiée. */
+int gpt2_gguf_validate_layer(const gpt2_gguf_layer_t* layer, uint32_t channels);
 
 #endif

--- a/tests/unit/kernel/test_gpt2_gguf.c
+++ b/tests/unit/kernel/test_gpt2_gguf.c
@@ -188,8 +188,14 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
         TEST_ASSERT_EQUAL(0, (int)layer.layer_index);
         TEST_ASSERT_EQUAL(0, gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT, &tensor));
         TEST_ASSERT_EQUAL(-1, gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_validate_layer(&layer, GPT2_QK_K));
+        TEST_ASSERT_EQUAL(-9, gpt2_gguf_validate_layer(&layer, GPT2_QK_K - 1U));
+        layer.tensors[0].shape[0] = GPT2_QK_K - 1U;
+        TEST_ASSERT_EQUAL(-9, gpt2_gguf_validate_layer(&layer, GPT2_QK_K));
+        layer.tensors[0].shape[0] = GPT2_QK_K;
         layer.present_mask = 0U;
         TEST_ASSERT_EQUAL(-8, gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT, &tensor));
+        TEST_ASSERT_EQUAL(-8, gpt2_gguf_validate_layer(&layer, GPT2_QK_K));
         TEST_ASSERT_EQUAL(-8, gpt2_gguf_map_layer(&index, 1U, name, sizeof(name), &layer));
     }
 }


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_validate_layer`;
- exige les dix rôles présents et des canaux multiples de `GPT2_QK_K`;
- valide rangs, formes, tailles et alignement des tenseurs Q3_K/Q4_K/Q6_K;
- ajoute les cas de rejet dans la fixture GGUF;
- documente les limites avant les matrices 2D complètes.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Les relations exactes des axes QKV/MLP restent le prochain incrément.