### PR TITLE
Lot 123: codec DNS A caller-owned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o build/net_ipv4_udp.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o build/net_ipv4_udp.o build/net_dns.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
 # Une évolution de structure doit donc reconstruire toute l'image, pas seulement ipc.o.
@@ -176,6 +176,10 @@ build/net_dhcp.o: kernel/net_dhcp.c kernel/net_dhcp.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/net_ipv4_udp.o: kernel/net_ipv4_udp.c kernel/net_ipv4_udp.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/net_dns.o: kernel/net_dns.c kernel/net_dns.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/aos123_dns_codec.md
+++ b/docs/aos123_dns_codec.md
@@ -1,0 +1,5 @@
+# AOS-123 — Codec DNS A caller-owned
+
+Le lot AOS-123 ajoute la construction bornée d’une requête DNS de type A et le parsing d’une réponse contenant un enregistrement A. Les labels sont encodés sans allocation dynamique et chaque longueur est contrôlée. Le parseur vérifie l’identifiant, le bit de réponse, le code RCODE, la section question et accepte les noms compressés dans les réponses avant de copier l’adresse IPv4 trouvée.
+
+Le test `test_net_dns.c` couvre la requête `example.com`, l’identifiant DNS et une réponse A compressée vers `10.0.2.15`, ainsi que le rejet d’un identifiant inattendu. La validation locale est de **279 tests verts** et le build i386 réussit. Le codec ne transmet pas encore de datagramme et devra être raccordé à UDP/IPv4 et au résolveur configuré par DHCP.

--- a/kernel/net_dns.c
+++ b/kernel/net_dns.c
@@ -1,0 +1,67 @@
+#include "net_dns.h"
+
+static uint16_t get16(const uint8_t* p) { return (uint16_t)(((uint16_t)p[0] << 8) | p[1]); }
+static void put16(uint8_t* p, uint16_t v) { p[0] = (uint8_t)(v >> 8); p[1] = (uint8_t)v; }
+
+int net_dns_build_a_query(uint8_t* packet, uint32_t capacity,
+                          uint16_t id, const char* hostname) {
+    uint32_t pos = NET_DNS_HEADER_SIZE, label_start, label_len = 0U;
+    const char* cursor;
+    uint32_t i;
+    if (!packet || !hostname || capacity < NET_DNS_HEADER_SIZE + 5U) return -1;
+    for (i = 0; i < NET_DNS_HEADER_SIZE; ++i) packet[i] = 0U;
+    put16(packet, id); packet[2] = 1U; packet[5] = 1U;
+    cursor = hostname;
+    while (*cursor) {
+        label_start = pos; pos++;
+        label_len = 0U;
+        while (cursor[label_len] && cursor[label_len] != '.') {
+            if (label_len >= 63U) return -2;
+            label_len++;
+        }
+        if (pos + label_len + 1U + 4U > capacity) return -3;
+        packet[label_start] = (uint8_t)label_len;
+        for (i = 0; i < label_len; ++i) packet[pos + i] = (uint8_t)cursor[i];
+        pos += label_len;
+        cursor += label_len;
+        if (*cursor == '.') cursor++;
+    }
+    if (label_len == 0U || pos + 5U > capacity) return -4;
+    packet[pos++] = 0U; put16(packet + pos, NET_DNS_TYPE_A); pos += 2U;
+    put16(packet + pos, NET_DNS_CLASS_IN); pos += 2U;
+    return (int)pos;
+}
+
+int net_dns_parse_a_response(const uint8_t* packet, uint32_t length,
+                             uint16_t expected_id, net_dns_a_result_t* out) {
+    uint16_t qd, an; uint32_t pos; uint16_t i;
+    if (!packet || !out || length < NET_DNS_HEADER_SIZE || get16(packet) != expected_id ||
+        (packet[2] & 0x80U) == 0U || (packet[3] & 0x0fU) != 0U) return -1;
+    qd = get16(packet + 4); an = get16(packet + 6);
+    if (qd == 0U || an == 0U) return -2;
+    pos = NET_DNS_HEADER_SIZE;
+    for (i = 0; i < qd; ++i) {
+        uint32_t guard = 0U;
+        while (pos < length && packet[pos] != 0U && guard++ < length) {
+            uint8_t n = packet[pos++];
+            if ((n & 0xc0U) != 0U || n > 63U || pos + n > length) return -3;
+            pos += n;
+        }
+        if (pos >= length || ++pos + 4U > length) return -3;
+        pos += 4U;
+    }
+    for (i = 0; i < an; ++i) {
+        uint16_t type, class_code, rdlen;
+        if (pos + 12U > length) return -4;
+        if ((packet[pos] & 0xc0U) == 0xc0U) pos += 2U;
+        else { while (pos < length && packet[pos] != 0U) { uint8_t n=packet[pos++]; if (n>63U || pos+n>length) return -4; pos+=n; } if (pos>=length) return -4; pos++; }
+        if (pos + 10U > length) return -4;
+        type = get16(packet + pos); class_code = get16(packet + pos + 2U); rdlen = get16(packet + pos + 8U); pos += 10U;
+        if (pos + rdlen > length) return -4;
+        if (type == NET_DNS_TYPE_A && class_code == NET_DNS_CLASS_IN && rdlen == 4U) {
+            out->id = expected_id; out->address[0]=packet[pos]; out->address[1]=packet[pos+1]; out->address[2]=packet[pos+2]; out->address[3]=packet[pos+3]; return 0;
+        }
+        pos += rdlen;
+    }
+    return -5;
+}

