### PR TITLE
Lot 119: extraction RX NE2000 bornée

### DIFF
--- a/docs/aos119_ne2k_rx_extract.md
+++ b/docs/aos119_ne2k_rx_extract.md
@@ -1,0 +1,9 @@
+# AOS-119 — Extraction RX NE2000 bornée
+
+Le lot AOS-119 ajoute `ne2k_rx_extract`, une primitive qui lit l’en-tête de réception fourni par le DMA NE2000, valide le statut et la longueur little-endian, copie uniquement la charge utile dans une file `net_nic_queue_t`, puis publie la longueur par `commit`.
+
+La fonction rejette les buffers trop courts, les paquets dont le bit de succès est absent, les longueurs inférieures à l’en-tête ou supérieures au buffer DMA et les files saturées. Elle ne lit jamais au-delà des bornes fournies et n’alloue aucune mémoire.
+
+Le test `test_ne2k.c` couvre la publication FIFO d’une trame de cinq octets et le rejet d’une réception en erreur. La validation locale est de **275 tests verts**, avec compilation complète de la suite Unity. Le build i386 devra être relancé avant publication de la PR.
+
+Cette primitive prépare le chemin RX mais ne programme pas encore les registres de ring NE2000, ne traite pas les interruptions et ne fournit pas de transmission TX autonome.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -27,6 +27,29 @@ int ne2k_set_mac(ne2k_device_t* device, const uint8_t mac[6]) {
     return nonzero ? 0 : -2;
 }
 
+int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
+                    net_nic_queue_t* rx_queue) {
+    uint16_t packet_length;
+    uint8_t* destination;
+    uint16_t capacity;
+    if (!dma_buffer || !rx_queue || dma_length < NE2K_RX_HEADER_SIZE)
+        return -1;
+    if ((dma_buffer[0] & NE2K_RX_STATUS_OK) == 0U) return -2;
+    packet_length = (uint16_t)(dma_buffer[2] | ((uint16_t)dma_buffer[3] << 8));
+    if (packet_length < NE2K_RX_HEADER_SIZE || packet_length > dma_length)
+        return -3;
+    if (net_nic_queue_acquire(rx_queue, &destination, &capacity) != 0 ||
+        packet_length - NE2K_RX_HEADER_SIZE > capacity)
+        return -4;
+    {
+        uint16_t i;
+        for (i = 0; i < packet_length - NE2K_RX_HEADER_SIZE; ++i)
+            destination[i] = dma_buffer[NE2K_RX_HEADER_SIZE + i];
+    }
+    return net_nic_queue_commit(rx_queue,
+                                 (uint16_t)(packet_length - NE2K_RX_HEADER_SIZE));
+}
+
 int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io) {
     uint16_t base;
     if (!device || !io || !io->outb || device->base_port == 0U) return -1;

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -2,6 +2,7 @@
 #define AIOS_NE2K_H
 
 #include <stdint.h>
+#include "net_nic.h"
 
 #define NE2K_REG_COMMAND 0x00U
 #define NE2K_REG_RESET   0x1fU
@@ -12,6 +13,8 @@
 #define NE2K_COMMAND_PAGE1 0x40U
 #define NE2K_DCR_WORD_MODE 0x49U
 #define NE2K_ISR_RESET 0x80U
+#define NE2K_RX_HEADER_SIZE 4U
+#define NE2K_RX_STATUS_OK 0x01U
 
 typedef uint8_t (*ne2k_inb_fn)(void* context, uint16_t port);
 typedef void (*ne2k_outb_fn)(void* context, uint16_t port, uint8_t value);
@@ -34,5 +37,8 @@ int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io);
 int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io);
 /* Définit une MAC locale valide: non nulle et non multicast. */
 int ne2k_set_mac(ne2k_device_t* device, const uint8_t mac[6]);
+/* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */
+int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
+                    net_nic_queue_t* rx_queue);
 
 #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,9 +108,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_n
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -122,6 +122,7 @@ run_test() {
     fi
     if [ "$(basename "$test_file")" = "test_ne2k.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/ne2k.c"
+        extra_src="$extra_src $BASE_DIR/kernel/net_nic.c"
     fi
     if [ "$(basename "$test_file")" = "test_pci.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/pci.c"

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -36,6 +36,18 @@ void test_probe_and_prepare_use_injected_io(void) {
     { uint8_t multicast[6] = {0x01, 0, 0, 0, 0, 1}; TEST_ASSERT_NOT_EQUAL(0, ne2k_set_mac(&device, multicast)); }
 }
 
+void test_rx_extract_publishes_bounded_frame(void) {
+    uint8_t storage[NET_NIC_QUEUE_CAPACITY * 64U] = {0};
+    uint8_t dma[9] = {NE2K_RX_STATUS_OK, 0, 9, 0, 1, 2, 3, 4, 5};
+    net_nic_queue_t queue; uint8_t* frame; uint16_t length;
+    TEST_ASSERT_EQUAL(0, net_nic_queue_init(&queue, storage, sizeof(storage), 64));
+    TEST_ASSERT_EQUAL(0, ne2k_rx_extract(dma, sizeof(dma), &queue));
+    TEST_ASSERT_EQUAL(0, net_nic_queue_pop(&queue, &frame, &length));
+    TEST_ASSERT_EQUAL(5, length); TEST_ASSERT_EQUAL(1, frame[0]); TEST_ASSERT_EQUAL(5, frame[4]);
+    dma[0] = 0; TEST_ASSERT_NOT_EQUAL(0, ne2k_rx_extract(dma, sizeof(dma), &queue));
+}
+
+
 void test_probe_rejects_missing_reset_ack(void) {
     fake_ne2k_t fake = {0, 0, 0};
     ne2k_io_t io = {&fake, fake_inb, fake_outb};
@@ -46,6 +58,7 @@ void test_probe_rejects_missing_reset_ack(void) {
 int main(void) {
     unity_init();
     RUN_TEST(test_probe_and_prepare_use_injected_io);
+    RUN_TEST(test_rx_extract_publishes_bounded_frame);
     RUN_TEST(test_probe_rejects_missing_reset_ack);
     unity_print_results();
     unity_cleanup();


### PR DESCRIPTION
## Résumé

Ajoute l’extraction bornée d’une trame RX NE2000 vers la file NIC caller-owned.

## Contrat

Le statut et la longueur du paquet sont validés avant copie; les buffers courts, les statuts en erreur, les longueurs incohérentes et les files pleines sont rejetés.

## Validation

- `make test-all`: 275/275 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-119.

La programmation matérielle du ring RX, les interruptions et le chemin TX restent à implémenter.