### PR TITLE
Lot 128: framing TLS record caller-owned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
           build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
-          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o build/net_ipv4_udp.o build/net_dns.o build/net_tcp.o build/sha256.o
+          build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o build/net_ipv4_udp.o build/net_dns.o build/net_tcp.o build/sha256.o build/net_tls_record.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
 # Une évolution de structure doit donc reconstruire toute l'image, pas seulement ipc.o.
@@ -188,6 +188,10 @@ build/net_tcp.o: kernel/net_tcp.c kernel/net_tcp.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/sha256.o: kernel/sha256.c kernel/sha256.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/net_tls_record.o: kernel/net_tls_record.c kernel/net_tls_record.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/aos128_tls_record_codec.md
+++ b/docs/aos128_tls_record_codec.md
@@ -1,0 +1,7 @@
+# AOS-128 — Codec TLS record caller-owned
+
+Le lot AOS-128 ajoute le framing TLS record pour TLS 1.2: type de contenu, version `3.3`, longueur 16 bits et payload. La construction copie uniquement dans un buffer fourni par l’appelant; le parsing retourne une vue bornée sans allocation et rejette les versions incohérentes, les types nuls et les longueurs dépassant le paquet.
+
+Cette primitive ne réalise pas de handshake, de dérivation de clés, de chiffrement, de validation X.509 ni de HTTP. Elle établit seulement un contrat de transport pour les futurs messages TLS, en complément de SHA-256 et HMAC-SHA-256.
+
+Le test `test_net_tls_record.c` couvre la construction et le parsing d’un record Handshake ainsi que le rejet d’une version invalide. La validation locale est de **284 tests verts**, avec build i386 et initrd réussis.

--- a/kernel/net_tls_record.c
+++ b/kernel/net_tls_record.c
@@ -1,0 +1,5 @@
+#include "net_tls_record.h"
+static uint16_t get16(const uint8_t* p){return (uint16_t)(((uint16_t)p[0]<<8)|p[1]);}
+static void put16(uint8_t* p,uint16_t v){p[0]=(uint8_t)(v>>8);p[1]=(uint8_t)v;}
+int net_tls_record_build(uint8_t* record,uint32_t capacity,uint8_t content_type,const uint8_t* payload,uint16_t payload_length){uint16_t i;if(!record||(!payload&&payload_length)||capacity<(uint32_t)NET_TLS_RECORD_HEADER+payload_length||content_type==0U)return -1;record[0]=content_type;record[1]=NET_TLS_VERSION_1_2_MAJOR;record[2]=NET_TLS_VERSION_1_2_MINOR;put16(record+3,payload_length);for(i=0;i<payload_length;i++)record[5+i]=payload[i];return (int)(5U+payload_length);}
+int net_tls_record_parse(const uint8_t* record,uint32_t length,net_tls_record_view_t* out){uint16_t payload_length;if(!record||!out||length<NET_TLS_RECORD_HEADER||record[1]!=NET_TLS_VERSION_1_2_MAJOR||record[2]!=NET_TLS_VERSION_1_2_MINOR)return -1;payload_length=get16(record+3);if((uint32_t)payload_length+NET_TLS_RECORD_HEADER>length||record[0]==0U)return -2;out->content_type=record[0];out->major=record[1];out->minor=record[2];out->payload=record+5;out->payload_length=payload_length;return 0;}

--- a/kernel/net_tls_record.h
+++ b/kernel/net_tls_record.h
@@ -1,0 +1,11 @@
+#ifndef AIOS_NET_TLS_RECORD_H
+#define AIOS_NET_TLS_RECORD_H
+#include <stdint.h>
+#define NET_TLS_RECORD_HEADER 5U
+#define NET_TLS_CONTENT_HANDSHAKE 22U
+#define NET_TLS_VERSION_1_2_MAJOR 3U
+#define NET_TLS_VERSION_1_2_MINOR 3U
+typedef struct { uint8_t content_type; uint8_t major; uint8_t minor; const uint8_t* payload; uint16_t payload_length; } net_tls_record_view_t;
+int net_tls_record_build(uint8_t* record, uint32_t capacity, uint8_t content_type, const uint8_t* payload, uint16_t payload_length);
+int net_tls_record_parse(const uint8_t* record, uint32_t length, net_tls_record_view_t* out);
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,6 +108,12 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_ethernet_arp: $(UNIT_DIR)/kernel/test_n
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_tls_record: $(UNIT_DIR)/kernel/test_net_tls_record.c ../kernel/net_tls_record.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_tls_record.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_sha256: $(UNIT_DIR)/kernel/test_sha256.c ../kernel/sha256.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/sha256.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -120,6 +120,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_service_registry.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/service_registry.c"
     fi
+    if [ "$(basename "$test_file")" = "test_net_tls_record.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/net_tls_record.c"
+    fi
     if [ "$(basename "$test_file")" = "test_sha256.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/sha256.c"
     fi

--- a/tests/unit/kernel/test_net_tls_record.c
+++ b/tests/unit/kernel/test_net_tls_record.c
@@ -1,0 +1,5 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/net_tls_record.h"
+void setUp(void){} void tearDown(void){}
+void test_tls_record_build_parse(void){uint8_t record[32]={0},payload[3]={'C','H','1'};net_tls_record_view_t view;TEST_ASSERT_EQUAL(8,net_tls_record_build(record,sizeof(record),NET_TLS_CONTENT_HANDSHAKE,payload,3));TEST_ASSERT_EQUAL(0,net_tls_record_parse(record,8,&view));TEST_ASSERT_EQUAL(NET_TLS_CONTENT_HANDSHAKE,view.content_type);TEST_ASSERT_EQUAL(3,view.payload_length);TEST_ASSERT_EQUAL('C',view.payload[0]);record[2]=2;TEST_ASSERT_NOT_EQUAL(0,net_tls_record_parse(record,8,&view));}
+int main(void){unity_init();RUN_TEST(test_tls_record_build_parse);unity_print_results();unity_cleanup();return unity_stats.tests_failed==0?0:1;}


### PR DESCRIPTION
## Résumé

Ajoute le framing TLS 1.2 record avec construction et parsing bornés.

## Validation

- `make test-all`: 284/284 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-128.

Aucun handshake, chiffrement, certificat ou secret n’est intégré par cette PR.