--- a/kernel/net_dns.h
+++ b/kernel/net_dns.h
@@ -1,0 +1,20 @@
+#ifndef AIOS_NET_DNS_H
+#define AIOS_NET_DNS_H
+
+#include <stdint.h>
+
+#define NET_DNS_HEADER_SIZE 12U
+#define NET_DNS_TYPE_A 1U
+#define NET_DNS_CLASS_IN 1U
+
+typedef struct {
+    uint16_t id;
+    uint8_t address[4];
+} net_dns_a_result_t;
+
+int net_dns_build_a_query(uint8_t* packet, uint32_t capacity,
+                          uint16_t id, const char* hostname);
+int net_dns_parse_a_response(const uint8_t* packet, uint32_t length,
+                             uint16_t expected_id, net_dns_a_result_t* out);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,6 +108,12 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_n
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dns: $(UNIT_DIR)/kernel/test_net_dns.c ../kernel/net_dns.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_dns.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ipv4_udp: $(UNIT_DIR)/kernel/test_net_ipv4_udp.c ../kernel/net_ipv4_udp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_ipv4_udp.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -120,6 +120,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
     fi
+    if [ "$(basename "$test_file")" = "test_net_dns.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/net_dns.c"
+    fi
     if [ "$(basename "$test_file")" = "test_net_ipv4_udp.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/net_ipv4_udp.c"
     fi

--- a/tests/unit/kernel/test_net_dns.c
+++ b/tests/unit/kernel/test_net_dns.c
@@ -1,0 +1,29 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/net_dns.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_dns_query_and_a_response(void) {
+    uint8_t packet[128] = {0};
+    net_dns_a_result_t result;
+    int length = net_dns_build_a_query(packet, sizeof(packet), 0x4321, "example.com");
+    TEST_ASSERT_GREATER_THAN(12, length);
+    TEST_ASSERT_EQUAL(0x43, packet[0]); TEST_ASSERT_EQUAL(0x21, packet[1]);
+    packet[2] = 0x81; packet[3] = 0x80; packet[6] = 0; packet[7] = 1;
+    packet[length++] = 0xc0; packet[length++] = 0x0c;
+    packet[length++] = 0; packet[length++] = 1; packet[length++] = 0; packet[length++] = 1;
+    packet[length++] = 0; packet[length++] = 0; packet[length++] = 0; packet[length++] = 30;
+    packet[length++] = 0; packet[length++] = 4; packet[length++] = 10; packet[length++] = 0; packet[length++] = 2; packet[length++] = 15;
+    TEST_ASSERT_EQUAL(0, net_dns_parse_a_response(packet, (uint32_t)length, 0x4321, &result));
+    TEST_ASSERT_EQUAL(10, result.address[0]); TEST_ASSERT_EQUAL(15, result.address[3]);
+    TEST_ASSERT_NOT_EQUAL(0, net_dns_parse_a_response(packet, (uint32_t)length, 0x1111, &result));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_dns_query_and_a_response);
+    unity_print_results();
+    unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Résumé

Ajoute la construction bornée d’une requête DNS A et le parsing d’une réponse A avec compression de noms.

## Validation

- `make test-all`: 279/279 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-123.

Le transport UDP effectif, la configuration DNS issue de DHCP et TCP restent à intégrer.