### PR TITLE
Lot 96: accumulation des values du cache KV

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -297,3 +297,4 @@ Le lot 94 ajoute `gpt2_gguf_kv_cache_copy_history`, qui copie un intervalle de p
 
 
 Le lot 95 ajoute `gpt2_gguf_kv_cache_query_scores`, qui calcule les produits scalaires query-key sur un historique KV sans allocation. Les scores restent bruts, sans softmax ni mise à l’échelle, et les capacités du scratch et du tableau de sortie sont contrôlées. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.
+Le lot 96 ajoute `gpt2_gguf_kv_cache_accumulate_values`, qui calcule le vecteur de sortie par accumulation des values historiques pondérées. La primitive lit le cache sans le modifier, n’alloue aucun buffer, contrôle les capacités caller-owned et laisse le softmax ainsi que la mise à l’échelle aux incréments suivants. `make test-all` reste à **265 tests réussis, 0 échec et 0 test ignoré**.

--- a/docs/mohhos_foundation_increment_96_value_accumulation.md
+++ b/docs/mohhos_foundation_increment_96_value_accumulation.md
@@ -1,0 +1,39 @@
+# MOHHOS Foundation — Incrément 96 : accumulation des values
+
+**État :** implémenté et testé.
+
+## Objectif
+
+Le lot 96 complète l’étape située après les scores query-key bruts. `gpt2_gguf_kv_cache_accumulate_values` produit le vecteur d’attention en accumulant les values historiques avec les poids fournis par l’appelant :
+
+\[
+O_c = \sum_{p=0}^{N-1} w_p \times V_{p,c}
+\]
+
+Les poids peuvent être des probabilités issues d’un softmax futur ou tout autre vecteur normalisé préparé par le caller. La primitive ne réalise pas encore le softmax ni la mise à l’échelle des scores; elle reste donc composable avec les incréments suivants.
+
+## Contrat caller-owned
+
+| Élément | Contrat |
+| --- | --- |
+| `weights` | tableau fourni par l’appelant, de capacité au moins égale à `position_count` |
+| `output` | tableau fourni par l’appelant, de capacité au moins égale à `cache->channels` |
+| allocation | aucune allocation dynamique et aucun buffer caché |
+| sortie | `output[0..channels-1]`, `out_count = channels` |
+| état du cache | lecture seule; les clés et values historiques ne sont pas modifiées |
+
+La sortie est remise à zéro avant l’accumulation, ce qui rend la fonction réutilisable pour chaque tête, couche ou position sans dépendre d’un contenu précédent du buffer.
+
+## Validation des erreurs
+
+La primitive suit les conventions du cache KV. Elle renvoie `-1` lorsqu’un pointeur requis manque, `-6` lorsqu’une capacité est insuffisante et `-9` lorsqu’une couche ou une fenêtre historique est hors bornes. Pour une fenêtre vide, elle retourne un succès et `out_count = 0`, sans lire les poids ni modifier la sortie.
+
+## Tests
+
+La fixture du cache contient les values `[5,6,7,8]`, `[19,6,7,8]` et `[5,6,7,8]`. Avec les poids `[0,2, 0,3, 0,5]`, la sortie attendue est `[9,2, 6, 7, 8]`. Les tests couvrent le résultat pondéré, le nombre de canaux produit, un tableau de poids trop court, une sortie trop courte et une fenêtre hors historique.
+
+`make test-all` passe avec **265 tests réussis, 0 échec et 0 test ignoré**.
+
+## Suite
+
+L’étape suivante peut introduire la mise à l’échelle des scores par la dimension de tête, puis un softmax stable caller-owned avant d’appeler cette accumulation.

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -403,3 +403,31 @@ int gpt2_gguf_kv_cache_query_scores(const gpt2_gguf_kv_cache_t* cache, uint32_t 
     *out_count = position_count;
     return 0;
 }
