### PR TITLE
Lot 122: codec IPv4 UDP caller-owned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o build/net_ipv4_udp.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
 # Une évolution de structure doit donc reconstruire toute l'image, pas seulement ipc.o.
@@ -172,6 +172,10 @@ build/ne2k.o: kernel/ne2k.c kernel/ne2k.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/net_dhcp.o: kernel/net_dhcp.c kernel/net_dhcp.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/net_ipv4_udp.o: kernel/net_ipv4_udp.c kernel/net_ipv4_udp.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/aos122_ipv4_udp_codec.md
+++ b/docs/aos122_ipv4_udp_codec.md
@@ -1,0 +1,5 @@
+# AOS-122 — Codec IPv4/UDP caller-owned
+
+Le lot AOS-122 ajoute le checksum IPv4 et la construction/parsing bornés de datagrammes UDP sur IPv4. Les adresses, ports, protocole, longueur totale et checksum d’en-tête sont vérifiés sans allocation dynamique. Le checksum UDP reste explicitement nul, ce qui est autorisé pour UDP sur IPv4 et sera complété lors de l’intégration du pseudo-en-tête et du transport réel.
+
+Le test `test_net_ipv4_udp.c` couvre la construction, le parsing, les ports, le payload et le rejet d’un en-tête modifié. La validation locale est de **278 tests verts**, avec build i386 et initrd réussis. Le codec ne transmet encore aucun paquet: il constitue la couche de représentation avant le raccordement au NE2000 et au DHCP.

--- a/kernel/net_ipv4_udp.c
+++ b/kernel/net_ipv4_udp.c
@@ -1,0 +1,53 @@
+#include "net_ipv4_udp.h"
+
+static uint16_t get16(const uint8_t* p) { return (uint16_t)(((uint16_t)p[0] << 8) | p[1]); }
+static void put16(uint8_t* p, uint16_t v) { p[0] = (uint8_t)(v >> 8); p[1] = (uint8_t)v; }
+static void copy4(uint8_t* d, const uint8_t* s) { d[0]=s[0]; d[1]=s[1]; d[2]=s[2]; d[3]=s[3]; }
+
+uint16_t net_ipv4_checksum(const uint8_t* header, uint16_t length) {
+    uint32_t sum = 0U; uint16_t i;
+    if (!header || (length & 1U) != 0U) return 0U;
+    for (i = 0; i < length; i += 2U) {
+        sum += get16(header + i);
+        while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16);
+    }
+    return (uint16_t)~sum;
+}
+
+int net_udp_build_ipv4(uint8_t* packet, uint32_t capacity,
+                       const uint8_t source_ip[4], const uint8_t destination_ip[4],
+                       uint16_t source_port, uint16_t destination_port,
+                       const uint8_t* payload, uint16_t payload_length) {
+    uint16_t total = (uint16_t)(NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE + payload_length);
+    uint16_t i;
+    if (!packet || !source_ip || !destination_ip || (payload_length && !payload) ||
+        capacity < total || total < NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE)
+        return -1;
+    for (i = 0; i < NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE; ++i) packet[i] = 0U;
+    packet[0] = 0x45U; put16(packet + 2, total); packet[6] = 0x40U;
+    packet[8] = 64U; packet[9] = NET_IPV4_PROTOCOL_UDP;
+    copy4(packet + 12, source_ip); copy4(packet + 16, destination_ip);
+    put16(packet + 10, net_ipv4_checksum(packet, NET_IPV4_HEADER_SIZE));
+    put16(packet + 20, source_port); put16(packet + 22, destination_port);
+    put16(packet + 24, (uint16_t)(NET_UDP_HEADER_SIZE + payload_length));
+    /* UDP checksum is optional for IPv4; zero is explicit and deterministic. */
+    put16(packet + 26, 0U);
+    for (i = 0; i < payload_length; ++i) packet[28U + i] = payload[i];
+    return total;
+}
+
+int net_udp_parse_ipv4(const uint8_t* packet, uint32_t length,
+                       net_udp_view_t* out) {
+    uint16_t total; uint16_t udp_length;
+    if (!packet || !out || length < 28U || (packet[0] >> 4) != 4U ||
+        (packet[0] & 0x0fU) != 5U || packet[9] != NET_IPV4_PROTOCOL_UDP)
+        return -1;
+    total = get16(packet + 2); udp_length = get16(packet + 24);
+    if (total < 28U || total > length || udp_length < 8U ||
+        udp_length > total - 20U || net_ipv4_checksum(packet, 20U) != 0U)
+        return -2;
+    copy4(out->source_ip, packet + 12); copy4(out->destination_ip, packet + 16);
+    out->source_port = get16(packet + 20); out->destination_port = get16(packet + 22);
+    out->payload = packet + 28; out->payload_length = (uint16_t)(udp_length - 8U);
+    return 0;
+}

