### PR TITLE
Captures QEMU : curseur, défilement et commandes de test

### DIFF
--- a/tests/scripts/gui_screendump.py
+++ b/tests/scripts/gui_screendump.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""QEMU GTK screendumps: shell, help, scrollback, FAT16, net-status."""
+"""QEMU GTK screendumps: shell, help, scrollback, FAT16, ps, mem, net-status."""
 from __future__ import print_function
 
 import os
@@ -11,13 +11,13 @@ import time
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 KERNEL = os.path.join(ROOT, "build", "ai_os.bin")
 INITRD = os.path.join(ROOT, "my_initrd.tar")
-DISK = os.path.join(ROOT, "build", "overlay.img")
+DISK = os.path.join(ROOT, "test_logs", "gui-capture-overlay.img")
 LOG_DIR = os.path.join(ROOT, "test_logs")
 LOG = os.path.join(LOG_DIR, "gui-capture-serial.log")
 ERR = os.path.join(LOG_DIR, "gui-capture-stderr.log")
 MON_SOCK = os.path.join(LOG_DIR, "gui-capture-monitor.sock")
 SHOT_DIR = "/opt/cursor/artifacts/screenshots"
-KEY_DELAY = 0.55
+KEY_DELAY = 0.65
 BOOT_TIMEOUT = 90.0
 
 
@@ -112,6 +112,15 @@ def screendump(client, name):
     print("saved", path, os.path.getsize(path))
 
 
+def prepare_disk():
+    os.makedirs(LOG_DIR, exist_ok=True)
+    subprocess.run([
+        sys.executable,
+        os.path.join(ROOT, "tests", "scripts", "make_fat16_image.py"),
+        "--image", DISK,
+    ], check=True)
+
+
 def terminate(proc):
     if proc is None or proc.poll() is not None:
         return
@@ -125,6 +134,7 @@ def terminate(proc):
 def main():
     os.makedirs(LOG_DIR, exist_ok=True)
     os.makedirs(SHOT_DIR, exist_ok=True)
+    prepare_disk()
     for path in (LOG, ERR, MON_SOCK):
         try:
             os.remove(path)
@@ -178,14 +188,30 @@ def main():
             time.sleep(0.6)
             screendump(monitor, "06-fat16-list.png")
 
+            send_command(monitor, "fat16-cat fatok.txt")
+            wait_for(proc, "ligne lue: fat16-cat", 25)
+            time.sleep(0.6)
+            screendump(monitor, "07-fat16-cat.png")
+
             send_command(monitor, "net-status")
             wait_for(proc, "ligne lue: net-status", 20)
             time.sleep(0.6)
-            screendump(monitor, "07-net-status.png")
+            screendump(monitor, "08-net-status.png")
+
+            send_command(monitor, "ps")
+            wait_for(proc, "ligne lue: ps", 20)
+            time.sleep(0.6)
+            screendump(monitor, "09-ps.png")
+
+            send_command(monitor, "mem")
+            wait_for(proc, "ligne lue: mem", 20)
+            time.sleep(0.6)
+            screendump(monitor, "10-mem.png")
 
             send_command(monitor, "ai-runtime")
-            wait_for(proc, "ligne lue: ai-runtime", 20)
-            screendump(monitor, "08-ai-runtime.png")
+            wait_for(proc, "Runtime IA bare-metal", 25)
+            time.sleep(0.6)
+            screendump(monitor, "11-ai-runtime.png")
         print("GUI capture done")
         return 0
     finally:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Captures QEMU GTK des tests shell après fusion de la console VGA (curseur bloc, Page Up/Down, FAT16, réseau, `ps`, `mem`, runtime IA).

Le script `tests/scripts/gui_screendump.py` recrée un disque FAT16 isolé et enregistre les PNG.

## Captures

Prompt et curseur bloc :

[Prompt shell et curseur bloc](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F01-shell.png)

`help` trop long pour un écran (bas de page) :

[Aide en bas d ecran](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F02-help-bottom.png)

Après **Page Up** (historique, commandes de supervision) :

[Aide apres Page Up](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F03-help-pageup.png)

Après **Page Down** : section AFFICHAGE et prompt :

[Aide apres Page Down](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F04-help-pagedown.png)

`ls` (initrd) :

[ls initrd](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F05-ls.png)

`fat16-list` :

[fat16-list](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F06-fat16-list.png)

`fat16-cat fatok.txt` :

[fat16-cat](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F07-fat16-cat.png)

`net-status` :

[net-status](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F08-net-status.png)

`ps` :

[ps](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F09-ps.png)

`mem` :

[mem](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F10-mem.png)

`ai-runtime` :

[ai-runtime](https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F11-ai-runtime.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6ae7da-49a3-457b-9258-06ebb6fe6f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

