### PR TITLE
Lot 90: calcul sur ligne quantifiée caller-owned

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -276,3 +276,6 @@ Le lot 88 ajoute `gpt2_gguf_validate_gpt2_layer_storage`, qui compose la validat
 
 
 Le lot 89 ajoute `gpt2_gguf_read_quant_row_fat16`, qui lit une ligne Q3_K, Q4_K ou Q6_K depuis FAT16 dans un buffer caller-owned, avec contrôle de largeur, index, capacité, offsets et lecture partielle. Les marqueurs physiques Q4_K `0x11` et `0x77` sont vérifiés ligne par ligne; Q3_K, Q6_K et le buffer insuffisant sont également couverts. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+
+Le lot 90 ajoute `gpt2_gguf_dot_quant_row_buffer`, qui calcule une ligne quantifiée déjà lue sans nouvel accès FAT16, allocation ni cache implicite. La primitive accumule les super-blocs Q3_K, Q4_K ou Q6_K avec les kernels existants et contrôle largeur, capacité et type. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.

--- a/docs/mohhos_foundation_increment_90_quantized_row_buffer_dot.md
+++ b/docs/mohhos_foundation_increment_90_quantized_row_buffer_dot.md
@@ -1,0 +1,29 @@
+# MOHHOS Foundation — Incrément 90 : calcul sur ligne quantifiée
+
+**État :** implémenté sur la branche de travail du lot 90.
+
+## Objectif
+
+Le lot 89 séparait la lecture brute d’une ligne quantifiée. Le lot 90 ajoute `gpt2_gguf_dot_quant_row_buffer`, qui consomme directement cette ligne dans un buffer caller-owned et accumule les super-blocs Q3_K, Q4_K ou Q6_K avec les kernels quantifiés existants.
+
+La primitive ne relit pas FAT16, ne conserve pas de cache implicite et n’alloue aucune mémoire. L’appelant contrôle la durée de vie du buffer, de l’entrée float et du résultat.
+
+## Contrat
+
+La largeur de la ligne doit être `shape[0]` et un multiple de 256. La capacité doit couvrir `shape[0] / 256` super-blocs avec la taille propre au type. Le calcul retourne `0` pour Q3_K, Q4_K et Q6_K valides; `-4` pour un type non supporté, `-6` pour une capacité insuffisante et `-7` pour une largeur incompatible.
+
+| Type | Kernel appelé | Taille par super-bloc |
+| --- | --- | ---: |
+| Q3_K | `gpt2_q3_k_dot_f32` | 110 octets |
+| Q4_K | `gpt2_q4_k_dot_f32` | 144 octets |
+| Q6_K | `gpt2_q6_k_dot_f32` | 210 octets |
+
+L’accumulation est effectuée en float, bloc par bloc, avec une adresse calculée depuis le buffer fourni par l’appelant. Le chemin est donc compatible avec la contrainte noyau sans allocation dynamique.
+
+## Tests
+
+La fixture FAT16 lit d’abord une ligne Q4_K, puis la calcule avec une entrée nulle. La même ligne est testée via les chemins Q3_K et Q6_K, et les rejets de capacité insuffisante et de largeur de 32 valeurs sont vérifiés. `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Suite
+
+Le prochain incrément peut intégrer la séquence lecture-calcul au contexte de forward et commencer à exposer une opération de projection QKV sur une ligne à la fois.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -212,3 +212,31 @@ int gpt2_gguf_read_quant_row_fat16(const fat16_volume_t* volume, const char* fil
     if (*out_read != (uint32_t)row_bytes) return -8;
     return 0;
 }
+
+
+int gpt2_gguf_dot_quant_row_buffer(const gpt2_gguf_tensor_t* tensor,
+                                   const uint8_t* row_buffer, uint32_t row_capacity,
+                                   const float* input, uint32_t count, float* out_dot) {
+    uint32_t block_bytes;
+    uint32_t blocks;
+    uint32_t block;
+    float total = 0.0f;
+    if (!tensor || !row_buffer || !input || !out_dot || tensor->dimensions == 0U || tensor->dimensions > 2U) return -1;
+    if (tensor->shape[0] == 0U || tensor->shape[0] > 0xFFFFFFFFULL) return -9;
+    if (count != (uint32_t)tensor->shape[0] || (count % GPT2_QK_K) != 0U) return -7;
+    if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) block_bytes = GPT2_Q3_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) block_bytes = GPT2_Q4_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q6_K) block_bytes = GPT2_Q6_K_BLOCK_BYTES;
+    else return -4;
+    blocks = count / GPT2_QK_K;
+    if (blocks > 0xFFFFFFFFU / block_bytes || row_capacity < blocks * block_bytes) return -6;
+    for (block = 0U; block < blocks; block++) {
+        const float* values = input + block * GPT2_QK_K;
+        const uint8_t* encoded = row_buffer + block * block_bytes;
+        if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) total += gpt2_q3_k_dot_f32(values, encoded, GPT2_QK_K);
+        else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) total += gpt2_q4_k_dot_f32(values, encoded, GPT2_QK_K);
+        else total += gpt2_q6_k_dot_f32(values, encoded, GPT2_QK_K);
+    }
+    *out_dot = total;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -69,5 +69,9 @@ int gpt2_gguf_read_quant_row_fat16(const fat16_volume_t* volume, const char* fil
                                    const gpt2_gguf_tensor_t* tensor,
                                    uint32_t row_index, uint8_t* buffer,
                                    uint32_t capacity, uint32_t* out_read);
+/* Calcule une ligne quantifiée déjà présente dans un buffer caller-owned. */
+int gpt2_gguf_dot_quant_row_buffer(const gpt2_gguf_tensor_t* tensor,
+                                   const uint8_t* row_buffer, uint32_t row_capacity,
+                                   const float* input, uint32_t count, float* out_dot);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -163,6 +163,18 @@ static void test_loads_gpt2_from_fat16(void) {
             TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_row_fat16(&volume, "gpt2.ggu", &model, &variant, 0U, row, sizeof(row), &row_read));
             TEST_ASSERT_EQUAL(GPT2_Q6_K_BLOCK_BYTES, (int)row_read);
             TEST_ASSERT_EQUAL(-6, gpt2_gguf_read_quant_row_fat16(&volume, "gpt2.ggu", &model, &tensor, 0U, row, 1U, &row_read));
+            {
+                float input[GPT2_QK_K] = {0.0f};
+                float dot = 1.0f;
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_row_buffer(&tensor, row, sizeof(row), input, GPT2_QK_K, &dot));
+                TEST_ASSERT_EQUAL(0, (int)dot);
+                variant.type = GPT2_GGUF_TENSOR_Q3_K;
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_row_buffer(&variant, row, sizeof(row), input, GPT2_QK_K, &dot));
+                variant.type = GPT2_GGUF_TENSOR_Q6_K;
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_row_buffer(&variant, row, sizeof(row), input, GPT2_QK_K, &dot));
+                TEST_ASSERT_EQUAL(-6, gpt2_gguf_dot_quant_row_buffer(&tensor, row, 1U, input, GPT2_QK_K, &dot));
+                TEST_ASSERT_EQUAL(-7, gpt2_gguf_dot_quant_row_buffer(&tensor, row, sizeof(row), input, 32U, &dot));
+            }
         }
         {
             float input[GPT2_QK_K] = {0.0f};


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_dot_quant_row_buffer`;
- consomme une ligne quantifiée déjà lue sans nouvel accès FAT16;
- accumule les super-blocs Q3_K, Q4_K et Q6_K;
- contrôle largeur, capacité et type;
- couvre les trois kernels avec entrée nulle et les erreurs de capacité/largeur;
- documente le chemin sans allocation dynamique.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le prochain lot pourra intégrer lecture et calcul au contexte de forward QKV.