### PR TITLE
Lot 121: codec DHCP DISCOVER OFFER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
 # Une évolution de structure doit donc reconstruire toute l'image, pas seulement ipc.o.
@@ -168,6 +168,10 @@ build/pci.o: kernel/pci.c kernel/pci.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/ne2k.o: kernel/ne2k.c kernel/ne2k.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/net_dhcp.o: kernel/net_dhcp.c kernel/net_dhcp.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/aos121_dhcp_codec.md
+++ b/docs/aos121_dhcp_codec.md
@@ -1,0 +1,7 @@
+# AOS-121 — Codec DHCP DISCOVER/OFFER
+
+Le lot AOS-121 introduit un codec DHCP caller-owned pour préparer la configuration IPv4 sans secret intégré. `net_dhcp_build_discover` construit un message DISCOVER avec XID, adresse MAC, cookie magique et option de type. `net_dhcp_parse_offer` vérifie le type BOOTP, le XID attendu, le cookie, le type OFFER et la présence d’un identifiant serveur avant de copier l’adresse offerte et celle du serveur.
+
+Les longueurs d’options sont contrôlées avant chaque lecture. Les fonctions n’allouent pas de mémoire et écrivent uniquement dans les structures ou buffers fournis par l’appelant. Le codec ne transporte encore aucun paquet UDP: il constitue la couche de représentation avant le raccordement au pilote NE2000 et à IPv4/UDP.
+
+Le test `test_net_dhcp.c` couvre la construction, le cookie, le XID, le parsing d’un OFFER et le rejet d’un XID inattendu. La validation locale est de **277 tests verts**, avec build i386 et initrd réussis.

--- a/kernel/net_dhcp.c
+++ b/kernel/net_dhcp.c
@@ -1,0 +1,58 @@
+#include "net_dhcp.h"
+
+static void put_be32(uint8_t* p, uint32_t value) {
+    p[0] = (uint8_t)(value >> 24); p[1] = (uint8_t)(value >> 16);
+    p[2] = (uint8_t)(value >> 8); p[3] = (uint8_t)value;
+}
+static uint32_t get_be32(const uint8_t* p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8) | p[3];
+}
+static void copy_bytes(uint8_t* dst, const uint8_t* src, uint32_t n) {
+    uint32_t i; for (i = 0; i < n; ++i) dst[i] = src[i];
+}
+
+int net_dhcp_build_discover(uint8_t* packet, uint32_t capacity,
+                            uint32_t xid, const uint8_t mac[6]) {
+    uint32_t i;
+    if (!packet || !mac || capacity < 244U) return -1;
+    for (i = 0; i < 244U; ++i) packet[i] = 0U;
+    packet[0] = 1U; packet[1] = 1U; packet[2] = 6U;
+    put_be32(packet + 4, xid);
+    copy_bytes(packet + 28, mac, 6);
+    put_be32(packet + 236, NET_DHCP_MAGIC_COOKIE);
+    packet[240] = NET_DHCP_OPTION_MESSAGE_TYPE; packet[241] = 1U;
+    packet[242] = NET_DHCP_DISCOVER; packet[243] = NET_DHCP_OPTION_END;
+    return 244;
+}
+
+int net_dhcp_parse_offer(const uint8_t* packet, uint32_t length,
+                         uint32_t expected_xid, net_dhcp_offer_t* out) {
+    uint32_t pos;
+    uint8_t type = 0U;
+    uint8_t server_seen = 0U;
+    if (!packet || !out || length < 244U || packet[0] != 2U ||
+        get_be32(packet + 4) != expected_xid ||
+        get_be32(packet + 236) != NET_DHCP_MAGIC_COOKIE)
+        return -1;
+    copy_bytes(out->offered_ip, packet + 16, 4);
+    out->server_ip[0] = out->server_ip[1] = out->server_ip[2] = out->server_ip[3] = 0U;
+    out->xid = expected_xid;
+    for (pos = 240U; pos < length;) {
+        uint8_t code = packet[pos++];
+        uint8_t size;
+        if (code == NET_DHCP_OPTION_END) break;
+        if (code == 0U) continue;
+        if (pos >= length) return -2;
+        size = packet[pos++];
+        if (pos + size > length) return -2;
+        if (code == NET_DHCP_OPTION_MESSAGE_TYPE && size == 1U) type = packet[pos];
+        if (code == NET_DHCP_OPTION_SERVER_ID && size == 4U) {
+            copy_bytes(out->server_ip, packet + pos, 4); server_seen = 1U;
+        }
+        pos += size;
+    }
+    if (type != NET_DHCP_OFFER || !server_seen) return -3;
+    out->message_type = type;
+    return 0;
+}

