### PR TITLE
Lot 130: adaptateur I/O i386 NE2000

### DIFF
--- a/docs/aos130_ne2k_i386_io.md
+++ b/docs/aos130_ne2k_i386_io.md
@@ -1,0 +1,7 @@
+# AOS-130 — Adaptateur d’E/S i386 NE2000
+
+Le lot AOS-130 ajoute `ne2k_i386_io`, qui fournit les callbacks `inb/outb` réels du noyau i386 aux primitives NE2000 existantes. L’assembleur inline est encapsulé dans le pilote et l’API retourne un refus hors i386; les tests Unity continuent d’utiliser des callbacks simulés et ne touchent jamais les ports matériels.
+
+Cette étape permet le raccordement ultérieur du probe et de la configuration des anneaux à un `ne2k_isa` QEMU. Elle ne modifie pas encore le chemin de boot, ne lit pas la PROM MAC et n’envoie aucune trame.
+
+La validation locale est de **284 tests verts**, avec build i386 et initrd réussis.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -1,5 +1,26 @@
 #include "ne2k.h"
 
+#ifdef __i386__
+static uint8_t ne2k_i386_inb(void* context, uint16_t port) {
+    uint8_t value; (void)context;
+    __asm__ volatile ("inb %1, %0" : "=a"(value) : "Nd"(port));
+    return value;
+}
+static void ne2k_i386_outb(void* context, uint16_t port, uint8_t value) {
+    (void)context;
+    __asm__ volatile ("outb %0, %1" : : "a"(value), "Nd"(port));
+}
+#endif
+
+int ne2k_i386_io(ne2k_io_t* io) {
+    if (!io) return -1;
+#ifdef __i386__
+    io->context = (void*)0; io->inb = ne2k_i386_inb; io->outb = ne2k_i386_outb; return 0;
+#else
+    io->context = (void*)0; io->inb = (ne2k_inb_fn)0; io->outb = (ne2k_outb_fn)0; return -1;
+#endif
+}
+
 int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io) {
     uint8_t reset_value;
     if (!device || !io || !io->inb || !io->outb || base_port == 0U) return -1;

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -40,6 +40,8 @@ typedef struct {
 
 /* Sonde le registre reset et prépare le mode arrêt/word pour une init ultérieure. */
 int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io);
+/* Prépare les callbacks de ports i386 réels; retourne -1 hors noyau i386. */
+int ne2k_i386_io(ne2k_io_t* io);
 /* Initialise les paramètres invariants du contrôleur sans allocation. */
 int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io);
 /* Configure un anneau RX et une page TX dans la mémoire locale du NE2000. */


### PR DESCRIPTION
## Résumé

Expose les callbacks `inb/outb` i386 réels au pilote NE2000, avec refus hors i386.

## Validation

- `make test-all`: 284/284 tests verts;
- `make all`: build i386 et initrd réussis;
- documentation française AOS-130.

Le raccordement au boot et l’émission matérielle restent à implémenter.