### PR TITLE
Lot 87: validation des tailles de stockage quantifiées

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -267,3 +267,6 @@ Le lot 85 ajoute `gpt2_gguf_validate_layer`, qui exige les dix rôles présents,
 
 
 Le lot 86 ajoute `gpt2_gguf_validate_gpt2_layer`, qui applique les formes du forward legacy: biais et normalisations `[C]`, QKV `[C,3C]`, projection attention `[C,C]`, expansion MLP `[C,4C]` et projection MLP `[4C,C]`. Une fixture synthétique couvre les formes 2D et rejette un axe QKV incorrect. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. La correspondance entre formes et tailles de données quantifiées FAT16 reste à vérifier au prochain incrément.
+
+
+Le lot 87 ajoute `gpt2_gguf_validate_tensor_size`, qui recalcule et compare `byte_size` pour F32/F16 et les super-blocs Q3_K (110 octets), Q4_K (144 octets) et Q6_K (210 octets) sur 256 valeurs. Les produits d’axes, les dépassements et les formes non alignées sont rejetés sans allocation ni lecture de blob. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.

--- a/docs/mohhos_foundation_increment_87_quantized_storage_sizes.md
+++ b/docs/mohhos_foundation_increment_87_quantized_storage_sizes.md
@@ -1,0 +1,31 @@
+# MOHHOS Foundation — Incrément 87 : tailles de stockage quantifiées
+
+**État :** implémenté sur la branche de travail du lot 87.
+
+## Objectif
+
+Le lot 86 valide les axes 2D GPT-2. Le lot 87 ajoute `gpt2_gguf_validate_tensor_size`, qui recalcule `byte_size` à partir du produit des axes et du type GGUF avant toute lecture FAT16 ou tout appel de kernel quantifié.
+
+Les tailles de super-blocs sont celles utilisées par les kernels locaux:
+
+| Type | Valeurs par bloc | Octets par bloc |
+| --- | ---: | ---: |
+| Q3_K | 256 | 110 |
+| Q4_K | 256 | 144 |
+| Q6_K | 256 | 210 |
+
+Les tenseurs F32 et F16 utilisent respectivement quatre et deux octets par élément. Les produits d’axes sont contrôlés contre les dépassements 32 bits et les types inconnus sont rejetés.
+
+## Contrat
+
+La fonction retourne `0` uniquement si les axes sont non nuls, compatibles avec le type et si la taille calculée correspond exactement à `tensor->byte_size`. Une forme quantifiée non multiple de 256, une taille tronquée ou un produit trop grand retourne `-9`; un type non supporté retourne `-4`.
+
+La validation ne prend pas possession du tenseur, ne lit pas le blob et n’alloue aucune mémoire. Elle est donc utilisable avant `gpt2_gguf_read_tensor_fat16` ou les primitives `gpt2_gguf_dot_quant_*_fat16`.
+
+## Tests
+
+Le test GGUF vérifie un Q4_K nominal, une taille de données décrémentée et une forme de 255 éléments. Les tests de rangs, axes QKV/MLP et bornes des lots précédents restent actifs. `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Suite
+
+Le prochain incrément pourra intégrer cette vérification dans le contexte de forward et refuser automatiquement une matrice avant sa lecture paginée FAT16.

--- a/kernel/llm/gpt2_gguf.c
+++ b/kernel/llm/gpt2_gguf.c
@@ -534,3 +534,36 @@ int gpt2_gguf_validate_gpt2_layer(const gpt2_gguf_layer_t* layer, uint32_t chann
     t = &layer->tensors[9]; if (!gpt2_gguf_shape_is(t, 4U * channels, channels)) return -9;
     return 0;
 }
+
+
+int gpt2_gguf_validate_tensor_size(const gpt2_gguf_tensor_t* tensor) {
+    uint64_t elements = 1U;
+    uint64_t bytes;
+    uint32_t i;
+    uint32_t block_size = 1U;
+    uint32_t block_bytes = 0U;
+    if (!tensor || tensor->dimensions == 0U || tensor->dimensions > 4U) return -1;
+    for (i = 0U; i < tensor->dimensions; i++) {
+        uint64_t next;
+        if (tensor->shape[i] == 0U || tensor->shape[i] > 0xFFFFFFFFULL) return -9;
+        next = elements * tensor->shape[i];
+        if (next > 0xFFFFFFFFULL) return -9;
+        elements = next;
+    }
+    switch (tensor->type) {
+        case GPT2_GGUF_TENSOR_F32: block_bytes = 4U; break;
+        case GPT2_GGUF_TENSOR_F16: block_bytes = 2U; break;
+        case GPT2_GGUF_TENSOR_Q3_K: block_size = GPT2_QK_K; block_bytes = GPT2_Q3_K_BLOCK_BYTES; break;
+        case GPT2_GGUF_TENSOR_Q4_K: block_size = GPT2_QK_K; block_bytes = GPT2_Q4_K_BLOCK_BYTES; break;
+        case GPT2_GGUF_TENSOR_Q6_K: block_size = GPT2_QK_K; block_bytes = GPT2_Q6_K_BLOCK_BYTES; break;
+        default: return -4;
+    }
+    if (block_size != 1U) {
+        if ((elements & (block_size - 1U)) != 0U) return -9;
+        bytes = (elements >> 8U) * block_bytes;
+    } else {
+        bytes = elements * block_bytes;
+    }
+    if (bytes > 0xFFFFFFFFULL || tensor->byte_size != (uint32_t)bytes) return -9;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf.h
+++ b/kernel/llm/gpt2_gguf.h
@@ -125,5 +125,7 @@ int gpt2_gguf_layer_get(const gpt2_gguf_layer_t* layer, gpt2_gguf_role_t role,
 int gpt2_gguf_validate_layer(const gpt2_gguf_layer_t* layer, uint32_t channels);
 /* Valide les rangs et axes GPT-2 legacy: C, 3C et 4C. */
 int gpt2_gguf_validate_gpt2_layer(const gpt2_gguf_layer_t* layer, uint32_t channels);
+/* Vérifie que byte_size correspond au produit des axes et au type GGUF. */
+int gpt2_gguf_validate_tensor_size(const gpt2_gguf_tensor_t* tensor);
 
 #endif

--- a/tests/unit/kernel/test_gpt2_gguf.c
+++ b/tests/unit/kernel/test_gpt2_gguf.c
@@ -169,6 +169,12 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
     TEST_ASSERT_EQUAL(0, gpt2_gguf_index_find(&index, "output.weight", &tensor));
     TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
     TEST_ASSERT_EQUAL(4 * 160, (int)tensor.data_offset);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_validate_tensor_size(&tensor));
+    tensor.byte_size--;
+    TEST_ASSERT_EQUAL(-9, gpt2_gguf_validate_tensor_size(&tensor));
+    tensor.byte_size++;
+    tensor.shape[0] = GPT2_QK_K - 1U;
+    TEST_ASSERT_EQUAL(-9, gpt2_gguf_validate_tensor_size(&tensor));
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_TOKEN_EMBEDDING, &tensor));
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_POSITION_EMBEDDING, &tensor));
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&index, GPT2_GGUF_ROLE_OUTPUT_NORM_WEIGHT, &tensor));


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_validate_tensor_size`;
- recalcule `byte_size` pour F32/F16 et Q3_K/Q4_K/Q6_K;
- rejette les formes non multiples de 256, tailles tronquées et dépassements;
- conserve une implémentation compatible i386 freestanding sans `__udivdi3`;
- ajoute les tests nominal, tronqué et non aligné;
- documente les tailles de super-blocs.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le prochain lot pourra intégrer ce contrôle au contexte de forward avant lecture FAT16 paginée.