### PR TITLE
Lot 115: file NIC statique caller-owned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
 # Une évolution de structure doit donc reconstruire toute l'image, pas seulement ipc.o.
@@ -156,6 +156,10 @@ build/syscall.o: kernel/syscall/syscall.c kernel/syscall/syscall.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/net_ethernet_arp.o: kernel/net_ethernet_arp.c kernel/net_ethernet_arp.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/net_nic.o: kernel/net_nic.c kernel/net_nic.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/aos115_nic_queue.md
+++ b/docs/aos115_nic_queue.md
@@ -1,0 +1,32 @@
+# AOS-115 — File NIC RX/TX statique
+
+## Objectif
+
+Le lot AOS-115 ajoute le contrat mémoire entre un futur pilote de carte réseau et la pile Ethernet/ARP. La file est circulaire, de capacité fixe et entièrement alimentée par des buffers fournis par l’appelant.
+
+## Contrat
+
+`net_nic_queue_init` reçoit une zone de stockage contiguë pour huit trames. Chaque emplacement est borné par `frame_capacity`, avec une limite maximale de 1536 octets adaptée à une trame Ethernet standard avec marge de traitement. Aucune fonction ne réalise d’allocation dynamique.
+
+| Opération | Garantie |
+|---|---|
+| `acquire` | Retourne le prochain emplacement libre sans copier de données. |
+| `commit` | Publie une longueur vérifiée et avance l’index producteur. |
+| `pop` | Retourne la vue de la plus ancienne trame publiée et avance l’index consommateur. |
+| `reset` | Vide la file en O(1) et conserve les buffers de l’appelant. |
+| `count` | Retourne le nombre d’emplacements publiés, borné à 8. |
+
+La séparation `acquire`/`commit` permet au pilote RX de remplir directement un buffer et au pilote TX de préparer une trame sans copie intermédiaire. Une file pleine ou une longueur supérieure à la capacité sont rejetées.
+
+## Validation
+
+Le test `tests/unit/kernel/test_net_nic.c` couvre l’initialisation, la propriété caller-owned des buffers, l’ordre FIFO, la saturation logique et le reset. Le runner autonome lie explicitement `kernel/net_nic.c` au test.
+
+La validation locale du groupe est :
+
+```text
+make test-all                  270 tests, 270 passés, 0 échec, 0 ignoré
+make all                       build i386 et initrd réussis
+```
+
+Cette file ne détecte ni ne programme encore un contrôleur PCI/NIC. Elle constitue le contrat stable nécessaire avant l’implémentation du pilote matériel et de ses opérations RX/TX.

--- a/kernel/net_nic.c
+++ b/kernel/net_nic.c
@@ -1,0 +1,64 @@
+#include "net_nic.h"
+
+int net_nic_queue_init(net_nic_queue_t* queue,
+                       uint8_t* storage, uint32_t storage_size,
+                       uint16_t frame_capacity) {
+    uint32_t i;
+    if (!queue || !storage || frame_capacity == 0U ||
+        frame_capacity > NET_NIC_FRAME_CAPACITY ||
+        storage_size < frame_capacity * NET_NIC_QUEUE_CAPACITY)
+        return -1;
+    queue->head = 0U;
+    queue->tail = 0U;
+    queue->count = 0U;
+    for (i = 0; i < NET_NIC_QUEUE_CAPACITY; ++i) {
+        queue->frames[i].storage = storage + i * frame_capacity;
+        queue->frames[i].capacity = frame_capacity;
+        queue->frames[i].length = 0U;
+    }
+    return 0;
+}
+
+void net_nic_queue_reset(net_nic_queue_t* queue) {
+    uint32_t i;
+    if (!queue) return;
+    queue->head = 0U;
+    queue->tail = 0U;
+    queue->count = 0U;
+    for (i = 0; i < NET_NIC_QUEUE_CAPACITY; ++i)
+        queue->frames[i].length = 0U;
+}
+
+int net_nic_queue_acquire(net_nic_queue_t* queue, uint8_t** buffer,
+                          uint16_t* capacity) {
+    if (!queue || !buffer || !capacity || queue->count >= NET_NIC_QUEUE_CAPACITY)
+        return -1;
+    *buffer = queue->frames[queue->tail].storage;
+    *capacity = queue->frames[queue->tail].capacity;
+    return 0;
+}
+
+int net_nic_queue_commit(net_nic_queue_t* queue, uint16_t length) {
+    if (!queue || queue->count >= NET_NIC_QUEUE_CAPACITY ||
+        length > queue->frames[queue->tail].capacity)
+        return -1;
+    queue->frames[queue->tail].length = length;
+    queue->tail = (uint8_t)((queue->tail + 1U) % NET_NIC_QUEUE_CAPACITY);
+    queue->count++;
+    return 0;
+}
+
+int net_nic_queue_pop(net_nic_queue_t* queue, uint8_t** buffer,
+                      uint16_t* length) {
+    if (!queue || !buffer || !length || queue->count == 0U)
+        return -1;
+    *buffer = queue->frames[queue->head].storage;
+    *length = queue->frames[queue->head].length;
+    queue->head = (uint8_t)((queue->head + 1U) % NET_NIC_QUEUE_CAPACITY);
+    queue->count--;
+    return 0;
+}
+
+uint8_t net_nic_queue_count(const net_nic_queue_t* queue) {
+    return queue ? queue->count : 0U;
+}

