### PR TITLE
Lot 93: cache KV GGUF caller-owned

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -285,3 +285,9 @@ Le lot 91 ajoute `gpt2_gguf_project_qkv_row_fat16`, qui valide une matrice QKV `
 
 
 Le lot 92 ajoute `gpt2_gguf_project_qkv_fat16`, qui accumule les `3C` projections d’une matrice `[C,3C]` en séparant query, key et value dans trois buffers caller-owned. Un unique buffer de ligne quantifiée est réutilisé et les capacités de sortie sont contrôlées avant lecture. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+
+Le lot 93 ajoute `gpt2_gguf_kv_cache_t` et ses opérations d’initialisation, écriture et lecture. Le cache caller-owned stocke `[couche][position][K puis V]`, contrôle la capacité totale et suit la plus grande position écrite via `count`, sans allocation noyau. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+
+Le lot 93 ajoute `gpt2_gguf_kv_cache_t` et ses opérations d’initialisation, écriture et lecture. Le cache caller-owned stocke `[couche][position][K puis V]`, contrôle la capacité totale et suit la plus grande position écrite via `count`, sans allocation noyau. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. Le build i386 et la relance propre du smoke QEMU valident core, extras, persist, spawn et exec.

--- a/docs/mohhos_foundation_increment_93_kv_cache.md
+++ b/docs/mohhos_foundation_increment_93_kv_cache.md
@@ -1,0 +1,31 @@
+# MOHHOS Foundation — Incrément 93 : cache KV caller-owned
+
+**État :** implémenté sur la branche de travail du lot 93.
+
+## Objectif
+
+Le lot 93 ajoute un cache KV GGUF séquentiel, fourni et dimensionné par l’appelant. Il stocke les clés et valeurs par couche et position selon la disposition `[layer][position][K puis V]`.
+
+`gpt2_gguf_kv_cache_init` vérifie la capacité totale avant d’initialiser le descripteur. `gpt2_gguf_kv_cache_put` écrit une paire K/V à une position, tandis que `gpt2_gguf_kv_cache_get` la relit dans des buffers fournis par l’appelant. Le champ `count` suit la plus grande position écrite plus un, ce qui prépare le parcours autoregressif.
+
+## Contrat
+
+| Élément | Garantie |
+| --- | --- |
+| mémoire | aucun `kmalloc`, aucun buffer interne |
+| disposition | `[couche][position][K][V]` |
+| bornes | couche et position contrôlées |
+| capacité | `layers × max_positions × 2 × channels` floats exigés |
+| progression | `count = max(count, position + 1)` |
+
+Les calculs d’offsets utilisent des produits 64 bits contrôlés puis un index 32 bits compatible avec le noyau i386 freestanding.
+
+## Tests
+
+La fixture alloue un cache `2 × 3 × 2 × 4`, écrit et relit les K/V de la couche 1 à la position 2, vérifie `count == 3`, puis rejette une couche hors bornes, une capacité de stockage insuffisante et un pointeur nul. `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+Le build i386 et le smoke QEMU complet (core, extras, persist, spawn, exec) sont également verts. Un premier passage QEMU avait expiré sur un événement de supervision du runner lent; la relance propre a validé tous les scénarios.
+
+## Suite
+
+Le prochain incrément pourra connecter l’accumulation QKV aux écritures du cache et ajouter une primitive d’itération des positions historiques pour l’attention autoregressive.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -285,3 +285,65 @@ int gpt2_gguf_project_qkv_fat16(const fat16_volume_t* volume, const char* filena
     }
     return 0;
 }
