### PR TITLE
Lot 116: découverte PCI bornée

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
 # Une évolution de structure doit donc reconstruire toute l'image, pas seulement ipc.o.
@@ -160,6 +160,10 @@ build/net_ethernet_arp.o: kernel/net_ethernet_arp.c kernel/net_ethernet_arp.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/net_nic.o: kernel/net_nic.c kernel/net_nic.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/pci.o: kernel/pci.c kernel/pci.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/aos116_pci_discovery.md
+++ b/docs/aos116_pci_discovery.md
@@ -1,0 +1,22 @@
+# AOS-116 — Accès PCI borné pour le futur pilote NIC
+
+## Objectif
+
+Le lot AOS-116 ajoute la première primitive matérielle nécessaire au réseau effectif: accès à l’espace de configuration PCI via les ports standard `0xCF8` et `0xCFC`, calcul d’adresses alignées et recherche bornée d’un périphérique par classe et sous-classe.
+
+## Contrat
+
+`pci_config_address` masque les champs bus, slot, fonction et offset aux largeurs PCI attendues. `pci_decode_id` extrait les identifiants vendor/device sans conserver de pointeur externe. `pci_find_class` parcourt au plus 256 bus, 32 slots et 8 fonctions et écrit le résultat dans une structure caller-owned.
+
+La recherche ignore les entrées vendor `0xffff`. Aucun tableau dynamique ni état global n’est créé. La lecture matérielle n’est pas invoquée dans les tests Unity; les tests couvrent le calcul d’adresse et le décodage pur.
+
+## Validation
+
+Le test `tests/unit/kernel/test_pci.c` vérifie l’alignement et le masquage de l’adresse de configuration ainsi que l’extraction des identifiants d’un registre PCI. La validation du groupe est :
+
+```text
+make test-all                  272 tests, 272 passés, 0 échec, 0 ignoré
+make all                       build i386 et initrd réussis
+```
+
+Le lot ne sélectionne encore aucun modèle de NIC et ne programme pas d’anneau matériel. Le prochain jalon devra détecter explicitement un contrôleur supporté, récupérer ses BAR/IRQ et raccorder ses buffers à `net_nic_queue_t`.

--- a/kernel/pci.c
+++ b/kernel/pci.c
@@ -1,0 +1,64 @@
+#include "pci.h"
+
+static inline void pci_outl(uint16_t port, uint32_t value) {
+    __asm__ volatile ("outl %0, %1" : : "a"(value), "Nd"(port));
+}
+
+static inline uint32_t pci_inl(uint16_t port) {
+    uint32_t value;
+    __asm__ volatile ("inl %1, %0" : "=a"(value) : "Nd"(port));
+    return value;
+}
+
+uint32_t pci_config_address(uint8_t bus, uint8_t slot, uint8_t function,
+                             uint8_t offset) {
+    return 0x80000000U |
+           ((uint32_t)bus << 16) |
+           ((uint32_t)(slot & 0x1fU) << 11) |
+           ((uint32_t)(function & 0x07U) << 8) |
+           ((uint32_t)(offset & 0xfcU));
+}
+
+void pci_decode_id(uint32_t value, pci_device_t* device) {
+    if (!device) return;
+    device->vendor_id = (uint16_t)(value & 0xffffU);
+    device->device_id = (uint16_t)(value >> 16);
+}
+
+uint32_t pci_config_read32(uint8_t bus, uint8_t slot, uint8_t function,
+                           uint8_t offset) {
+    if ((offset & 3U) != 0U) return 0xffffffffU;
+    pci_outl(0xcf8U, pci_config_address(bus, slot, function, offset));
+    return pci_inl(0xcfcU);
+}
+
+int pci_find_class(uint8_t class_code, uint8_t subclass, pci_device_t* out) {
+    uint32_t bus;
+    uint32_t slot;
+    uint32_t function;
+    if (!out) return -1;
+    for (bus = 0; bus < 256U; ++bus) {
+        for (slot = 0; slot < 32U; ++slot) {
+            for (function = 0; function < 8U; ++function) {
+                uint32_t id = pci_config_read32((uint8_t)bus, (uint8_t)slot,
+                                                (uint8_t)function, 0);
+                uint32_t class_info;
+                if ((id & 0xffffU) == 0xffffU) continue;
+                class_info = pci_config_read32((uint8_t)bus, (uint8_t)slot,
+                                               (uint8_t)function, 8);
+                if ((class_info >> 24) != class_code ||
+                    ((class_info >> 16) & 0xffU) != subclass)
+                    continue;
+                out->bus = (uint8_t)bus;
+                out->slot = (uint8_t)slot;
+                out->function = (uint8_t)function;
+                pci_decode_id(id, out);
+                out->prog_if = (uint8_t)((class_info >> 8) & 0xffU);
+                out->subclass = (uint8_t)((class_info >> 16) & 0xffU);
+                out->class_code = (uint8_t)(class_info >> 24);
+                return 0;
+            }
+        }
+    }
+    return -2;
+}

--- a/kernel/pci.h
+++ b/kernel/pci.h
@@ -1,0 +1,24 @@
+#ifndef AIOS_PCI_H
+#define AIOS_PCI_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint8_t bus;
+    uint8_t slot;
+    uint8_t function;
+    uint16_t vendor_id;
+    uint16_t device_id;
+    uint8_t class_code;
+    uint8_t subclass;
+    uint8_t prog_if;
+} pci_device_t;
+
+uint32_t pci_config_address(uint8_t bus, uint8_t slot, uint8_t function,
+                             uint8_t offset);
+void pci_decode_id(uint32_t value, pci_device_t* device);
+uint32_t pci_config_read32(uint8_t bus, uint8_t slot, uint8_t function,
+                           uint8_t offset);
+int pci_find_class(uint8_t class_code, uint8_t subclass, pci_device_t* out);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,6 +108,12 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_n
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_pci: $(UNIT_DIR)/kernel/test_pci.c ../kernel/pci.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/pci.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_nic: $(UNIT_DIR)/kernel/test_net_nic.c ../kernel/net_nic.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_nic.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -120,6 +120,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
     fi
+    if [ "$(basename "$test_file")" = "test_pci.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/pci.c"
+    fi
     if [ "$(basename "$test_file")" = "test_net_nic.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/net_nic.c"
     fi

--- a/tests/unit/kernel/test_pci.c
+++ b/tests/unit/kernel/test_pci.c
@@ -1,0 +1,27 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/pci.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_config_address_masks_fields_and_aligns_offset(void) {
+    TEST_ASSERT_EQUAL(0x80000000U | (2U << 16) | (3U << 11) |
+                      (1U << 8) | 0x20U,
+                      pci_config_address(2, 3, 1, 0x23));
+}
+
+void test_decode_id_extracts_vendor_and_device(void) {
+    pci_device_t device = {0};
+    pci_decode_id(0x813910ecU, &device);
+    TEST_ASSERT_EQUAL(0x10ec, device.vendor_id);
+    TEST_ASSERT_EQUAL(0x8139, device.device_id);
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_config_address_masks_fields_and_aligns_offset);
+    RUN_TEST(test_decode_id_extracts_vendor_and_device);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Résumé

Ajoute les primitives PCI nécessaires au futur pilote NIC: calcul d’adresse de configuration, lecture 32 bits, décodage vendor/device et recherche bornée par classe.

## Validation

- `make test-all`: 272/272 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-116.

Le lot ne programme encore aucun contrôleur NIC; le prochain jalon raccordera un périphérique supporté à la file RX/TX caller-owned.