### PR TITLE
Lot 129: configuration des anneaux NE2000

### DIFF
--- a/docs/aos129_ne2k_ring_config.md
+++ b/docs/aos129_ne2k_ring_config.md
@@ -1,0 +1,7 @@
+# AOS-129 — Configuration des anneaux NE2000
+
+Le lot AOS-129 ajoute la configuration bornée des pages mémoire NE2000: page de transmission `0x40`, anneau de réception `0x46..0x60`, frontière de réception initiale `0x46`, réception broadcast et activation du contrôleur. La séquence est effectuée via les callbacks d’E/S injectables existants, sans allocation dynamique ni état global.
+
+Le lot ne prétend pas encore effectuer le DMA distant, la lecture PROM de la MAC, l’émission matérielle ou le raccordement du périphérique QEMU au chemin de boot. Il établit le contrat d’initialisation qui précède le polling RX/TX effectif.
+
+La validation locale est de **284 tests verts**, incluant trois scénarios NE2000, avec build i386 et initrd réussis.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -16,6 +16,22 @@ int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io) {
     return 0;
 }
 
+int ne2k_configure_rings(ne2k_device_t* device, const ne2k_io_t* io) {
+    uint16_t base;
+    if (!device || !io || !io->outb || device->base_port == 0U) return -1;
+    base = device->base_port;
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_COMMAND),
+             NE2K_COMMAND_STOP | NE2K_COMMAND_PAGE0);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_TPSR), 0x40U);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_PSTART), 0x46U);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_PSTOP), 0x60U);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_BNRY), 0x46U);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_RCR), 0x04U);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_TCR), 0x00U);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_COMMAND), 0x22U);
+    return 0;
+}
+
 int ne2k_set_mac(ne2k_device_t* device, const uint8_t mac[6]) {
     uint32_t i;
     uint8_t nonzero = 0U;

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -8,6 +8,13 @@
 #define NE2K_REG_RESET   0x1fU
 #define NE2K_REG_DCR     0x0eU
 #define NE2K_REG_ISR     0x07U
+#define NE2K_REG_TPSR    0x04U
+#define NE2K_REG_PSTART  0x01U
+#define NE2K_REG_PSTOP   0x02U
+#define NE2K_REG_BNRY    0x03U
+#define NE2K_REG_RCR     0x0cU
+#define NE2K_REG_TCR     0x0dU
+#define NE2K_REG_CURR    0x07U
 #define NE2K_COMMAND_STOP 0x01U
 #define NE2K_COMMAND_PAGE0 0x00U
 #define NE2K_COMMAND_PAGE1 0x40U
@@ -35,6 +42,8 @@ typedef struct {
 int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io);
 /* Initialise les paramètres invariants du contrôleur sans allocation. */
 int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io);
+/* Configure un anneau RX et une page TX dans la mémoire locale du NE2000. */
+int ne2k_configure_rings(ne2k_device_t* device, const ne2k_io_t* io);
 /* Définit une MAC locale valide: non nulle et non multicast. */
 int ne2k_set_mac(ne2k_device_t* device, const uint8_t mac[6]);
 /* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -29,8 +29,9 @@ void test_probe_and_prepare_use_injected_io(void) {
     ne2k_device_t device;
     TEST_ASSERT_EQUAL(0, ne2k_probe(&device, 0x300, &io));
     TEST_ASSERT_EQUAL(0, ne2k_prepare(&device, &io));
+    TEST_ASSERT_EQUAL(0, ne2k_configure_rings(&device, &io));
     TEST_ASSERT_EQUAL(1, device.initialized);
-    TEST_ASSERT_GREATER_THAN(2, fake.writes);
+    TEST_ASSERT_GREATER_THAN(8, fake.writes);
     { uint8_t mac[6] = {0x02, 0, 0, 0, 0, 1}; TEST_ASSERT_EQUAL(0, ne2k_set_mac(&device, mac)); TEST_ASSERT_EQUAL(0x02, device.mac[0]); }
     { uint8_t zero[6] = {0, 0, 0, 0, 0, 0}; TEST_ASSERT_NOT_EQUAL(0, ne2k_set_mac(&device, zero)); }
     { uint8_t multicast[6] = {0x01, 0, 0, 0, 0, 1}; TEST_ASSERT_NOT_EQUAL(0, ne2k_set_mac(&device, multicast)); }


### PR DESCRIPTION
## Résumé

Configure les pages RX/TX du NE2000 via callbacks d’E/S caller-owned.

## Validation

- `make test-all`: 284/284 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-129.

Le DMA, l’émission matérielle et le raccordement boot/QEMU restent à implémenter.