--- a/kernel/net_nic.h
+++ b/kernel/net_nic.h
@@ -1,0 +1,38 @@
+#ifndef AIOS_NET_NIC_H
+#define AIOS_NET_NIC_H
+
+#include <stdint.h>
+
+#define NET_NIC_QUEUE_CAPACITY 8U
+#define NET_NIC_FRAME_CAPACITY 1536U
+
+typedef struct {
+    uint8_t* storage;
+    uint16_t capacity;
+    uint16_t length;
+} net_nic_frame_t;
+
+typedef struct {
+    net_nic_frame_t frames[NET_NIC_QUEUE_CAPACITY];
+    uint8_t head;
+    uint8_t tail;
+    uint8_t count;
+} net_nic_queue_t;
+
+/* Initialise une file avec des buffers fournis par l’appelant. */
+int net_nic_queue_init(net_nic_queue_t* queue,
+                       uint8_t* storage, uint32_t storage_size,
+                       uint16_t frame_capacity);
+/* Réinitialisation O(1): les buffers restent la propriété de l’appelant. */
+void net_nic_queue_reset(net_nic_queue_t* queue);
+/* Réserve le prochain emplacement RX/TX sans copier la trame. */
+int net_nic_queue_acquire(net_nic_queue_t* queue, uint8_t** buffer,
+                          uint16_t* capacity);
+/* Publie la longueur de l’emplacement réservé. */
+int net_nic_queue_commit(net_nic_queue_t* queue, uint16_t length);
+/* Retire la prochaine trame prête et retourne sa vue bornée. */
+int net_nic_queue_pop(net_nic_queue_t* queue, uint8_t** buffer,
+                      uint16_t* length);
+uint8_t net_nic_queue_count(const net_nic_queue_t* queue);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,6 +108,12 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_n
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_nic: $(UNIT_DIR)/kernel/test_net_nic.c ../kernel/net_nic.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_nic.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_quant: $(UNIT_DIR)/kernel/test_gpt2_quant.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -120,6 +120,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
     fi
+    if [ "$(basename "$test_file")" = "test_net_nic.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/net_nic.c"
+    fi
     if [ "$(basename "$test_file")" = "test_net_ethernet_arp.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/net_ethernet_arp.c"
     fi

--- a/tests/unit/kernel/test_net_nic.c
+++ b/tests/unit/kernel/test_net_nic.c
@@ -1,0 +1,44 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/net_nic.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_queue_is_fifo_and_caller_owned(void) {
+    uint8_t storage[NET_NIC_QUEUE_CAPACITY * 64U] = {0};
+    net_nic_queue_t queue;
+    uint8_t* buffer;
+    uint16_t capacity;
+    uint16_t length;
+    TEST_ASSERT_EQUAL(0, net_nic_queue_init(&queue, storage, sizeof(storage), 64));
+    TEST_ASSERT_EQUAL(0, net_nic_queue_acquire(&queue, &buffer, &capacity));
+    TEST_ASSERT_EQUAL(64, capacity);
+    buffer[0] = 0xa5;
+    TEST_ASSERT_EQUAL(0, net_nic_queue_commit(&queue, 1));
+    TEST_ASSERT_EQUAL(1, net_nic_queue_count(&queue));
+    TEST_ASSERT_EQUAL(0, net_nic_queue_pop(&queue, &buffer, &length));
+    TEST_ASSERT_EQUAL(1, length);
+    TEST_ASSERT_EQUAL(0xa5, buffer[0]);
+}
+
+void test_queue_rejects_bad_capacity_and_reset(void) {
+    uint8_t storage[NET_NIC_QUEUE_CAPACITY * 64U] = {0};
+    net_nic_queue_t queue;
+    uint8_t* buffer;
+    uint16_t capacity;
+    TEST_ASSERT_NOT_EQUAL(0, net_nic_queue_init(&queue, storage, sizeof(storage), 0));
+    TEST_ASSERT_EQUAL(0, net_nic_queue_init(&queue, storage, sizeof(storage), 64));
+    TEST_ASSERT_EQUAL(0, net_nic_queue_acquire(&queue, &buffer, &capacity));
+    TEST_ASSERT_EQUAL(0, net_nic_queue_commit(&queue, 3));
+    net_nic_queue_reset(&queue);
+    TEST_ASSERT_EQUAL(0, net_nic_queue_count(&queue));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_queue_is_fifo_and_caller_owned);
+    RUN_TEST(test_queue_rejects_bad_capacity_and_reset);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Résumé

Ajoute une file circulaire RX/TX de capacité fixe pour le futur pilote NIC, entièrement caller-owned et sans allocation dynamique.

## Modifications

- `kernel/net_nic.c/.h`: init, acquire, commit, pop, reset et count;
- test Unity `test_net_nic.c`;
- intégration Makefile et runner;
- documentation française AOS-115.

## Validation

- `make test-all`: 270/270 tests verts;
- `make all`: build i386 et initrd réussis.

La détection PCI et le pilote matériel RX/TX restent le prochain sous-lot; cette PR ne simule aucun paquet réseau.