### PR TITLE
Lot 124: codec TCP SYN SYN-ACK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o build/net_ipv4_udp.o build/net_dns.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o build/net_ipv4_udp.o build/net_dns.o build/net_tcp.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
 # Une évolution de structure doit donc reconstruire toute l'image, pas seulement ipc.o.
@@ -180,6 +180,10 @@ build/net_ipv4_udp.o: kernel/net_ipv4_udp.c kernel/net_ipv4_udp.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/net_dns.o: kernel/net_dns.c kernel/net_dns.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/net_tcp.o: kernel/net_tcp.c kernel/net_tcp.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/aos124_tcp_syn_codec.md
+++ b/docs/aos124_tcp_syn_codec.md
@@ -1,0 +1,7 @@
+# AOS-124 — Codec TCP SYN/SYN-ACK caller-owned
+
+Le lot AOS-124 ajoute un codec TCP minimal pour construire un segment SYN et parser un segment TCP avec en-tête standard. Les ports nuls, les en-têtes inférieurs à 20 octets et les longueurs d’en-tête incohérentes sont rejetés. Les séquences, acquittements, drapeaux et payload sont exposés dans une vue bornée sans allocation dynamique.
+
+Le codec ne fournit pas encore de checksum pseudo-en-tête, de retransmission, de temporisation, de fenêtre ou d’état de connexion. Il établit le contrat de représentation nécessaire avant l’intégration TCP sur IPv4 et la future couche TLS.
+
+Le test `test_net_tcp.c` couvre la construction SYN, le parsing SYN-ACK et le rejet d’un port source nul. La validation locale est de **280 tests verts**, avec build i386 et initrd réussis.

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -1,0 +1,32 @@
+#include "net_tcp.h"
+
+static uint16_t get16(const uint8_t* p) { return (uint16_t)(((uint16_t)p[0] << 8) | p[1]); }
+static uint32_t get32(const uint8_t* p) { return ((uint32_t)p[0]<<24)|((uint32_t)p[1]<<16)|((uint32_t)p[2]<<8)|p[3]; }
+static void put16(uint8_t* p, uint16_t v) { p[0]=(uint8_t)(v>>8); p[1]=(uint8_t)v; }
+static void put32(uint8_t* p, uint32_t v) { p[0]=(uint8_t)(v>>24); p[1]=(uint8_t)(v>>16); p[2]=(uint8_t)(v>>8); p[3]=(uint8_t)v; }
+
+int net_tcp_build_syn(uint8_t* segment, uint32_t capacity,
+                      uint16_t source_port, uint16_t destination_port,
+                      uint32_t sequence) {
+    uint16_t i;
+    if (!segment || capacity < NET_TCP_HEADER_SIZE || source_port == 0U || destination_port == 0U) return -1;
+    for (i=0; i<NET_TCP_HEADER_SIZE; ++i) segment[i]=0U;
+    put16(segment, source_port); put16(segment+2, destination_port);
+    put32(segment+4, sequence); segment[12]=0x50U; segment[13]=NET_TCP_FLAG_SYN;
+    put16(segment+14, 65535U);
+    return NET_TCP_HEADER_SIZE;
+}
+
+int net_tcp_parse(const uint8_t* segment, uint32_t length, net_tcp_view_t* out) {
+    uint8_t header_words;
+    uint16_t header_size;
+    if (!segment || !out || length < NET_TCP_HEADER_SIZE) return -1;
+    header_words = (uint8_t)(segment[12] >> 4); header_size = (uint16_t)header_words * 4U;
+    if (header_words < 5U || header_size > length) return -2;
+    out->source_port=get16(segment); out->destination_port=get16(segment+2);
+    if (out->source_port == 0U || out->destination_port == 0U) return -3;
+    out->sequence=get32(segment+4); out->acknowledgment=get32(segment+8);
+    out->flags=(uint8_t)(segment[13] & 0x3fU);
+    out->payload=segment+header_size; out->payload_length=(uint16_t)(length-header_size);
+    return 0;
+}

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -1,0 +1,28 @@
+#ifndef AIOS_NET_TCP_H
+#define AIOS_NET_TCP_H
+
+#include <stdint.h>
+
+#define NET_TCP_HEADER_SIZE 20U
+#define NET_TCP_FLAG_FIN 0x01U
+#define NET_TCP_FLAG_SYN 0x02U
+#define NET_TCP_FLAG_RST 0x04U
+#define NET_TCP_FLAG_ACK 0x10U
+
+typedef struct {
+    uint16_t source_port;
+    uint16_t destination_port;
+    uint32_t sequence;
+    uint32_t acknowledgment;
+    uint8_t flags;
+    const uint8_t* payload;
+    uint16_t payload_length;
+} net_tcp_view_t;
+
+int net_tcp_build_syn(uint8_t* segment, uint32_t capacity,
+                      uint16_t source_port, uint16_t destination_port,
+                      uint32_t sequence);
+int net_tcp_parse(const uint8_t* segment, uint32_t length,
+                  net_tcp_view_t* out);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,6 +108,12 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_n
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_tcp: $(UNIT_DIR)/kernel/test_net_tcp.c ../kernel/net_tcp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_tcp.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dns: $(UNIT_DIR)/kernel/test_net_dns.c ../kernel/net_dns.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_dns.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -120,6 +120,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
     fi
+    if [ "$(basename "$test_file")" = "test_net_tcp.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/net_tcp.c"
+    fi
     if [ "$(basename "$test_file")" = "test_net_dns.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/net_dns.c"
     fi

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -1,0 +1,23 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/net_tcp.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_build_and_parse_syn_ack(void) {
+    uint8_t segment[32] = {0}; net_tcp_view_t view;
+    TEST_ASSERT_EQUAL(20, net_tcp_build_syn(segment, sizeof(segment), 49152, 443, 0x10203040U));
+    TEST_ASSERT_EQUAL(0, net_tcp_parse(segment, 20, &view));
+    TEST_ASSERT_EQUAL(49152, view.source_port); TEST_ASSERT_EQUAL(443, view.destination_port);
+    TEST_ASSERT_EQUAL(0x10203040U, view.sequence); TEST_ASSERT_EQUAL(NET_TCP_FLAG_SYN, view.flags);
+    segment[13] = NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK; segment[8]=0x10; segment[9]=0x20; segment[10]=0x30; segment[11]=0x41;
+    TEST_ASSERT_EQUAL(0, net_tcp_parse(segment, 20, &view));
+    TEST_ASSERT_EQUAL(NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, view.flags);
+    TEST_ASSERT_EQUAL(0x10203041U, view.acknowledgment);
+    segment[0] = 0; segment[1] = 0; TEST_ASSERT_NOT_EQUAL(0, net_tcp_parse(segment, 20, &view));
+}
+
+int main(void) {
+    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); unity_print_results(); unity_cleanup();
+    return (unity_stats.tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Résumé

Ajoute un codec TCP caller-owned pour construire un SYN et parser un SYN-ACK.

## Validation

- `make test-all`: 280/280 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-124.

La machine TCP complète, les checksums pseudo-en-tête, retransmissions, TLS et HTTP restent à implémenter.