### PR TITLE
Lot 127: HMAC SHA-256 caller-owned

### DIFF
--- a/docs/aos127_hmac_sha256.md
+++ b/docs/aos127_hmac_sha256.md
@@ -1,0 +1,5 @@
+# AOS-127 — HMAC-SHA-256 caller-owned
+
+Le lot AOS-127 complète la primitive SHA-256 par HMAC-SHA-256. Les clés supérieures à 64 octets sont d’abord condensées, puis les pads interne et externe sont traités via le contexte SHA-256 existant. Les buffers temporaires sont locaux à l’appel; aucune allocation dynamique et aucun secret persistant ne sont introduits.
+
+Le test couvre les vecteurs SHA-256 de la chaîne vide et de `abc`, ainsi que le vecteur RFC 4231 `key=0b…0b`, message `Hi There`. La validation locale est de **283 tests verts**, avec build i386 et initrd réussis. Cette brique prépare TLS mais ne constitue pas encore une implémentation X.509 ou HTTPS.

--- a/kernel/sha256.c
+++ b/kernel/sha256.c
@@ -5,3 +5,22 @@ static void transform(sha256_ctx_t*c,const uint8_t*b){uint32_t w[64],a,bb,cc,d,e
 void sha256_init(sha256_ctx_t*c){static const uint32_t s[8]={0x6a09e667U,0xbb67ae85U,0x3c6ef372U,0xa54ff53aU,0x510e527fU,0x9b05688cU,0x1f83d9abU,0x5be0cd19U};uint32_t i;if(!c)return;for(i=0;i<8;i++)c->state[i]=s[i];c->bit_count=0;c->block_len=0;}
 void sha256_update(sha256_ctx_t*c,const uint8_t*d,uint32_t n){uint32_t take;if(!c||(!d&&n))return;c->bit_count+=(uint64_t)n*8U;while(n){take=64U-c->block_len;if(take>n)take=n;{uint32_t i;for(i=0;i<take;i++)c->block[c->block_len+i]=d[i];}c->block_len+=take;d+=take;n-=take;if(c->block_len==64U){transform(c,c->block);c->block_len=0;}}}
 void sha256_final(sha256_ctx_t*c,uint8_t digest[32]){uint32_t i;uint64_t bits;if(!c||!digest)return;bits=c->bit_count;c->block[c->block_len++]=0x80U;while(c->block_len!=56U){if(c->block_len==64U){transform(c,c->block);c->block_len=0;}else c->block[c->block_len++]=0U;}for(i=0;i<8;i++)c->block[56+i]=(uint8_t)(bits>>(56U-8U*i));transform(c,c->block);for(i=0;i<8;i++){digest[4*i]=(uint8_t)(c->state[i]>>24);digest[4*i+1]=(uint8_t)(c->state[i]>>16);digest[4*i+2]=(uint8_t)(c->state[i]>>8);digest[4*i+3]=(uint8_t)c->state[i];}}
+
+void hmac_sha256(const uint8_t* key, uint32_t key_length,
+                 const uint8_t* message, uint32_t message_length,
+                 uint8_t digest[32]) {
+    uint8_t block[64], inner[32];
+    sha256_ctx_t ctx;
+    uint32_t i;
+    if ((!key && key_length) || (!message && message_length) || !digest) return;
+    for (i = 0; i < 64U; ++i) block[i] = 0U;
+    if (key_length > 64U) {
+        sha256_init(&ctx); sha256_update(&ctx, key, key_length); sha256_final(&ctx, block);
+    } else {
+        for (i = 0; i < key_length; ++i) block[i] = key[i];
+    }
+    for (i = 0; i < 64U; ++i) block[i] ^= 0x36U;
+    sha256_init(&ctx); sha256_update(&ctx, block, 64U); sha256_update(&ctx, message, message_length); sha256_final(&ctx, inner);
+    for (i = 0; i < 64U; ++i) block[i] ^= (uint8_t)(0x36U ^ 0x5cU);
+    sha256_init(&ctx); sha256_update(&ctx, block, 64U); sha256_update(&ctx, inner, 32U); sha256_final(&ctx, digest);
+}

--- a/kernel/sha256.h
+++ b/kernel/sha256.h
@@ -5,4 +5,7 @@ typedef struct { uint32_t state[8]; uint64_t bit_count; uint8_t block[64]; uint3
 void sha256_init(sha256_ctx_t* ctx);
 void sha256_update(sha256_ctx_t* ctx, const uint8_t* data, uint32_t length);
 void sha256_final(sha256_ctx_t* ctx, uint8_t digest[32]);
+void hmac_sha256(const uint8_t* key, uint32_t key_length,
+                 const uint8_t* message, uint32_t message_length,
+                 uint8_t digest[32]);
 #endif

--- a/tests/unit/kernel/test_sha256.c
+++ b/tests/unit/kernel/test_sha256.c
@@ -8,6 +8,12 @@ void test_sha256_empty(void){
     TEST_ASSERT_EQUAL(0x42,d[3]);
     TEST_ASSERT_EQUAL(0x55,d[31]);
 }
+void test_hmac_sha256(void){
+    uint8_t key[20], digest[32]; const uint8_t message[] = "Hi There"; uint32_t i;
+    for (i=0;i<20;i++) key[i]=0x0b;
+    hmac_sha256(key,20,message,8,digest);
+    TEST_ASSERT_EQUAL(0xb0,digest[0]); TEST_ASSERT_EQUAL(0x34,digest[1]); TEST_ASSERT_EQUAL(0x4c,digest[2]); TEST_ASSERT_EQUAL(0xf7,digest[31]);
+}
 void test_sha256_fragmented_abc(void){
     sha256_ctx_t c; uint8_t d[32]; const uint8_t a[]={'a','b','c'};
     sha256_init(&c); sha256_update(&c,a,1); sha256_update(&c,a+1,2); sha256_final(&c,d);
@@ -16,4 +22,4 @@ void test_sha256_fragmented_abc(void){
     TEST_ASSERT_EQUAL(0x16,d[2]);
     TEST_ASSERT_EQUAL(0xad,d[31]);
 }
-int main(void){unity_init();RUN_TEST(test_sha256_empty);RUN_TEST(test_sha256_fragmented_abc);unity_print_results();unity_cleanup();return unity_stats.tests_failed==0?0:1;}
+int main(void){unity_init();RUN_TEST(test_sha256_empty);RUN_TEST(test_sha256_fragmented_abc);RUN_TEST(test_hmac_sha256);unity_print_results();unity_cleanup();return unity_stats.tests_failed==0?0:1;}


### PR DESCRIPTION
## Résumé

Ajoute HMAC-SHA-256 au module crypto freestanding existant, sans allocation dynamique.

## Validation

- `make test-all`: 283/283 tests verts;
- `make all`: build i386 et initrd réussis;
- vecteur HMAC RFC 4231 vérifié;
- documentation française AOS-127.

La validation X.509, TLS et HTTP restent à implémenter.