### PR TITLE
Lot 94: itération historique du cache KV

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -291,3 +291,6 @@ Le lot 93 ajoute `gpt2_gguf_kv_cache_t` et ses opérations d’initialisation, �
 
 
 Le lot 93 ajoute `gpt2_gguf_kv_cache_t` et ses opérations d’initialisation, écriture et lecture. Le cache caller-owned stocke `[couche][position][K puis V]`, contrôle la capacité totale et suit la plus grande position écrite via `count`, sans allocation noyau. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**. Le build i386 et la relance propre du smoke QEMU valident core, extras, persist, spawn et exec.
+
+
+Le lot 94 ajoute `gpt2_gguf_kv_cache_copy_history`, qui copie un intervalle de positions K/V historiques d’une couche vers des buffers caller-owned compacts. L’itération respecte `cache->count`, isole les couches et rejette les capacités ou intervalles hors bornes. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.

--- a/docs/mohhos_foundation_increment_94_kv_history_iteration.md
+++ b/docs/mohhos_foundation_increment_94_kv_history_iteration.md
@@ -1,0 +1,29 @@
+# MOHHOS Foundation — Incrément 94 : itération historique du cache KV
+
+**État :** implémenté sur la branche de travail du lot 94.
+
+## Objectif
+
+Le lot 94 ajoute `gpt2_gguf_kv_cache_copy_history`, qui copie un intervalle de positions historiques d’une couche du cache KV vers deux buffers caller-owned, l’un pour les clés et l’autre pour les valeurs.
+
+La copie est bornée par `cache->count`: une position non encore écrite ou un intervalle dépassant l’historique disponible est rejeté. Les couches restent isolées par le calcul d’offset déjà utilisé par `get`, et la fonction ne crée aucune mémoire interne.
+
+## Contrat
+
+| Condition | Résultat |
+| --- | --- |
+| intervalle `[start, start + count)` disponible | K/V copiés dans l’ordre |
+| `position_count == 0` | succès avec `out_count = 0` |
+| capacité K ou V insuffisante | `-6` |
+| couche ou intervalle hors bornes | `-9` |
+| pointeur de sortie ou compteur absent | `-1` |
+
+Les sorties sont compactes: la position `start + i` est écrite à l’index `i` dans les buffers K/V. Cette disposition est directement exploitable par une boucle de score d’attention causale.
+
+## Tests
+
+La fixture écrit trois positions distinctes dans la couche 1, relit l’historique complet, vérifie l’ordre des valeurs et rejette une lecture sur la couche 0 non alimentée, une capacité K insuffisante et les pointeurs invalides. `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Suite
+
+Le prochain incrément pourra calculer les scores query-key sur l’historique copié, puis accumuler les valeurs pondérées pour l’attention autoregressive.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -347,3 +347,30 @@ int gpt2_gguf_kv_cache_get(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
     }
     return 0;
 }
+
+
+int gpt2_gguf_kv_cache_copy_history(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                                    uint32_t start_position, uint32_t position_count,
+                                    float* key_out, uint32_t key_capacity,
+                                    float* value_out, uint32_t value_capacity,
+                                    uint32_t* out_count) {
+    uint32_t position;
+    uint32_t copied = 0U;
+    int status;
+    if (out_count) *out_count = 0U;
+    if (!cache || !key_out || !value_out || !out_count) return -1;
+    if (position_count == 0U) return 0;
+    if (position_count > 0xFFFFFFFFU / cache->channels ||
+        key_capacity < position_count * cache->channels ||
+        value_capacity < position_count * cache->channels) return -6;
+    if (start_position > cache->count || position_count > cache->count - start_position) return -9;
+    for (position = 0U; position < position_count; position++) {
+        status = gpt2_gguf_kv_cache_get(cache, layer, start_position + position,
+                                        key_out + position * cache->channels,
+                                        value_out + position * cache->channels);
+        if (status != 0) return status;
+        copied++;
+    }
+    *out_count = copied;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -43,6 +43,12 @@ int gpt2_gguf_kv_cache_put(gpt2_gguf_kv_cache_t* cache, uint32_t layer,
 /* Relit les K/V d’une couche et d’une position dans les buffers appelant. */
 int gpt2_gguf_kv_cache_get(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
                            uint32_t position, float* key, float* value);
+/* Copie un intervalle de positions historiques d’une couche. */
+int gpt2_gguf_kv_cache_copy_history(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                                    uint32_t start_position, uint32_t position_count,
+                                    float* key_out, uint32_t key_capacity,
+                                    float* value_out, uint32_t value_capacity,
+                                    uint32_t* out_count);
 
 /* Lit un fichier FAT16 8.3 dans le buffer fourni puis indexe son GGUF. */
 int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -128,6 +128,10 @@ static void test_loads_gpt2_from_fat16(void) {
         float value_out[4] = {0.0f};
         gpt2_gguf_kv_cache_t cache;
         TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_init(storage, 48U, 2U, 3U, 4U, &cache));
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_put(&cache, 1U, 0U, key, value));
+        key[0] = 9.0f; value[0] = 19.0f;
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_put(&cache, 1U, 1U, key, value));
+        key[0] = 1.0f; value[0] = 5.0f;
         TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_put(&cache, 1U, 2U, key, value));
         TEST_ASSERT_EQUAL(3, (int)cache.count);
         TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_get(&cache, 1U, 2U, key_out, value_out));
@@ -136,6 +140,24 @@ static void test_loads_gpt2_from_fat16(void) {
         TEST_ASSERT_EQUAL(-9, gpt2_gguf_kv_cache_get(&cache, 2U, 0U, key_out, value_out));
         TEST_ASSERT_EQUAL(-6, gpt2_gguf_kv_cache_init(storage, 47U, 2U, 3U, 4U, &cache));
         TEST_ASSERT_EQUAL(-1, gpt2_gguf_kv_cache_put(&cache, 0U, 0U, 0, value));
+        {
+            float history_key[12] = {0.0f};
+            float history_value[12] = {0.0f};
+            uint32_t history_count = 0U;
+            TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_copy_history(&cache, 1U, 0U, 3U,
+                                                                  history_key, 12U, history_value, 12U,
+                                                                  &history_count));
+            TEST_ASSERT_EQUAL(3, (int)history_count);
+            TEST_ASSERT_EQUAL(1, (int)history_key[0]);
+            TEST_ASSERT_EQUAL(9, (int)history_key[4]);
+            TEST_ASSERT_EQUAL(19, (int)history_value[4]);
+            TEST_ASSERT_EQUAL(-9, gpt2_gguf_kv_cache_copy_history(&cache, 0U, 2U, 2U,
+                                                                   history_key, 12U, history_value, 12U,
+                                                                   &history_count));
+            TEST_ASSERT_EQUAL(-6, gpt2_gguf_kv_cache_copy_history(&cache, 1U, 0U, 3U,
+                                                                   history_key, 8U, history_value, 12U,
+                                                                   &history_count));
+        }
     }
     TEST_ASSERT_EQUAL(480, (int)model.bytes_loaded);
     TEST_ASSERT_EQUAL(1, model.index.tensor_count);


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_kv_cache_copy_history`;
- copie un intervalle historique K/V vers des buffers caller-owned;
- respecte `cache->count` et l’isolation par couche;
- contrôle les capacités et les intervalles hors bornes;
- conserve une sortie compacte adaptée à l’attention causale.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec

Le prochain lot pourra calculer les scores query-key sur l’historique KV.