### PR TITLE
Lot 117: sonde NE2000 pour QEMU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
 # Une évolution de structure doit donc reconstruire toute l'image, pas seulement ipc.o.
@@ -164,6 +164,10 @@ build/net_nic.o: kernel/net_nic.c kernel/net_nic.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/pci.o: kernel/pci.c kernel/pci.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/ne2k.o: kernel/ne2k.c kernel/ne2k.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/aos117_ne2k_probe.md
+++ b/docs/aos117_ne2k_probe.md
@@ -1,0 +1,22 @@
+# AOS-117 — Sonde NE2000 pour QEMU
+
+## Objectif
+
+Le lot AOS-117 ajoute une sonde NE2000 minimale destinée au contrôleur `ne2k_isa` de QEMU. Le pilote reçoit une interface d’E/S injectable, ce qui permet de vérifier le protocole sans effectuer d’accès matériel pendant les tests Unity.
+
+## Contrat
+
+`ne2k_probe` positionne le contrôleur en mode arrêt, déclenche la séquence reset et vérifie l’acquittement du registre ISR. `ne2k_prepare` programme le mode mot et efface les interruptions latentes. L’état du périphérique est conservé dans une structure caller-owned; aucune allocation dynamique n’est utilisée.
+
+Cette version ne lit pas encore la PROM MAC, ne programme pas l’anneau RX/TX et n’émet aucune trame. Elle établit le point d’intégration matériel vérifiable avant le raccordement des buffers `net_nic_queue_t`.
+
+## Validation
+
+Le test `tests/unit/kernel/test_ne2k.c` injecte des fonctions `inb/outb`, vérifie la séquence d’initialisation et rejette l’absence d’acquittement reset. La validation locale du groupe est :
+
+```text
+make test-all                  274 tests, 274 passés, 0 échec, 0 ignoré
+make all                       build i386 et initrd réussis
+```
+
+Le prochain sous-lot devra récupérer l’adresse MAC et brancher des opérations RX/TX contrôlées sur QEMU avec `-netdev user -device ne2k_isa`.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -1,0 +1,29 @@
+#include "ne2k.h"
+
+int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io) {
+    uint8_t reset_value;
+    if (!device || !io || !io->inb || !io->outb || base_port == 0U) return -1;
+    device->base_port = base_port;
+    device->initialized = 0U;
+    device->mac[0] = device->mac[1] = device->mac[2] = 0U;
+    device->mac[3] = device->mac[4] = device->mac[5] = 0U;
+    io->outb(io->context, (uint16_t)(base_port + NE2K_REG_COMMAND),
+             NE2K_COMMAND_STOP | NE2K_COMMAND_PAGE0);
+    reset_value = io->inb(io->context, (uint16_t)(base_port + NE2K_REG_RESET));
+    io->outb(io->context, (uint16_t)(base_port + NE2K_REG_RESET), reset_value);
+    if ((io->inb(io->context, (uint16_t)(base_port + NE2K_REG_ISR)) & NE2K_ISR_RESET) == 0U)
+        return -2;
+    return 0;
+}
+
+int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io) {
+    uint16_t base;
+    if (!device || !io || !io->outb || device->base_port == 0U) return -1;
+    base = device->base_port;
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_COMMAND),
+             NE2K_COMMAND_STOP | NE2K_COMMAND_PAGE0);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_DCR), NE2K_DCR_WORD_MODE);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_ISR), 0xffU);
+    device->initialized = 1U;
+    return 0;
+}

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -1,0 +1,36 @@
+#ifndef AIOS_NE2K_H
+#define AIOS_NE2K_H
+
+#include <stdint.h>
+
+#define NE2K_REG_COMMAND 0x00U
+#define NE2K_REG_RESET   0x1fU
+#define NE2K_REG_DCR     0x0eU
+#define NE2K_REG_ISR     0x07U
+#define NE2K_COMMAND_STOP 0x01U
+#define NE2K_COMMAND_PAGE0 0x00U
+#define NE2K_COMMAND_PAGE1 0x40U
+#define NE2K_DCR_WORD_MODE 0x49U
+#define NE2K_ISR_RESET 0x80U
+
+typedef uint8_t (*ne2k_inb_fn)(void* context, uint16_t port);
+typedef void (*ne2k_outb_fn)(void* context, uint16_t port, uint8_t value);
+
+typedef struct {
+    void* context;
+    ne2k_inb_fn inb;
+    ne2k_outb_fn outb;
+} ne2k_io_t;
+
+typedef struct {
+    uint16_t base_port;
+    uint8_t initialized;
+    uint8_t mac[6];
+} ne2k_device_t;
+
+/* Sonde le registre reset et prépare le mode arrêt/word pour une init ultérieure. */
+int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io);
+/* Initialise les paramètres invariants du contrôleur sans allocation. */
+int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,6 +108,12 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_n
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_pci: $(UNIT_DIR)/kernel/test_pci.c ../kernel/pci.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/pci.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -120,6 +120,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
     fi
+    if [ "$(basename "$test_file")" = "test_ne2k.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/ne2k.c"
+    fi
     if [ "$(basename "$test_file")" = "test_pci.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/pci.c"
     fi

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -1,0 +1,50 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/ne2k.h"
+
+typedef struct {
+    uint8_t reset;
+    uint8_t isr;
+    uint8_t writes;
+} fake_ne2k_t;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static uint8_t fake_inb(void* context, uint16_t port) {
+    fake_ne2k_t* fake = (fake_ne2k_t*)context;
+    if ((port & 0x1fU) == NE2K_REG_RESET) return fake->reset;
+    if ((port & 0x1fU) == NE2K_REG_ISR) return fake->isr;
+    return 0U;
+}
+
+static void fake_outb(void* context, uint16_t port, uint8_t value) {
+    fake_ne2k_t* fake = (fake_ne2k_t*)context;
+    fake->writes++;
+    if ((port & 0x1fU) == NE2K_REG_RESET) fake->reset = value;
+}
+
+void test_probe_and_prepare_use_injected_io(void) {
+    fake_ne2k_t fake = {0x12, NE2K_ISR_RESET, 0};
+    ne2k_io_t io = {&fake, fake_inb, fake_outb};
+    ne2k_device_t device;
+    TEST_ASSERT_EQUAL(0, ne2k_probe(&device, 0x300, &io));
+    TEST_ASSERT_EQUAL(0, ne2k_prepare(&device, &io));
+    TEST_ASSERT_EQUAL(1, device.initialized);
+    TEST_ASSERT_GREATER_THAN(2, fake.writes);
+}
+
+void test_probe_rejects_missing_reset_ack(void) {
+    fake_ne2k_t fake = {0, 0, 0};
+    ne2k_io_t io = {&fake, fake_inb, fake_outb};
+    ne2k_device_t device;
+    TEST_ASSERT_NOT_EQUAL(0, ne2k_probe(&device, 0x300, &io));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_probe_and_prepare_use_injected_io);
+    RUN_TEST(test_probe_rejects_missing_reset_ack);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Résumé

Ajoute une sonde NE2000 minimale pour le contrôleur `ne2k_isa` de QEMU, avec interface d’E/S injectable et sans allocation dynamique.

## Modifications

- séquence STOP/reset et préparation word-mode;
- test Unity par callbacks `inb/outb` simulés;
- intégration Makefile et runner;
- documentation française AOS-117.

## Validation

- `make test-all`: 274/274 tests verts;
- `make all`: build i386 et initrd réussis.

La lecture MAC, les anneaux RX/TX et l’émission de trames restent le prochain sous-lot; cette PR ne prétend pas encore fournir un transport réseau.