### PR TITLE
Lot 89: lecture de ligne quantifiée FAT16

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -273,3 +273,6 @@ Le lot 87 ajoute `gpt2_gguf_validate_tensor_size`, qui recalcule et compare `byt
 
 
 Le lot 88 ajoute `gpt2_gguf_validate_gpt2_layer_storage`, qui compose la validation des axes GPT-2 et la cohérence de `byte_size` des dix tenseurs. `gpt2_gguf_forward_context_init` appelle cette barrière après le mapping de couche; les matrices et vecteurs incohérents sont donc rejetés avant lecture FAT16. L’implémentation reste sans allocation et sans division 64 bits runtime. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+
+Le lot 89 ajoute `gpt2_gguf_read_quant_row_fat16`, qui lit une ligne Q3_K, Q4_K ou Q6_K depuis FAT16 dans un buffer caller-owned, avec contrôle de largeur, index, capacité, offsets et lecture partielle. Les marqueurs physiques Q4_K `0x11` et `0x77` sont vérifiés ligne par ligne; Q3_K, Q6_K et le buffer insuffisant sont également couverts. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.

--- a/docs/mohhos_foundation_increment_89_quantized_row_read.md
+++ b/docs/mohhos_foundation_increment_89_quantized_row_read.md
@@ -1,0 +1,30 @@
+# MOHHOS Foundation — Incrément 89 : lecture de ligne quantifiée FAT16
+
+**État :** implémenté sur la branche de travail du lot 89.
+
+## Objectif
+
+Le lot 89 ajoute `gpt2_gguf_read_quant_row_fat16`, une primitive de lecture brute d’une ligne quantifiée dans un buffer fourni par l’appelant. Elle complète les lectures de tenseur et de super-bloc sans charger une matrice complète en mémoire.
+
+La fonction accepte les tenseurs 1D ou 2D, interprète `shape[0]` comme largeur de ligne et `shape[1]` comme nombre de lignes lorsqu’il est présent. Elle calcule la taille d’une ligne selon le type Q3_K, Q4_K ou Q6_K, vérifie l’alignement sur 256 valeurs, contrôle l’index de ligne et la capacité caller-owned, puis délègue à `gpt2_gguf_read_tensor_fat16` pour la plage physique exacte.
+
+## Contrat
+
+| Condition | Résultat |
+| --- | --- |
+| Q3_K, Q4_K ou Q6_K valide | lecture exacte de la ligne |
+| largeur non multiple de 256 | `-7` |
+| ligne hors bornes ou overflow | `-9` |
+| buffer trop petit | `-6` |
+| type non quantifié supporté | `-4` |
+| lecture physique partielle | `-8` |
+
+Aucune allocation dynamique n’est utilisée. Le résultat est écrit uniquement dans le buffer de l’appelant et `out_read` est remis à zéro sur les erreurs après validation du pointeur.
+
+## Tests
+
+La fixture FAT16 vérifie les deux lignes Q4_K avec les marqueurs physiques `0x11` et `0x77`, puis couvre les variantes Q3_K et Q6_K ainsi qu’un buffer insuffisant. La non-régression `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Suite
+
+Le prochain lot peut utiliser cette primitive pour découpler la lecture d’une ligne de son calcul, puis connecter les lignes QKV et MLP aux kernels de produit quantifié déjà présents.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -177,3 +177,38 @@ int gpt2_gguf_forward_context_init(const gpt2_gguf_loaded_model_t* model,
     out->position = position;
     return 0;
 }