--- a/kernel/net_dhcp.h
+++ b/kernel/net_dhcp.h
@@ -1,0 +1,27 @@
+#ifndef AIOS_NET_DHCP_H
+#define AIOS_NET_DHCP_H
+
+#include <stdint.h>
+
+#define NET_DHCP_FIXED_HEADER 236U
+#define NET_DHCP_COOKIE_SIZE 4U
+#define NET_DHCP_MAGIC_COOKIE 0x63825363U
+#define NET_DHCP_OPTION_MESSAGE_TYPE 53U
+#define NET_DHCP_OPTION_SERVER_ID 54U
+#define NET_DHCP_OPTION_END 255U
+#define NET_DHCP_DISCOVER 1U
+#define NET_DHCP_OFFER 2U
+
+typedef struct {
+    uint32_t xid;
+    uint8_t offered_ip[4];
+    uint8_t server_ip[4];
+    uint8_t message_type;
+} net_dhcp_offer_t;
+
+int net_dhcp_build_discover(uint8_t* packet, uint32_t capacity,
+                            uint32_t xid, const uint8_t mac[6]);
+int net_dhcp_parse_offer(const uint8_t* packet, uint32_t length,
+                         uint32_t expected_xid, net_dhcp_offer_t* out);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,6 +108,12 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_n
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dhcp: $(UNIT_DIR)/kernel/test_net_dhcp.c ../kernel/net_dhcp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_dhcp.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -120,6 +120,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
     fi
+    if [ "$(basename "$test_file")" = "test_net_dhcp.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/net_dhcp.c"
+    fi
     if [ "$(basename "$test_file")" = "test_ne2k.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/ne2k.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_nic.c"

--- a/tests/unit/kernel/test_net_dhcp.c
+++ b/tests/unit/kernel/test_net_dhcp.c
@@ -1,0 +1,32 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/net_dhcp.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_build_and_parse_dhcp_offer(void) {
+    uint8_t packet[256] = {0};
+    uint8_t mac[6] = {2, 0, 0, 0, 0, 1};
+    net_dhcp_offer_t offer;
+    TEST_ASSERT_EQUAL(244, net_dhcp_build_discover(packet, sizeof(packet), 0x12345678U, mac));
+    TEST_ASSERT_EQUAL(1, packet[0]);
+    TEST_ASSERT_EQUAL(0x63, packet[236]);
+    packet[0] = 2;
+    packet[16] = 10; packet[17] = 0; packet[18] = 2; packet[19] = 15;
+    packet[240] = NET_DHCP_OPTION_MESSAGE_TYPE; packet[241] = 1; packet[242] = NET_DHCP_OFFER;
+    packet[243] = NET_DHCP_OPTION_SERVER_ID; packet[244] = 4;
+    packet[245] = 10; packet[246] = 0; packet[247] = 2; packet[248] = 2;
+    packet[249] = NET_DHCP_OPTION_END;
+    TEST_ASSERT_EQUAL(0, net_dhcp_parse_offer(packet, 250, 0x12345678U, &offer));
+    TEST_ASSERT_EQUAL(10, offer.offered_ip[0]);
+    TEST_ASSERT_EQUAL(2, offer.server_ip[3]);
+    TEST_ASSERT_NOT_EQUAL(0, net_dhcp_parse_offer(packet, 250, 0x87654321U, &offer));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_build_and_parse_dhcp_offer);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Résumé

Ajoute un codec DHCP caller-owned pour construire un DISCOVER et parser un OFFER associé au XID attendu.

## Contrat

Cookie, XID, types de message, identifiant serveur et longueurs d’options sont validés sans allocation dynamique ni secret intégré.

## Validation

- `make test-all`: 277/277 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-121.

Le transport UDP/IPv4 et le raccordement réel au NE2000 restent les prochaines étapes.