### PR TITLE
Lot 114: codec Ethernet ARP caller-owned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
 # Une évolution de structure doit donc reconstruire toute l'image, pas seulement ipc.o.
@@ -154,6 +154,11 @@ build/task.o: kernel/task/task.c kernel/task/task.h
 build/syscall.o: kernel/syscall/syscall.c kernel/syscall/syscall.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
+
+build/net_ethernet_arp.o: kernel/net_ethernet_arp.c kernel/net_ethernet_arp.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
 
 # Règles de compilation pour le système de fichiers
 build/initrd.o: fs/initrd.c fs/initrd.h

--- a/docs/aos114_ethernet_arp_codec.md
+++ b/docs/aos114_ethernet_arp_codec.md
@@ -1,0 +1,31 @@
+# AOS-114 — Codec Ethernet/ARP caller-owned
+
+## Objectif
+
+Le lot AOS-114 introduit la première brique du réseau effectif sans simuler une carte réseau. Le noyau peut désormais décoder un en-tête Ethernet, parser une trame ARP Ethernet/IPv4 et construire une requête ARP dans un buffer fourni par l’appelant.
+
+## Contrat mémoire
+
+Les fonctions de `kernel/net_ethernet_arp.c` n’allouent aucune mémoire. Les buffers d’entrée restent sous le contrôle de l’appelant et les fonctions de parsing copient les champs utiles dans des structures de sortie caller-owned. Toute longueur insuffisante est rejetée avant lecture.
+
+| Fonction | Contrat |
+|---|---|
+| `net_ethernet_parse` | Lit exactement les 14 octets d’un en-tête Ethernet et convertit l’EtherType big-endian. |
+| `net_arp_parse` | Accepte uniquement ARP Ethernet/IPv4 avec tailles matérielle 6 et protocolaire 4. |
+| `net_arp_build_request` | Construit une requête ARP broadcast de 42 octets dans le buffer fourni. |
+| `net_arp_is_reply_for` | Vérifie opcode, IPv4 local cible et IPv4 demandée source. |
+
+> Le codec ne transmet encore aucune trame. Il fournit une primitive déterministe au futur pilote NIC et évite de confondre la préparation de paquet avec un transport réseau opérationnel.
+
+## Validation
+
+Le test `tests/unit/kernel/test_net_ethernet_arp.c` couvre la construction et le parsing d’une requête, le rejet des buffers courts et des EtherTypes non ARP, ainsi que la reconnaissance d’une réponse correspondant aux adresses demandées. Le runner `tests/scripts/run_all_tests.sh` lie explicitement l’implémentation du codec au test, comme les autres modules kernel spécialisés.
+
+La validation locale du lot est :
+
+```text
+make test-all                  268 tests, 268 passés, 0 échec, 0 ignoré
+make all                       build i386 et initrd réussis
+```
+
+Les étapes réseau suivantes restent nécessaires avant une requête effective : détection PCI/NIC, anneau RX/TX, émission matérielle, IPv4/UDP/DHCP, DNS, TCP, TLS et client HTTP borné. Aucune clé API et aucun secret ne sont intégrés à l’image.

