### PR TITLE
Lot 125: checksum TCP IPv4

### DIFF
--- a/docs/aos125_tcp_ipv4_checksum.md
+++ b/docs/aos125_tcp_ipv4_checksum.md
@@ -1,0 +1,7 @@
+# AOS-125 — Checksum TCP IPv4
+
+Le lot AOS-125 complète le codec TCP par le calcul du checksum avec pseudo-en-tête IPv4. La fonction additionne les adresses source et destination, le protocole TCP, la longueur et les octets du segment, puis replie les retenues 16 bits. Elle accepte les segments de longueur paire ou impaire et ne modifie jamais le buffer caller-owned.
+
+Ce lot prépare la validation du segment TCP avant émission sur IPv4. Il ne fournit pas encore de machine d’état, de retransmission, de contrôle de fenêtre, de checksum écrit automatiquement dans l’en-tête, de TLS ou de HTTP.
+
+Le test TCP couvre la stabilité du checksum pour un segment SYN-ACK. La validation locale est de **280 tests verts**, avec build i386 et initrd réussis.

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -17,6 +17,25 @@ int net_tcp_build_syn(uint8_t* segment, uint32_t capacity,
     return NET_TCP_HEADER_SIZE;
 }
 
+uint16_t net_tcp_checksum_ipv4(const uint8_t source_ip[4], const uint8_t destination_ip[4],
+                               const uint8_t* segment, uint16_t length) {
+    uint32_t sum = 0U; uint16_t i;
+    if (!source_ip || !destination_ip || !segment || length == 0U) return 0U;
+    sum += ((uint16_t)source_ip[0] << 8) | source_ip[1];
+    sum += ((uint16_t)source_ip[2] << 8) | source_ip[3];
+    sum += ((uint16_t)destination_ip[0] << 8) | destination_ip[1];
+    sum += ((uint16_t)destination_ip[2] << 8) | destination_ip[3];
+    sum += NET_TCP_PROTOCOL;
+    sum += length;
+    for (i = 0; i + 1U < length; i += 2U) {
+        sum += get16(segment + i);
+        while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16);
+    }
+    if (length & 1U) sum += (uint16_t)segment[length - 1U] << 8;
+    while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16);
+    return (uint16_t)~sum;
+}
+
 int net_tcp_parse(const uint8_t* segment, uint32_t length, net_tcp_view_t* out) {
     uint8_t header_words;
     uint16_t header_size;

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #define NET_TCP_HEADER_SIZE 20U
+#define NET_TCP_PROTOCOL 6U
 #define NET_TCP_FLAG_FIN 0x01U
 #define NET_TCP_FLAG_SYN 0x02U
 #define NET_TCP_FLAG_RST 0x04U
@@ -24,5 +25,8 @@ int net_tcp_build_syn(uint8_t* segment, uint32_t capacity,
                       uint32_t sequence);
 int net_tcp_parse(const uint8_t* segment, uint32_t length,
                   net_tcp_view_t* out);
+/* Calcule le checksum TCP IPv4 sur le segment caller-owned. */
+uint16_t net_tcp_checksum_ipv4(const uint8_t source_ip[4], const uint8_t destination_ip[4],
+                               const uint8_t* segment, uint16_t length);
 
 #endif

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -13,6 +13,7 @@ void test_build_and_parse_syn_ack(void) {
     segment[13] = NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK; segment[8]=0x10; segment[9]=0x20; segment[10]=0x30; segment[11]=0x41;
     TEST_ASSERT_EQUAL(0, net_tcp_parse(segment, 20, &view));
     TEST_ASSERT_EQUAL(NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, view.flags);
+    { uint8_t source[4] = {10,0,2,15}; uint8_t destination[4] = {10,0,2,2}; uint16_t checksum = net_tcp_checksum_ipv4(source, destination, segment, 20); TEST_ASSERT_NOT_EQUAL(0, checksum); TEST_ASSERT_EQUAL(checksum, net_tcp_checksum_ipv4(source, destination, segment, 20)); }
     TEST_ASSERT_EQUAL(0x10203041U, view.acknowledgment);
     segment[0] = 0; segment[1] = 0; TEST_ASSERT_NOT_EQUAL(0, net_tcp_parse(segment, 20, &view));
 }


### PR DESCRIPTION
## Résumé

Ajoute le calcul du checksum TCP avec pseudo-en-tête IPv4, sans modifier le segment caller-owned.

## Validation

- `make test-all`: 280/280 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-125.

La machine TCP complète, TLS et HTTP restent à implémenter.