### PR TITLE
Lot 120: mise en file TX Ethernet

### DIFF
--- a/docs/aos120_nic_tx_queue.md
+++ b/docs/aos120_nic_tx_queue.md
@@ -1,0 +1,7 @@
+# AOS-120 — Mise en file TX Ethernet
+
+Le lot AOS-120 ajoute `net_nic_queue_push_frame`, une primitive TX caller-owned qui rejette les trames inférieures à la taille Ethernet minimale de 60 octets, vérifie la capacité de l’emplacement réservé, copie les octets dans la file et publie la trame par `commit`.
+
+Cette opération ne transmet pas encore sur le contrôleur NE2000. Elle sépare explicitement la préparation d’une trame du futur transfert matériel, évite les allocations dynamiques et garantit qu’une trame trop courte ne quitte pas le contrat Ethernet.
+
+Le test `test_net_nic.c` couvre le rejet d’une trame de 59 octets, la copie et la restitution FIFO d’une trame de 60 octets. La validation locale est de **276 tests verts** et le build i386 complet réussit.

--- a/kernel/net_nic.c
+++ b/kernel/net_nic.c
@@ -62,3 +62,17 @@ int net_nic_queue_pop(net_nic_queue_t* queue, uint8_t** buffer,
 uint8_t net_nic_queue_count(const net_nic_queue_t* queue) {
     return queue ? queue->count : 0U;
 }
+
+int net_nic_queue_push_frame(net_nic_queue_t* queue, const uint8_t* frame,
+                             uint16_t length) {
+    uint8_t* destination;
+    uint16_t capacity;
+    uint16_t i;
+    if (!queue || !frame || length < NET_NIC_ETHERNET_MIN_FRAME)
+        return -1;
+    if (net_nic_queue_acquire(queue, &destination, &capacity) != 0 ||
+        length > capacity)
+        return -2;
+    for (i = 0; i < length; ++i) destination[i] = frame[i];
+    return net_nic_queue_commit(queue, length);
+}

--- a/kernel/net_nic.h
+++ b/kernel/net_nic.h
@@ -5,6 +5,7 @@
 
 #define NET_NIC_QUEUE_CAPACITY 8U
 #define NET_NIC_FRAME_CAPACITY 1536U
+#define NET_NIC_ETHERNET_MIN_FRAME 60U
 
 typedef struct {
     uint8_t* storage;
@@ -34,5 +35,8 @@ int net_nic_queue_commit(net_nic_queue_t* queue, uint16_t length);
 int net_nic_queue_pop(net_nic_queue_t* queue, uint8_t** buffer,
                       uint16_t* length);
 uint8_t net_nic_queue_count(const net_nic_queue_t* queue);
+/* Copie et publie une trame Ethernet TX après validation des bornes. */
+int net_nic_queue_push_frame(net_nic_queue_t* queue, const uint8_t* frame,
+                             uint16_t length);
 
 #endif

--- a/tests/unit/kernel/test_net_nic.c
+++ b/tests/unit/kernel/test_net_nic.c
@@ -21,6 +21,21 @@ void test_queue_is_fifo_and_caller_owned(void) {
     TEST_ASSERT_EQUAL(0xa5, buffer[0]);
 }
 
+void test_queue_push_frame_validates_ethernet_size(void) {
+    uint8_t storage[NET_NIC_QUEUE_CAPACITY * 64U] = {0};
+    uint8_t frame[60] = {0};
+    net_nic_queue_t queue;
+    uint8_t* received;
+    uint16_t length;
+    frame[0] = 0xa5;
+    TEST_ASSERT_EQUAL(0, net_nic_queue_init(&queue, storage, sizeof(storage), 64));
+    TEST_ASSERT_NOT_EQUAL(0, net_nic_queue_push_frame(&queue, frame, 59));
+    TEST_ASSERT_EQUAL(0, net_nic_queue_push_frame(&queue, frame, 60));
+    TEST_ASSERT_EQUAL(0, net_nic_queue_pop(&queue, &received, &length));
+    TEST_ASSERT_EQUAL(60, length);
+    TEST_ASSERT_EQUAL(0xa5, received[0]);
+}
+
 void test_queue_rejects_bad_capacity_and_reset(void) {
     uint8_t storage[NET_NIC_QUEUE_CAPACITY * 64U] = {0};
     net_nic_queue_t queue;
@@ -37,6 +52,7 @@ void test_queue_rejects_bad_capacity_and_reset(void) {
 int main(void) {
     unity_init();
     RUN_TEST(test_queue_is_fifo_and_caller_owned);
+    RUN_TEST(test_queue_push_frame_validates_ethernet_size);
     RUN_TEST(test_queue_rejects_bad_capacity_and_reset);
     unity_print_results();
     unity_cleanup();


### PR DESCRIPTION
## Résumé

Ajoute la préparation TX caller-owned d’une trame Ethernet dans la file NIC statique.

## Contrat

Les trames de moins de 60 octets sont rejetées; les autres sont copiées dans un emplacement borné puis publiées FIFO sans allocation dynamique.

## Validation

- `make test-all`: 276/276 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-120.

L’émission matérielle NE2000 reste le prochain jalon.