--- a/kernel/net_ethernet_arp.c
+++ b/kernel/net_ethernet_arp.c
@@ -1,0 +1,90 @@
+#include "net_ethernet_arp.h"
+
+static uint16_t read_be16(const uint8_t* p) {
+    return (uint16_t)(((uint16_t)p[0] << 8) | p[1]);
+}
+
+static void write_be16(uint8_t* p, uint16_t value) {
+    p[0] = (uint8_t)(value >> 8);
+    p[1] = (uint8_t)value;
+}
+
+static void copy_bytes(uint8_t* dst, const uint8_t* src, uint32_t count) {
+    uint32_t i;
+    for (i = 0; i < count; ++i) dst[i] = src[i];
+}
+
+static int bytes_equal(const uint8_t* a, const uint8_t* b, uint32_t count) {
+    uint32_t i;
+    for (i = 0; i < count; ++i) if (a[i] != b[i]) return 0;
+    return 1;
+}
+
+int net_ethernet_parse(const uint8_t* frame, uint32_t length,
+                       net_ethernet_header_t* out) {
+    if (!frame || !out || length < NET_ETHERNET_HEADER_SIZE) return -1;
+    copy_bytes(out->destination, frame, 6);
+    copy_bytes(out->source, frame + 6, 6);
+    out->ethertype = read_be16(frame + 12);
+    return 0;
+}
+
+int net_arp_parse(const uint8_t* frame, uint32_t length,
+                  net_arp_packet_t* out) {
+    net_ethernet_header_t ethernet;
+    const uint8_t* arp;
+    if (!out || !frame || length < NET_ETHERNET_HEADER_SIZE + NET_ARP_PACKET_SIZE)
+        return -1;
+    if (net_ethernet_parse(frame, length, &ethernet) != 0 ||
+        ethernet.ethertype != NET_ETHERTYPE_ARP)
+        return -2;
+    arp = frame + NET_ETHERNET_HEADER_SIZE;
+    out->hardware_type = read_be16(arp + 0);
+    out->protocol_type = read_be16(arp + 2);
+    out->hardware_size = arp[4];
+    out->protocol_size = arp[5];
+    out->opcode = read_be16(arp + 6);
+    copy_bytes(out->sender_mac, arp + 8, 6);
+    copy_bytes(out->sender_ipv4, arp + 14, 4);
+    copy_bytes(out->target_mac, arp + 18, 6);
+    copy_bytes(out->target_ipv4, arp + 24, 4);
+    if (out->hardware_type != NET_ARP_HTYPE_ETHERNET ||
+        out->protocol_type != NET_ARP_PTYPE_IPV4 ||
+        out->hardware_size != 6 || out->protocol_size != 4)
+        return -3;
+    return 0;
+}
+
+int net_arp_build_request(uint8_t* frame, uint32_t capacity,
+                          const uint8_t sender_mac[6], const uint8_t sender_ipv4[4],
+                          const uint8_t target_ipv4[4]) {
+    uint8_t* arp;
+    static const uint8_t broadcast[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    static const uint8_t zero_mac[6] = {0, 0, 0, 0, 0, 0};
+    if (!frame || !sender_mac || !sender_ipv4 || !target_ipv4 ||
+        capacity < NET_ETHERNET_HEADER_SIZE + NET_ARP_PACKET_SIZE)
+        return -1;
+    copy_bytes(frame, broadcast, 6);
+    copy_bytes(frame + 6, sender_mac, 6);
+    write_be16(frame + 12, NET_ETHERTYPE_ARP);
+    arp = frame + NET_ETHERNET_HEADER_SIZE;
+    write_be16(arp + 0, NET_ARP_HTYPE_ETHERNET);
+    write_be16(arp + 2, NET_ARP_PTYPE_IPV4);
+    arp[4] = 6;
+    arp[5] = 4;
+    write_be16(arp + 6, NET_ARP_OPCODE_REQUEST);
+    copy_bytes(arp + 8, sender_mac, 6);
+    copy_bytes(arp + 14, sender_ipv4, 4);
+    copy_bytes(arp + 18, zero_mac, 6);
+    copy_bytes(arp + 24, target_ipv4, 4);
+    return (int)(NET_ETHERNET_HEADER_SIZE + NET_ARP_PACKET_SIZE);
+}
+
+int net_arp_is_reply_for(const net_arp_packet_t* packet,
+                         const uint8_t local_ipv4[4],
+                         const uint8_t requested_ipv4[4]) {
+    if (!packet || !local_ipv4 || !requested_ipv4) return 0;
+    return packet->opcode == NET_ARP_OPCODE_REPLY &&
+           bytes_equal(packet->target_ipv4, local_ipv4, 4) &&
+           bytes_equal(packet->sender_ipv4, requested_ipv4, 4);
+}

--- a/kernel/net_ethernet_arp.h
+++ b/kernel/net_ethernet_arp.h
@@ -1,0 +1,49 @@
+#ifndef AIOS_NET_ETHERNET_ARP_H
+#define AIOS_NET_ETHERNET_ARP_H
+
+#include <stdint.h>
+
+#define NET_ETHERNET_HEADER_SIZE 14U
+#define NET_ARP_PACKET_SIZE 28U
+#define NET_ETHERTYPE_IPV4 0x0800U
+#define NET_ETHERTYPE_ARP  0x0806U
+#define NET_ARP_HTYPE_ETHERNET 1U
+#define NET_ARP_PTYPE_IPV4 0x0800U
+#define NET_ARP_OPCODE_REQUEST 1U
+#define NET_ARP_OPCODE_REPLY 2U
+
+/* Aucune structure ne pointe dans une trame reçue: les adresses sont copiées. */
+typedef struct {
+    uint8_t destination[6];
+    uint8_t source[6];
+    uint16_t ethertype;
+} net_ethernet_header_t;
+
+typedef struct {
+    uint16_t hardware_type;
+    uint16_t protocol_type;
+    uint8_t hardware_size;
+    uint8_t protocol_size;
+    uint16_t opcode;
+    uint8_t sender_mac[6];
+    uint8_t sender_ipv4[4];
+    uint8_t target_mac[6];
+    uint8_t target_ipv4[4];
+} net_arp_packet_t;
+
+/* Parse exactement un en-tête Ethernet. Retourne 0 si la trame est trop courte. */
+int net_ethernet_parse(const uint8_t* frame, uint32_t length,
+                       net_ethernet_header_t* out);
+/* Parse ARP Ethernet/IPv4 à partir du début d’une trame Ethernet. */
+int net_arp_parse(const uint8_t* frame, uint32_t length,
+                  net_arp_packet_t* out);
+/* Construit une requête ARP Ethernet/IPv4 dans le buffer caller-owned. */
+int net_arp_build_request(uint8_t* frame, uint32_t capacity,
+                          const uint8_t sender_mac[6], const uint8_t sender_ipv4[4],
+                          const uint8_t target_ipv4[4]);
+/* Reconnaît uniquement une réponse ARP destinée à l’adresse IPv4 fournie. */
+int net_arp_is_reply_for(const net_arp_packet_t* packet,
+                         const uint8_t local_ipv4[4],
+                         const uint8_t requested_ipv4[4]);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -102,6 +102,12 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_fat16: $(UNIT_DIR)/kernel/test_fat16.c ../k
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_net_ethernet_arp.c ../kernel/net_ethernet_arp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_ethernet_arp.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_quant: $(UNIT_DIR)/kernel/test_gpt2_quant.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -120,6 +120,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
     fi
+    if [ "$(basename "$test_file")" = "test_net_ethernet_arp.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/net_ethernet_arp.c"
+    fi
     if [ "$(basename "$test_file")" = "test_gpt2_gguf_bounds.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_gguf.c"
     fi

--- a/tests/unit/kernel/test_net_ethernet_arp.c
+++ b/tests/unit/kernel/test_net_ethernet_arp.c
@@ -1,0 +1,54 @@
+#include "../../framework/unity.h"
+#include "../../framework/test_kernel.h"
+#include "../../../kernel/net_ethernet_arp.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_build_and_parse_arp_request(void) {
+    uint8_t frame[64] = {0};
+    uint8_t mac[6] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+    uint8_t ip[4] = {10, 0, 2, 15};
+    uint8_t target[4] = {10, 0, 2, 2};
+    net_arp_packet_t packet;
+    int length = net_arp_build_request(frame, sizeof(frame), mac, ip, target);
+    TEST_ASSERT_EQUAL(42, length);
+    TEST_ASSERT_EQUAL(0, net_arp_parse(frame, (uint32_t)length, &packet));
+    TEST_ASSERT_EQUAL(NET_ARP_OPCODE_REQUEST, packet.opcode);
+    TEST_ASSERT_EQUAL_MEMORY(mac, packet.sender_mac, 6);
+    TEST_ASSERT_EQUAL_MEMORY(ip, packet.sender_ipv4, 4);
+    TEST_ASSERT_EQUAL_MEMORY(target, packet.target_ipv4, 4);
+}
+
+void test_rejects_short_or_non_arp_frame(void) {
+    uint8_t frame[42] = {0};
+    net_arp_packet_t packet;
+    frame[12] = 0x08;
+    frame[13] = 0x00;
+    TEST_ASSERT_NOT_EQUAL(0, net_arp_parse(frame, 13, &packet));
+    TEST_ASSERT_NOT_EQUAL(0, net_arp_parse(frame, sizeof(frame), &packet));
+}
+
+void test_reply_matches_local_and_requested_addresses(void) {
+    net_arp_packet_t packet = {0};
+    uint8_t local[4] = {10, 0, 2, 15};
+    uint8_t requested[4] = {10, 0, 2, 2};
+    packet.opcode = NET_ARP_OPCODE_REPLY;
+    packet.target_ipv4[0] = 10; packet.target_ipv4[1] = 0;
+    packet.target_ipv4[2] = 2; packet.target_ipv4[3] = 15;
+    packet.sender_ipv4[0] = 10; packet.sender_ipv4[1] = 0;
+    packet.sender_ipv4[2] = 2; packet.sender_ipv4[3] = 2;
+    TEST_ASSERT_EQUAL(1, net_arp_is_reply_for(&packet, local, requested));
+    packet.sender_ipv4[3] = 3;
+    TEST_ASSERT_EQUAL(0, net_arp_is_reply_for(&packet, local, requested));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_build_and_parse_arp_request);
+    RUN_TEST(test_rejects_short_or_non_arp_frame);
+    RUN_TEST(test_reply_matches_local_and_requested_addresses);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Résumé

Ajoute la première primitive réseau effective sans allocation dynamique: parsing Ethernet, parsing ARP Ethernet/IPv4, construction de requêtes ARP et validation bornée des réponses.

## Modifications

- `kernel/net_ethernet_arp.c/.h` avec buffers caller-owned et contrôles de longueur;
- test Unity `test_net_ethernet_arp.c`;
- intégration au build i386 et au runner de tests;
- documentation française AOS-114.

## Validation locale

- `make test-all`: 268/268 tests verts;
- `make all`: build i386 et initrd réussis.

Ce lot ne transmet encore aucune trame: le pilote NIC, RX/TX, IPv4, DHCP, DNS, TCP/TLS et HTTP restent les étapes suivantes.