### PR TITLE
Lot 92: accumulation QKV caller-owned

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -282,3 +282,6 @@ Le lot 90 ajoute `gpt2_gguf_dot_quant_row_buffer`, qui calcule une ligne quantif
 
 
 Le lot 91 ajoute `gpt2_gguf_project_qkv_row_fat16`, qui valide une matrice QKV `[C,3C]`, lit une sortie quantifiée à la fois depuis FAT16 et la calcule avec un buffer caller-owned. Les bornes `output_index < 3C` et la forme incompatible sont rejetées; aucune matrice complète ni allocation noyau n’est utilisée. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+
+Le lot 92 ajoute `gpt2_gguf_project_qkv_fat16`, qui accumule les `3C` projections d’une matrice `[C,3C]` en séparant query, key et value dans trois buffers caller-owned. Un unique buffer de ligne quantifiée est réutilisé et les capacités de sortie sont contrôlées avant lecture. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.

--- a/docs/mohhos_foundation_increment_92_qkv_accumulation.md
+++ b/docs/mohhos_foundation_increment_92_qkv_accumulation.md
@@ -1,0 +1,27 @@
+# MOHHOS Foundation — Incrément 92 : accumulation QKV caller-owned
+
+**État :** implémenté sur la branche de travail du lot 92.
+
+## Objectif
+
+Le lot 92 ajoute `gpt2_gguf_project_qkv_fat16`, qui enchaîne les projections ligne par ligne d’une matrice GGUF `[C,3C]` et sépare les résultats dans trois buffers caller-owned: `query`, `key` et `value`.
+
+Le même buffer quantifié est réutilisé pour chaque ligne. La fonction ne charge donc pas la matrice QKV complète et ne crée aucun workspace caché. Les capacités des trois sorties sont vérifiées avant toute lecture.
+
+## Séparation
+
+Les indices de sortie `[0,C)` sont écrits dans `query`, `[C,2C)` dans `key` et `[2C,3C)` dans `value`. Chaque scalaire est produit par `gpt2_gguf_project_qkv_row_fat16`, qui conserve les contrôles de forme `[C,3C]`, d’index, de lecture FAT16 et de type quantifié.
+
+| Segment | Indices source | Buffer destination |
+| --- | ---: | --- |
+| Query | `0 ... C-1` | `query[0 ... C-1]` |
+| Key | `C ... 2C-1` | `key[0 ... C-1]` |
+| Value | `2C ... 3C-1` | `value[0 ... C-1]` |
+
+## Tests
+
+Les tests vérifient que les capacités `query`, `key` et `value` sont contrôlées avant lecture, et qu’un pointeur de sortie nul est refusé. Les validations de forme QKV et de projection d’une ligne restent actives. `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Suite
+
+Le prochain incrément pourra connecter ces trois buffers à un contexte d’attention et préparer le cache KV séquentiel, sans modifier la contrainte caller-owned.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -258,3 +258,30 @@ int gpt2_gguf_project_qkv_row_fat16(const fat16_volume_t* volume, const char* fi
     if (status != 0) return status;
     return gpt2_gguf_dot_quant_row_buffer(tensor, row_buffer, read, input, channels, out_value);
 }
+
+
+int gpt2_gguf_project_qkv_fat16(const fat16_volume_t* volume, const char* filename,
+                                const gpt2_gguf_loaded_model_t* model,
+                                const gpt2_gguf_tensor_t* tensor, uint32_t channels,
+                                const float* input, uint8_t* row_buffer,
+                                uint32_t row_capacity, float* query, uint32_t query_capacity,
+                                float* key, uint32_t key_capacity,
+                                float* value, uint32_t value_capacity) {
+    uint32_t output_index;
+    int status;
+    if (!query || !key || !value || channels == 0U ||
+        query_capacity < channels * sizeof(float) ||
+        key_capacity < channels * sizeof(float) ||
+        value_capacity < channels * sizeof(float)) return -6;
+    for (output_index = 0U; output_index < 3U * channels; output_index++) {
+        float result = 0.0f;
+        status = gpt2_gguf_project_qkv_row_fat16(volume, filename, model, tensor, channels,
+                                                  output_index, input, row_buffer,
+                                                  row_capacity, &result);
+        if (status != 0) return status;
+        if (output_index < channels) query[output_index] = result;
+        else if (output_index < 2U * channels) key[output_index - channels] = result;
+        else value[output_index - 2U * channels] = result;
+    }
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -80,5 +80,13 @@ int gpt2_gguf_project_qkv_row_fat16(const fat16_volume_t* volume, const char* fi
                                     uint32_t output_index, const float* input,
                                     uint8_t* row_buffer, uint32_t row_capacity,
                                     float* out_value);
+/* Accumule les 3C sorties dans trois buffers query/key/value caller-owned. */
+int gpt2_gguf_project_qkv_fat16(const fat16_volume_t* volume, const char* filename,
+                                const gpt2_gguf_loaded_model_t* model,
+                                const gpt2_gguf_tensor_t* tensor, uint32_t channels,
+                                const float* input, uint8_t* row_buffer,
+                                uint32_t row_capacity, float* query, uint32_t query_capacity,
+                                float* key, uint32_t key_capacity,
+                                float* value, uint32_t value_capacity);
 
 #endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -186,6 +186,17 @@ static void test_loads_gpt2_from_fat16(void) {
                 qkv.shape[1] = 2U * GPT2_QK_K;
                 TEST_ASSERT_EQUAL(-9, gpt2_gguf_project_qkv_row_fat16(&volume, "gpt2.ggu", &model, &qkv,
                                                                         GPT2_QK_K, 0U, input, row, sizeof(row), &dot));
+                {
+                    float query[GPT2_QK_K] = {0.0f};
+                    float key[GPT2_QK_K] = {0.0f};
+                    float value[GPT2_QK_K] = {0.0f};
+                    TEST_ASSERT_EQUAL(-6, gpt2_gguf_project_qkv_fat16(&volume, "gpt2.ggu", &model, &qkv,
+                                                                       GPT2_QK_K, input, row, sizeof(row),
+                                                                       query, sizeof(query) - 1U, key, sizeof(key), value, sizeof(value)));
+                    TEST_ASSERT_EQUAL(-6, gpt2_gguf_project_qkv_fat16(&volume, "gpt2.ggu", &model, &qkv,
+                                                                       GPT2_QK_K, input, row, sizeof(row),
+                                                                       query, sizeof(query), key, sizeof(key), 0, sizeof(value)));
+                }
             }
             }
         }


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_project_qkv_fat16`;
- accumule les 3C sorties QKV sans charger la matrice complète;
- sépare query, key et value dans trois buffers caller-owned;
- réutilise un unique buffer de ligne quantifiée;
- contrôle les capacités avant toute lecture;
- documente le chemin vers le cache KV.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le prochain lot pourra connecter ces buffers à l’attention et au cache KV.