### PR TITLE
Lot 91: projection QKV quantifiée par ligne

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -279,3 +279,6 @@ Le lot 89 ajoute `gpt2_gguf_read_quant_row_fat16`, qui lit une ligne Q3_K, Q4_K 
 
 
 Le lot 90 ajoute `gpt2_gguf_dot_quant_row_buffer`, qui calcule une ligne quantifiée déjà lue sans nouvel accès FAT16, allocation ni cache implicite. La primitive accumule les super-blocs Q3_K, Q4_K ou Q6_K avec les kernels existants et contrôle largeur, capacité et type. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+
+Le lot 91 ajoute `gpt2_gguf_project_qkv_row_fat16`, qui valide une matrice QKV `[C,3C]`, lit une sortie quantifiée à la fois depuis FAT16 et la calcule avec un buffer caller-owned. Les bornes `output_index < 3C` et la forme incompatible sont rejetées; aucune matrice complète ni allocation noyau n’est utilisée. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.

--- a/docs/mohhos_foundation_increment_91_qkv_row_projection.md
+++ b/docs/mohhos_foundation_increment_91_qkv_row_projection.md
@@ -1,0 +1,29 @@
+# MOHHOS Foundation — Incrément 91 : projection QKV par ligne
+
+**État :** implémenté sur la branche de travail du lot 91.
+
+## Objectif
+
+Le lot 91 compose la lecture FAT16 d’une ligne quantifiée et le calcul caller-owned pour exposer `gpt2_gguf_project_qkv_row_fat16`. Cette primitive traite une sortie QKV à la fois à partir d’une matrice GGUF de forme `[C,3C]`, sans charger la matrice complète ni allouer de workspace noyau.
+
+L’appelant fournit le modèle, le tenseur, la configuration `channels`, l’index de sortie, le vecteur d’entrée, le buffer de ligne et le résultat. La fonction vérifie la forme exacte, impose `output_index < 3C`, lit la ligne quantifiée via FAT16, puis délègue au calcul multi-blocs Q3_K/Q4_K/Q6_K déjà validé.
+
+## Garanties
+
+| Vérification | Résultat |
+| --- | --- |
+| forme `[C,3C]` et index `< 3C` | projection de la sortie demandée |
+| axe ou index incompatible | `-9` |
+| largeur non compatible | propagée par le calcul de ligne |
+| buffer insuffisant | `-6` |
+| type K-Quant non supporté | `-4` |
+
+Le chemin est séquentiel et caller-owned: lecture d’une ligne, calcul, restitution d’un scalaire. Il ne conserve pas de cache implicite et ne prend possession d’aucun buffer.
+
+## Tests
+
+La fixture FAT16 construit une vue QKV `[256,768]` sur le tenseur quantifié, valide la sortie 0 avec une entrée nulle et rejette l’index `3C` ainsi qu’une forme `[C,2C]`. La suite `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Suite
+
+Le prochain incrément pourra accumuler les `3C` sorties, puis séparer les segments query, key et value pour préparer l’attention autoregressive.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -240,3 +240,21 @@ int gpt2_gguf_dot_quant_row_buffer(const gpt2_gguf_tensor_t* tensor,
     *out_dot = total;
     return 0;
 }
+
+
+int gpt2_gguf_project_qkv_row_fat16(const fat16_volume_t* volume, const char* filename,
+                                    const gpt2_gguf_loaded_model_t* model,
+                                    const gpt2_gguf_tensor_t* tensor, uint32_t channels,
+                                    uint32_t output_index, const float* input,
+                                    uint8_t* row_buffer, uint32_t row_capacity,
+                                    float* out_value) {
+    uint32_t read = 0U;
+    int status;
+    if (!tensor || channels == 0U || !input || !row_buffer || !out_value) return -1;
+    if (tensor->dimensions != 2U || tensor->shape[0] != channels ||
+        tensor->shape[1] != 3ULL * channels || output_index >= 3U * channels) return -9;
+    status = gpt2_gguf_read_quant_row_fat16(volume, filename, model, tensor,
+                                             output_index, row_buffer, row_capacity, &read);
+    if (status != 0) return status;
+    return gpt2_gguf_dot_quant_row_buffer(tensor, row_buffer, read, input, channels, out_value);
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -73,5 +73,12 @@ int gpt2_gguf_read_quant_row_fat16(const fat16_volume_t* volume, const char* fil
 int gpt2_gguf_dot_quant_row_buffer(const gpt2_gguf_tensor_t* tensor,
                                    const uint8_t* row_buffer, uint32_t row_capacity,
                                    const float* input, uint32_t count, float* out_dot);
+/* Lit et calcule une sortie QKV unique d’une matrice GGUF `[C,3C]`. */
+int gpt2_gguf_project_qkv_row_fat16(const fat16_volume_t* volume, const char* filename,
+                                    const gpt2_gguf_loaded_model_t* model,
+                                    const gpt2_gguf_tensor_t* tensor, uint32_t channels,
+                                    uint32_t output_index, const float* input,
+                                    uint8_t* row_buffer, uint32_t row_capacity,
+                                    float* out_value);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -174,6 +174,19 @@ static void test_loads_gpt2_from_fat16(void) {
                 TEST_ASSERT_EQUAL(0, gpt2_gguf_dot_quant_row_buffer(&variant, row, sizeof(row), input, GPT2_QK_K, &dot));
                 TEST_ASSERT_EQUAL(-6, gpt2_gguf_dot_quant_row_buffer(&tensor, row, 1U, input, GPT2_QK_K, &dot));
                 TEST_ASSERT_EQUAL(-7, gpt2_gguf_dot_quant_row_buffer(&tensor, row, sizeof(row), input, 32U, &dot));
+            {
+                gpt2_gguf_tensor_t qkv = tensor;
+                qkv.shape[1] = 3U * GPT2_QK_K;
+                qkv.byte_size = 3U * GPT2_QK_K * GPT2_Q4_K_BLOCK_BYTES;
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_project_qkv_row_fat16(&volume, "gpt2.ggu", &model, &qkv,
+                                                                       GPT2_QK_K, 0U, input, row, sizeof(row), &dot));
+                TEST_ASSERT_EQUAL(0, (int)dot);
+                TEST_ASSERT_EQUAL(-9, gpt2_gguf_project_qkv_row_fat16(&volume, "gpt2.ggu", &model, &qkv,
+                                                                        GPT2_QK_K, 3U * GPT2_QK_K, input, row, sizeof(row), &dot));
+                qkv.shape[1] = 2U * GPT2_QK_K;
+                TEST_ASSERT_EQUAL(-9, gpt2_gguf_project_qkv_row_fat16(&volume, "gpt2.ggu", &model, &qkv,
+                                                                        GPT2_QK_K, 0U, input, row, sizeof(row), &dot));
+            }
             }
         }
         {


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_project_qkv_row_fat16`;
- valide la forme GGUF `[C,3C]`;
- lit et calcule une sortie QKV à la fois;
- réutilise les primitives Q3_K/Q4_K/Q6_K caller-owned;
- rejette les axes et index hors bornes;
- documente l’absence de chargement complet et d’allocation dynamique.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le prochain lot pourra accumuler les 3C sorties et préparer la séparation query/key/value.