### PR TITLE
Lot 95: scores query-key sur cache KV

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -294,3 +294,6 @@ Le lot 93 ajoute `gpt2_gguf_kv_cache_t` et ses opérations d’initialisation, �
 
 
 Le lot 94 ajoute `gpt2_gguf_kv_cache_copy_history`, qui copie un intervalle de positions K/V historiques d’une couche vers des buffers caller-owned compacts. L’itération respecte `cache->count`, isole les couches et rejette les capacités ou intervalles hors bornes. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+
+
+Le lot 95 ajoute `gpt2_gguf_kv_cache_query_scores`, qui calcule les produits scalaires query-key sur un historique KV sans allocation. Les scores restent bruts, sans softmax ni mise à l’échelle, et les capacités du scratch et du tableau de sortie sont contrôlées. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.

--- a/docs/mohhos_foundation_increment_95_query_key_scores.md
+++ b/docs/mohhos_foundation_increment_95_query_key_scores.md
@@ -1,0 +1,29 @@
+# MOHHOS Foundation — Incrément 95 : scores query-key
+
+**État :** implémenté sur la branche de travail du lot 95.
+
+## Objectif
+
+Le lot 95 ajoute `gpt2_gguf_kv_cache_query_scores`, qui calcule les produits scalaires entre une query caller-owned et les clés historiques d’une couche du cache KV.
+
+La primitive retourne les scores bruts, dans l’ordre compact de l’intervalle demandé. Elle ne réalise volontairement ni mise à l’échelle par `sqrt(head_size)`, ni softmax: ces opérations appartiennent à l’étape d’attention suivante. Le segment K est lu directement depuis la disposition contrôlée du cache, avec un scratch caller-owned réutilisé à chaque position.
+
+## Contrat
+
+| Condition | Résultat |
+| --- | --- |
+| query et historique valides | scores `dot(query, key[position])` |
+| scratch K ou tableau scores insuffisant | `-6` |
+| couche ou intervalle hors historique | `-9` |
+| pointeur requis absent | `-1` |
+| intervalle vide | succès avec `out_count = 0` |
+
+Les scores sont calculés en float et écrits dans `scores[0 ... position_count-1]`. La fonction respecte le cache caller-owned et ne modifie ni les clés ni les valeurs stockées.
+
+## Tests
+
+La fixture contient les clés `[1,2,3,4]`, `[9,2,3,4]` et `[1,2,3,4]`. Une query de quatre composantes unitaires produit les scores `10`, `18` et `10`. Les tests couvrent également le scratch trop petit et un intervalle dépassant `cache->count`. `make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Suite
+
+Le prochain incrément pourra appliquer la normalisation de tête puis accumuler les valeurs historiques pondérées par les probabilités d’attention.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -374,3 +374,32 @@ int gpt2_gguf_kv_cache_copy_history(const gpt2_gguf_kv_cache_t* cache, uint32_t 
     *out_count = copied;
     return 0;
 }
+
+
+int gpt2_gguf_kv_cache_query_scores(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                                    uint32_t start_position, uint32_t position_count,
+                                    const float* query, float* key_scratch,
+                                    uint32_t key_scratch_capacity, float* scores,
+                                    uint32_t score_capacity, uint32_t* out_count) {
+    uint32_t position;
+    int status;
+    if (out_count) *out_count = 0U;
+    if (!cache || !query || !key_scratch || !scores || !out_count) return -1;
+    if (key_scratch_capacity < cache->channels || score_capacity < position_count) return -6;
+    if (position_count == 0U) return 0;
+    if (start_position > cache->count || position_count > cache->count - start_position) return -9;
+    for (position = 0U; position < position_count; position++) {
+        uint32_t i;
+        uint32_t offset;
+        float dot = 0.0f;
+        status = gpt2_gguf_kv_cache_offset(cache, layer, start_position + position, &offset);
+        if (status != 0) return status;
+        for (i = 0U; i < cache->channels; i++) {
+            key_scratch[i] = cache->storage[offset + i];
+            dot += query[i] * key_scratch[i];
+        }
+        scores[position] = dot;
+    }
+    *out_count = position_count;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -49,6 +49,12 @@ int gpt2_gguf_kv_cache_copy_history(const gpt2_gguf_kv_cache_t* cache, uint32_t 
                                     float* key_out, uint32_t key_capacity,
                                     float* value_out, uint32_t value_capacity,
                                     uint32_t* out_count);
+/* Calcule les scores query-key bruts sur un historique d’une couche. */
+int gpt2_gguf_kv_cache_query_scores(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                                    uint32_t start_position, uint32_t position_count,
+                                    const float* query, float* key_scratch,
+                                    uint32_t key_scratch_capacity, float* scores,
+                                    uint32_t score_capacity, uint32_t* out_count);
 
 /* Lit un fichier FAT16 8.3 dans le buffer fourni puis indexe son GGUF. */
 int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -157,6 +157,23 @@ static void test_loads_gpt2_from_fat16(void) {
             TEST_ASSERT_EQUAL(-6, gpt2_gguf_kv_cache_copy_history(&cache, 1U, 0U, 3U,
                                                                    history_key, 8U, history_value, 12U,
                                                                    &history_count));
+            {
+                float query[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+                float key_scratch[4] = {0.0f};
+                float scores[3] = {0.0f};
+                TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_query_scores(&cache, 1U, 0U, 3U,
+                                                                      query, key_scratch, 4U,
+                                                                      scores, 3U, &history_count));
+                TEST_ASSERT_EQUAL(10, (int)scores[0]);
+                TEST_ASSERT_EQUAL(18, (int)scores[1]);
+                TEST_ASSERT_EQUAL(10, (int)scores[2]);
+                TEST_ASSERT_EQUAL(-6, gpt2_gguf_kv_cache_query_scores(&cache, 1U, 0U, 3U,
+                                                                       query, key_scratch, 3U,
+                                                                       scores, 3U, &history_count));
+                TEST_ASSERT_EQUAL(-9, gpt2_gguf_kv_cache_query_scores(&cache, 1U, 2U, 2U,
+                                                                       query, key_scratch, 4U,
+                                                                       scores, 3U, &history_count));
+            }
         }
     }
     TEST_ASSERT_EQUAL(480, (int)model.bytes_loaded);


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_kv_cache_query_scores`;
- calcule les produits scalaires query-key sur l’historique KV;
- réutilise un scratch K caller-owned;
- conserve les scores bruts sans softmax ni mise à l’échelle;
- contrôle les capacités et les intervalles hors bornes;
- documente la prochaine étape d’accumulation des values.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec