### PR TITLE
Lot 118: validation MAC NE2000

### DIFF
--- a/docs/aos118_ne2k_mac_validation.md
+++ b/docs/aos118_ne2k_mac_validation.md
@@ -1,0 +1,5 @@
+# AOS-118 — Validation de l’adresse MAC NE2000
+
+Le lot AOS-118 complète la sonde NE2000 par `ne2k_set_mac`, une opération caller-owned qui copie une adresse MAC locale après validation. Les adresses nulles et multicast sont rejetées; aucune allocation ni référence vers le buffer d’entrée n’est conservée.
+
+Le test NE2000 vérifie une adresse unicast valide, le rejet de `00:00:00:00:00:00` et le rejet d’une adresse dont le bit multicast est positionné. La validation locale est de **274 tests verts** avec compilation Unity complète. Le pilote ne lit pas encore la PROM matérielle et ne transmet pas de trame; cette extension sécurise le contrat de configuration avant l’implémentation RX/TX.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -16,6 +16,17 @@ int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io) {
     return 0;
 }
 
+int ne2k_set_mac(ne2k_device_t* device, const uint8_t mac[6]) {
+    uint32_t i;
+    uint8_t nonzero = 0U;
+    if (!device || !mac || (mac[0] & 1U) != 0U) return -1;
+    for (i = 0; i < 6U; ++i) {
+        device->mac[i] = mac[i];
+        if (mac[i] != 0U) nonzero = 1U;
+    }
+    return nonzero ? 0 : -2;
+}
+
 int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io) {
     uint16_t base;
     if (!device || !io || !io->outb || device->base_port == 0U) return -1;

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -32,5 +32,7 @@ typedef struct {
 int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io);
 /* Initialise les paramètres invariants du contrôleur sans allocation. */
 int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io);
+/* Définit une MAC locale valide: non nulle et non multicast. */
+int ne2k_set_mac(ne2k_device_t* device, const uint8_t mac[6]);
 
 #endif

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -31,6 +31,9 @@ void test_probe_and_prepare_use_injected_io(void) {
     TEST_ASSERT_EQUAL(0, ne2k_prepare(&device, &io));
     TEST_ASSERT_EQUAL(1, device.initialized);
     TEST_ASSERT_GREATER_THAN(2, fake.writes);
+    { uint8_t mac[6] = {0x02, 0, 0, 0, 0, 1}; TEST_ASSERT_EQUAL(0, ne2k_set_mac(&device, mac)); TEST_ASSERT_EQUAL(0x02, device.mac[0]); }
+    { uint8_t zero[6] = {0, 0, 0, 0, 0, 0}; TEST_ASSERT_NOT_EQUAL(0, ne2k_set_mac(&device, zero)); }
+    { uint8_t multicast[6] = {0x01, 0, 0, 0, 0, 1}; TEST_ASSERT_NOT_EQUAL(0, ne2k_set_mac(&device, multicast)); }
 }
 
 void test_probe_rejects_missing_reset_ack(void) {


### PR DESCRIPTION
## Résumé

Complète la sonde NE2000 par une validation caller-owned de l’adresse MAC locale.

## Contrat

Les adresses nulles et multicast sont rejetées; une adresse unicast valide est copiée dans l’état du périphérique sans conserver le buffer source.

## Validation

- `make test-all`: 274/274 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-118.

La lecture PROM et les anneaux RX/TX restent les prochaines étapes.