+
+
+static int gpt2_gguf_kv_cache_offset(const gpt2_gguf_kv_cache_t* cache,
+                                     uint32_t layer, uint32_t position,
+                                     uint32_t* out_offset) {
+    uint64_t slots;
+    uint64_t offset;
+    if (!cache || !out_offset || !cache->storage || cache->layers == 0U ||
+        cache->max_positions == 0U || cache->channels == 0U ||
+        layer >= cache->layers || position >= cache->max_positions) return -9;
+    slots = ((uint64_t)layer * cache->max_positions) + position;
+    offset = slots * 2ULL * cache->channels;
+    if (offset > 0xFFFFFFFFULL || offset + 2ULL * cache->channels > 0xFFFFFFFFULL) return -9;
+    *out_offset = (uint32_t)offset;
+    return 0;
+}
+
+int gpt2_gguf_kv_cache_init(float* storage, uint32_t storage_floats,
+                            uint32_t layers, uint32_t max_positions,
+                            uint32_t channels, gpt2_gguf_kv_cache_t* out) {
+    uint64_t required;
+    if (!storage || !out || layers == 0U || max_positions == 0U || channels == 0U) return -1;
+    required = (uint64_t)layers * max_positions * 2ULL * channels;
+    if (required > 0xFFFFFFFFULL || storage_floats < (uint32_t)required) return -6;
+    out->storage = storage;
+    out->layers = layers;
+    out->max_positions = max_positions;
+    out->channels = channels;
+    out->count = 0U;
+    return 0;
+}
+
+int gpt2_gguf_kv_cache_put(gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                           uint32_t position, const float* key, const float* value) {
+    uint32_t offset;
+    uint32_t i;
+    int status;
+    if (!key || !value) return -1;
+    status = gpt2_gguf_kv_cache_offset(cache, layer, position, &offset);
+    if (status != 0) return status;
+    for (i = 0U; i < cache->channels; i++) {
+        cache->storage[offset + i] = key[i];
+        cache->storage[offset + cache->channels + i] = value[i];
+    }
+    if (position + 1U > cache->count) cache->count = position + 1U;
+    return 0;
+}
+
+int gpt2_gguf_kv_cache_get(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                           uint32_t position, float* key, float* value) {
+    uint32_t offset;
+    uint32_t i;
+    int status;
+    if (!key || !value) return -1;
+    status = gpt2_gguf_kv_cache_offset(cache, layer, position, &offset);
+    if (status != 0) return status;
+    for (i = 0U; i < cache->channels; i++) {
+        key[i] = cache->storage[offset + i];
+        value[i] = cache->storage[offset + cache->channels + i];
+    }
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -19,12 +19,30 @@ typedef struct {
     uint32_t position;
 } gpt2_gguf_forward_context_t;
 
+typedef struct {
+    float* storage;
+    uint32_t layers;
+    uint32_t max_positions;
+    uint32_t channels;
+    uint32_t count;
+} gpt2_gguf_kv_cache_t;
+
 /* Prépare une couche pour le futur forward sans prendre possession des buffers. */
 int gpt2_gguf_forward_context_init(const gpt2_gguf_loaded_model_t* model,
                                    uint32_t layer_index, uint32_t channels,
                                    uint32_t position, char* name, uint32_t name_capacity,
                                    uint8_t* scratch, uint32_t scratch_capacity,
                                    gpt2_gguf_forward_context_t* out);
+/* Initialise un cache KV fourni par l’appelant. */
+int gpt2_gguf_kv_cache_init(float* storage, uint32_t storage_floats,
+                            uint32_t layers, uint32_t max_positions,
+                            uint32_t channels, gpt2_gguf_kv_cache_t* out);
+/* Écrit les K/V d’une couche et d’une position dans le cache. */
+int gpt2_gguf_kv_cache_put(gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                           uint32_t position, const float* key, const float* value);
+/* Relit les K/V d’une couche et d’une position dans les buffers appelant. */
+int gpt2_gguf_kv_cache_get(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                           uint32_t position, float* key, float* value);
 
 /* Lit un fichier FAT16 8.3 dans le buffer fourni puis indexe son GGUF. */
 int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -120,6 +120,23 @@ static void test_loads_gpt2_from_fat16(void) {
                                                                context_name, sizeof(context_name),
                                                                0, sizeof(context_scratch), &context));
     }
+    {
+        float storage[2U * 3U * 2U * 4U] = {0.0f};
+        float key[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+        float value[4] = {5.0f, 6.0f, 7.0f, 8.0f};
+        float key_out[4] = {0.0f};
+        float value_out[4] = {0.0f};
+        gpt2_gguf_kv_cache_t cache;
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_init(storage, 48U, 2U, 3U, 4U, &cache));
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_put(&cache, 1U, 2U, key, value));
+        TEST_ASSERT_EQUAL(3, (int)cache.count);
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_get(&cache, 1U, 2U, key_out, value_out));
+        TEST_ASSERT_EQUAL(1, (int)key_out[0]);
+        TEST_ASSERT_EQUAL(8, (int)value_out[3]);
+        TEST_ASSERT_EQUAL(-9, gpt2_gguf_kv_cache_get(&cache, 2U, 0U, key_out, value_out));
+        TEST_ASSERT_EQUAL(-6, gpt2_gguf_kv_cache_init(storage, 47U, 2U, 3U, 4U, &cache));
+        TEST_ASSERT_EQUAL(-1, gpt2_gguf_kv_cache_put(&cache, 0U, 0U, 0, value));
+    }
     TEST_ASSERT_EQUAL(480, (int)model.bytes_loaded);
     TEST_ASSERT_EQUAL(1, model.index.tensor_count);
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_role(&model.index, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_kv_cache_t`;
- initialise un stockage caller-owned `[couche][position][K puis V]`;
- ajoute écriture et lecture K/V avec contrôles de bornes;
- suit la position maximale via `count`;
- refuse les capacités insuffisantes et les pointeurs nuls;
- documente le chemin vers l’attention autoregressive.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ après relance propre: core, extras, persist, spawn et exec

Le prochain lot pourra connecter l’accumulation QKV aux écritures du cache KV.