+
+
+int gpt2_gguf_kv_cache_accumulate_values(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                                         uint32_t start_position, uint32_t position_count,
+                                         const float* weights, uint32_t weight_capacity,
+                                         float* output, uint32_t output_capacity,
+                                         uint32_t* out_count) {
+    uint32_t position;
+    uint32_t channel;
+    int status;
+    if (out_count) *out_count = 0U;
+    if (!cache || !weights || !output || !out_count) return -1;
+    if (weight_capacity < position_count || output_capacity < cache->channels) return -6;
+    if (position_count == 0U) return 0;
+    if (start_position > cache->count || position_count > cache->count - start_position) return -9;
+    for (channel = 0U; channel < cache->channels; channel++) output[channel] = 0.0f;
+    for (position = 0U; position < position_count; position++) {
+        uint32_t offset;
+        float weight = weights[position];
+        status = gpt2_gguf_kv_cache_offset(cache, layer, start_position + position, &offset);
+        if (status != 0) return status;
+        for (channel = 0U; channel < cache->channels; channel++) {
+            output[channel] += weight * cache->storage[offset + cache->channels + channel];
+        }
+    }
+    *out_count = cache->channels;
+    return 0;
+}

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -55,6 +55,12 @@ int gpt2_gguf_kv_cache_query_scores(const gpt2_gguf_kv_cache_t* cache, uint32_t 
                                     const float* query, float* key_scratch,
                                     uint32_t key_scratch_capacity, float* scores,
                                     uint32_t score_capacity, uint32_t* out_count);
+/* Accumule les values historiques avec les poids fournis par l’appelant. */
+int gpt2_gguf_kv_cache_accumulate_values(const gpt2_gguf_kv_cache_t* cache, uint32_t layer,
+                                         uint32_t start_position, uint32_t position_count,
+                                         const float* weights, uint32_t weight_capacity,
+                                         float* output, uint32_t output_capacity,
+                                         uint32_t* out_count);
 
 /* Lit un fichier FAT16 8.3 dans le buffer fourni puis indexe son GGUF. */
 int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -173,6 +173,27 @@ static void test_loads_gpt2_from_fat16(void) {
                 TEST_ASSERT_EQUAL(-9, gpt2_gguf_kv_cache_query_scores(&cache, 1U, 2U, 2U,
                                                                        query, key_scratch, 4U,
                                                                        scores, 3U, &history_count));
+                {
+                    float weights[3] = {0.2f, 0.3f, 0.5f};
+                    float output[4] = {99.0f, 99.0f, 99.0f, 99.0f};
+                    TEST_ASSERT_EQUAL(0, gpt2_gguf_kv_cache_accumulate_values(&cache, 1U, 0U, 3U,
+                                                                                weights, 3U, output, 4U,
+                                                                                &history_count));
+                    TEST_ASSERT_EQUAL(4, (int)history_count);
+                    TEST_ASSERT_EQUAL(92, (int)(output[0] * 10.0f));
+                    TEST_ASSERT_EQUAL(60, (int)(output[1] * 10.0f));
+                    TEST_ASSERT_EQUAL(70, (int)(output[2] * 10.0f));
+                    TEST_ASSERT_EQUAL(80, (int)(output[3] * 10.0f));
+                    TEST_ASSERT_EQUAL(-6, gpt2_gguf_kv_cache_accumulate_values(&cache, 1U, 0U, 3U,
+                                                                                 weights, 2U, output, 4U,
+                                                                                 &history_count));
+                    TEST_ASSERT_EQUAL(-6, gpt2_gguf_kv_cache_accumulate_values(&cache, 1U, 0U, 3U,
+                                                                                 weights, 3U, output, 3U,
+                                                                                 &history_count));
+                    TEST_ASSERT_EQUAL(-9, gpt2_gguf_kv_cache_accumulate_values(&cache, 1U, 2U, 2U,
+                                                                                 weights, 3U, output, 4U,
+                                                                                 &history_count));
+                }
             }
         }
     }


### PR DESCRIPTION
## Résumé

- ajoute `gpt2_gguf_kv_cache_accumulate_values`;
- accumule les values historiques avec les poids caller-owned;
- ne modifie pas le cache et n’alloue aucun buffer;
- contrôle les capacités, couches et fenêtres historiques;
- ajoute les tests Unity et la documentation française;
- prépare l’appel après softmax/scaling.

## Validation locale

- `make test-all` ✅ **265 tests, 0 échec, 0 ignoré**
- `make all -j2` ✅
- `make qemu-smoke` ✅ core, extras, persist, spawn et exec