+
+
+int gpt2_gguf_read_quant_row_fat16(const fat16_volume_t* volume, const char* filename,
+                                   const gpt2_gguf_loaded_model_t* model,
+                                   const gpt2_gguf_tensor_t* tensor,
+                                   uint32_t row_index, uint8_t* buffer,
+                                   uint32_t capacity, uint32_t* out_read) {
+    uint64_t width;
+    uint64_t rows = 1U;
+    uint32_t block_bytes;
+    uint64_t row_bytes;
+    uint64_t row_offset;
+    int status;
+    if (out_read) *out_read = 0U;
+    if (!volume || !filename || !model || !tensor || !buffer || !out_read) return -1;
+    if (!model->index.info.is_valid || tensor->dimensions == 0U || tensor->dimensions > 2U) return -9;
+    width = tensor->shape[0];
+    if (tensor->dimensions == 2U) rows = tensor->shape[1];
+    if (width == 0U || width > 0xFFFFFFFFULL || rows == 0U || row_index >= rows) return -9;
+    if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) block_bytes = GPT2_Q3_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) block_bytes = GPT2_Q4_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q6_K) block_bytes = GPT2_Q6_K_BLOCK_BYTES;
+    else return -4;
+    if ((width % GPT2_QK_K) != 0U) return -7;
+    row_bytes = (width / GPT2_QK_K) * block_bytes;
+    row_offset = row_bytes * row_index;
+    if (row_bytes > 0xFFFFFFFFULL || row_offset > 0xFFFFFFFFULL) return -9;
+    if (capacity < (uint32_t)row_bytes) return -6;
+    status = gpt2_gguf_read_tensor_fat16(volume, filename, model, tensor,
+                                          (uint32_t)row_offset, buffer,
+                                          (uint32_t)row_bytes, out_read);
+    if (status != 0) return status;
+    if (*out_read != (uint32_t)row_bytes) return -8;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -63,5 +63,11 @@ int gpt2_gguf_dot_quant_row_fat16(const fat16_volume_t* volume, const char* file
                                   uint32_t row_index, const float* input,
                                   uint32_t count, uint8_t* scratch,
                                   uint32_t scratch_capacity, float* out_dot);
+/* Lit les octets d’une ligne quantifiée sans allocation ni chargement complet. */
+int gpt2_gguf_read_quant_row_fat16(const fat16_volume_t* volume, const char* filename,
+                                   const gpt2_gguf_loaded_model_t* model,
+                                   const gpt2_gguf_tensor_t* tensor,
+                                   uint32_t row_index, uint8_t* buffer,
+                                   uint32_t capacity, uint32_t* out_read);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -146,6 +146,25 @@ static void test_loads_gpt2_from_fat16(void) {
         TEST_ASSERT_EQUAL(0x77, block[0]);
         TEST_ASSERT_EQUAL(-6, gpt2_gguf_read_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, block, 1U, &block_read));
         {
+            uint8_t row[2U * GPT2_Q6_K_BLOCK_BYTES];
+            uint32_t row_read = 0U;
+            gpt2_gguf_tensor_t variant = tensor;
+            TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, row, sizeof(row), &row_read));
+            TEST_ASSERT_EQUAL(GPT2_Q4_K_BLOCK_BYTES, (int)row_read);
+            TEST_ASSERT_EQUAL(0x11, row[0]);
+            TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 1U, row, sizeof(row), &row_read));
+            TEST_ASSERT_EQUAL(0x77, row[0]);
+            variant.type = GPT2_GGUF_TENSOR_Q3_K;
+            variant.byte_size = 2U * GPT2_Q3_K_BLOCK_BYTES;
+            TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_row_fat16(&volume, "gpt2.ggu", &model, &variant, 0U, row, sizeof(row), &row_read));
+            TEST_ASSERT_EQUAL(GPT2_Q3_K_BLOCK_BYTES, (int)row_read);
+            variant.type = GPT2_GGUF_TENSOR_Q6_K;
+            variant.byte_size = 2U * GPT2_Q6_K_BLOCK_BYTES;
+            TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_row_fat16(&volume, "gpt2.ggu", &model, &variant, 0U, row, sizeof(row), &row_read));
+            TEST_ASSERT_EQUAL(GPT2_Q6_K_BLOCK_BYTES, (int)row_read);
+            TEST_ASSERT_EQUAL(-6, gpt2_gguf_read_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, row, 1U, &row_read));
+        }
+        {
             float input[GPT2_QK_K] = {0.0f};
             float dot = 1.0f;
             TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_block_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, input, GPT2_QK_K, block, sizeof(block), &dot));


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_read_quant_row_fat16`;
- lit une ligne Q3_K, Q4_K ou Q6_K dans un buffer caller-owned;
- contrôle largeur, index, capacité, offsets et lecture partielle;
- vérifie les deux marqueurs Q4_K physiques `0x11` et `0x77`;
- ajoute la couverture Q3_K, Q6_K et buffer insuffisant;
- documente le contrat sans allocation dynamique.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le prochain lot pourra brancher la lecture de lignes sur le calcul quantifié.