### PR TITLE
Lot 131: sonde NE2000 au démarrage

### DIFF
--- a/docs/aos131_ne2k_boot_probe.md
+++ b/docs/aos131_ne2k_boot_probe.md
@@ -1,0 +1,7 @@
+# AOS-131 — Sonde NE2000 au démarrage du noyau
+
+Le lot AOS-131 raccorde la sonde et la configuration des anneaux NE2000 au chemin d’initialisation du noyau sur le port ISA `0x300`. L’initialisation est tolérante à l’absence de carte: le boot poursuit son exécution et le noyau imprime explicitement que le réseau reste désactivé. Lorsqu’un contrôleur répond, les callbacks I/O i386 existants sont utilisés pour appliquer la préparation et les pages RX/TX.
+
+Le statut reste volontairement non déclaré dans `net-status` tant qu’aucun syscall de publication d’état n’est branché. Le lot ne lit pas encore la PROM MAC, ne configure pas d’IRQ réseau, n’effectue pas de DMA distant et ne transmet pas de trame.
+
+La validation locale est de **284 tests Unity verts**, build i386 réussi et smoke QEMU complet réussi: core, extras, persistance, spawn et exec.

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -19,6 +19,7 @@
 #include "keyboard.h"
 #include "service_registry.h"
 #include "vga_console.h"
+#include "ne2k.h"
 #include <stddef.h>
 
 // Function to read a byte from a port
@@ -27,6 +28,27 @@ unsigned char inb(unsigned short port);
 void outb(unsigned short port, unsigned char data);
 // Function to print string to serial port (forward declaration)
 void print_string_serial(const char* str);
+void print_string(const char* str);
+
+static ne2k_device_t boot_ne2k_device;
+static uint8_t boot_ne2k_present;
+
+static void ne2k_boot_probe(void) {
+    ne2k_io_t io;
+    boot_ne2k_present = 0U;
+    if (ne2k_i386_io(&io) != 0) return;
+    if (ne2k_probe(&boot_ne2k_device, 0x300U, &io) != 0) {
+        print_string("NE2000 ISA absent; reseau reste desactive.\\n");
+        return;
+    }
+    if (ne2k_prepare(&boot_ne2k_device, &io) != 0 ||
+        ne2k_configure_rings(&boot_ne2k_device, &io) != 0) {
+        print_string("NE2000 detecte mais initialisation incomplete.\\n");
+        return;
+    }
+    boot_ne2k_present = 1U;
+    print_string("NE2000 ISA detecte et anneaux RX/TX configures.\\n");
+}
 
 static int fat16_ata_read_sector(uint32_t lba, void* buffer) {
     return ata_read_sectors(lba, 1U, buffer);
@@ -482,6 +504,7 @@ void kmain(uint32_t multiboot_magic, uint32_t multiboot_addr) {
     asm volatile("sti");
     
     print_string("=== Systeme interruptions PRET ===\n");
+    ne2k_boot_probe();
     print_string("IRQ0 (timer): OK\n");
     print_string("IRQ1 (keyboard): OK\n");
     print_string("QEMU devrait maintenant generer les interruptions clavier.\n");


### PR DESCRIPTION
## Résumé

Raccorde la sonde et la configuration des anneaux NE2000 au démarrage i386, avec tolérance à l’absence de carte.

## Validation

- `make test-all`: 284/284 tests verts;
- `make all`: build i386 et initrd réussis;
- `make qemu-smoke`: core, extras, persist, spawn et exec réussis;
- documentation française AOS-131.

La publication syscall de l’état NIC, l’IRQ réseau et le DMA restent à implémenter.