--- a/kernel/net_ipv4_udp.h
+++ b/kernel/net_ipv4_udp.h
@@ -1,0 +1,27 @@
+#ifndef AIOS_NET_IPV4_UDP_H
+#define AIOS_NET_IPV4_UDP_H
+
+#include <stdint.h>
+
+#define NET_IPV4_HEADER_SIZE 20U
+#define NET_UDP_HEADER_SIZE 8U
+#define NET_IPV4_PROTOCOL_UDP 17U
+
+typedef struct {
+    uint8_t source_ip[4];
+    uint8_t destination_ip[4];
+    uint16_t source_port;
+    uint16_t destination_port;
+    const uint8_t* payload;
+    uint16_t payload_length;
+} net_udp_view_t;
+
+uint16_t net_ipv4_checksum(const uint8_t* header, uint16_t length);
+int net_udp_build_ipv4(uint8_t* packet, uint32_t capacity,
+                       const uint8_t source_ip[4], const uint8_t destination_ip[4],
+                       uint16_t source_port, uint16_t destination_port,
+                       const uint8_t* payload, uint16_t payload_length);
+int net_udp_parse_ipv4(const uint8_t* packet, uint32_t length,
+                       net_udp_view_t* out);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,6 +108,12 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_n
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ipv4_udp: $(UNIT_DIR)/kernel/test_net_ipv4_udp.c ../kernel/net_ipv4_udp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_ipv4_udp.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dhcp: $(UNIT_DIR)/kernel/test_net_dhcp.c ../kernel/net_dhcp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_dhcp.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -120,6 +120,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
     fi
+    if [ "$(basename "$test_file")" = "test_net_ipv4_udp.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/net_ipv4_udp.c"
+    fi
     if [ "$(basename "$test_file")" = "test_net_dhcp.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/net_dhcp.c"
     fi

--- a/tests/unit/kernel/test_net_ipv4_udp.c
+++ b/tests/unit/kernel/test_net_ipv4_udp.c
@@ -1,0 +1,28 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/net_ipv4_udp.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_build_parse_udp_ipv4(void) {
+    uint8_t packet[64] = {0};
+    uint8_t source[4] = {10,0,2,15}; uint8_t dest[4] = {10,0,2,2};
+    uint8_t payload[3] = {'D','H','C'};
+    net_udp_view_t view;
+    TEST_ASSERT_EQUAL(31, net_udp_build_ipv4(packet, sizeof(packet), source, dest, 68, 67, payload, 3));
+    TEST_ASSERT_EQUAL(0, net_udp_parse_ipv4(packet, 31, &view));
+    TEST_ASSERT_EQUAL(68, view.source_port);
+    TEST_ASSERT_EQUAL(67, view.destination_port);
+    TEST_ASSERT_EQUAL(3, view.payload_length);
+    TEST_ASSERT_EQUAL('D', view.payload[0]);
+    packet[12] ^= 1U;
+    TEST_ASSERT_NOT_EQUAL(0, net_udp_parse_ipv4(packet, 31, &view));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_build_parse_udp_ipv4);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Résumé

Ajoute le checksum IPv4 et la construction/parsing bornés de datagrammes UDP sur IPv4.

## Validation

- `make test-all`: 278/278 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-122.

Le raccordement au NE2000, le pseudo-en-tête UDP complet, DHCP effectif et les couches DNS/TCP restent à implémenter.