### PR TITLE
Lot 132: statut NIC dynamique et smoke NE2000

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -533,13 +533,14 @@ qemu-smoke: $(OS_IMAGE) pack-initrd disk
 
 # Contrats d’intégration QEMU versionnés : boot, shell/overlay, préemption IRQ0
 # et absence réseau OpenAI explicitement vérifiable.
-.PHONY: integration-qemu qemu-irq0-preemption qemu-ai-provider qemu-ipc-foundation qemu-vfs-service qemu-service-grant
+.PHONY: integration-qemu qemu-irq0-preemption qemu-ai-provider qemu-ne2k-status qemu-ipc-foundation qemu-vfs-service qemu-service-grant
 qemu-irq0-preemption: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/integration/test_qemu_irq0_preemption.py
 
 qemu-ai-provider: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/scripts/test_ai_provider_commands.py
-
+qemu-ne2k-status: $(OS_IMAGE) pack-initrd disk
+	@python3 tests/scripts/test_qemu_ne2k_status.py
 qemu-ipc-foundation: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/integration/test_qemu_ipc_foundation.py
 
@@ -551,6 +552,7 @@ qemu-service-grant: $(OS_IMAGE) pack-initrd disk
 
 integration-qemu: $(OS_IMAGE) pack-initrd disk
 	@python3 tests/integration/test_qemu_core_contract.py
+	@python3 tests/scripts/test_qemu_ne2k_status.py
 	@python3 tests/integration/test_qemu_irq0_preemption.py
 	@python3 tests/scripts/test_ai_provider_commands.py
 	@python3 tests/integration/test_qemu_ipc_foundation.py

--- a/docs/aos132_net_status_dynamic.md
+++ b/docs/aos132_net_status_dynamic.md
@@ -1,0 +1,19 @@
+# AOS-132 — Statut NIC dynamique et smoke NE2000
+
+Le lot AOS-132 remplace le diagnostic réseau statique par le syscall `SYS_NET_STATUS`. Le noyau retourne un bitmask sans pointeur utilisateur : le bit 0 indique qu’une carte NE2000 est détectée et le bit 1 que ses anneaux RX/TX ont été configurés. Le shell traduit ce résultat vers `net-status` et `net-status json`, tout en maintenant ARP, IPv4, DHCP, DNS, TCP et TLS explicitement absents tant que leurs chemins matériels ne sont pas raccordés.
+
+La sonde NE2000 est renforcée contre les faux positifs. Les ports flottants QEMU sans carte renvoient `0xff` et restent absents ; le contrôleur `ne2k_isa` QEMU est reconnu malgré le readback DCR non disponible sur ce modèle. La configuration DCR est toujours écrite, mais le critère de présence repose sur les valeurs reset et ISR matériellement observables.
+
+La validation locale est de **292 tests Unity verts**, avec build i386 réussi, smoke fournisseur sans NIC réussi et smoke matériel `qemu-ne2k-status` réussi avec `-netdev user -device ne2k_isa,netdev=n0`.
+
+Le lot ne fournit pas encore DHCP effectif, DMA distant, IRQ réseau, lecture PROM MAC, handshake TLS, validation X.509 ou client HTTP/OpenAI.
+
+## Contrats exposés
+
+| Élément | Contrat |
+|---|---|
+| `SYS_NET_STATUS` | Retourne un bitmask sans buffer utilisateur. |
+| `net-status` | Affiche la présence ou l’absence réelle de la NIC sondée au boot. |
+| `net-status json` | Produit un diagnostic machine-lisible ; les couches supérieures restent `absent`. |
+| QEMU sans NIC | Retour attendu : `"nic":"absent"`. |
+| QEMU avec `ne2k_isa` | Retour attendu : `"nic":"detected"`. |

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -162,8 +162,10 @@
 #define SYS_FAT16_READ 87
 /* EBX = tableau os_dirent_t, ECX = capacité ; liste de la racine FAT16. */
 #define SYS_FAT16_LIST 88
+/* Aucun argument; bit 0 = NIC détectée, bit 1 = anneaux initialisés. */
+#define SYS_NET_STATUS 89
 
-#define MAX_SYSCALLS 89
+#define MAX_SYSCALLS 90
 
 /* IPC Foundation : messages courts, copies par valeur et retours non bloquants. */
 #define OS_IPC_MAX_DATA 96U

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -50,6 +50,10 @@ static void ne2k_boot_probe(void) {
     print_string("NE2000 ISA detecte et anneaux RX/TX configures.\\n");
 }
 
+uint32_t kernel_net_status(void) {
+    return boot_ne2k_present ? 3U : 0U;
+}
+
 static int fat16_ata_read_sector(uint32_t lba, void* buffer) {
     return ata_read_sectors(lba, 1U, buffer);
 }

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -23,6 +23,7 @@ int ne2k_i386_io(ne2k_io_t* io) {
 
 int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io) {
     uint8_t reset_value;
+    uint8_t isr_value;
     if (!device || !io || !io->inb || !io->outb || base_port == 0U) return -1;
     device->base_port = base_port;
     device->initialized = 0U;
@@ -32,8 +33,12 @@ int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io) {
              NE2K_COMMAND_STOP | NE2K_COMMAND_PAGE0);
     reset_value = io->inb(io->context, (uint16_t)(base_port + NE2K_REG_RESET));
     io->outb(io->context, (uint16_t)(base_port + NE2K_REG_RESET), reset_value);
-    if ((io->inb(io->context, (uint16_t)(base_port + NE2K_REG_ISR)) & NE2K_ISR_RESET) == 0U)
+    isr_value = io->inb(io->context, (uint16_t)(base_port + NE2K_REG_ISR));
+    if ((isr_value & NE2K_ISR_RESET) == 0U)
         return -2;
+    io->outb(io->context, (uint16_t)(base_port + NE2K_REG_DCR), NE2K_DCR_WORD_MODE);
+    /* QEMU ne relit pas le DCR sur ce modèle; les ports flottants renvoient 0xff. */
+    if (reset_value == 0xffU || isr_value == 0xffU) return -3;
     return 0;
 }
 

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -24,6 +24,7 @@ extern void vmm_switch_page_directory(uint32_t phys_addr);
 
 // Fonctions externes
 extern void print_string_serial(const char* str);
+extern uint32_t kernel_net_status(void);
 extern void print_char(char c, int x, int y, char color);
 extern void write_serial(char c);
 
@@ -300,6 +301,9 @@ void syscall_handler(cpu_state_t* cpu) {
             break;
         case SYS_FAT16_LIST:
             cpu->eax = (uint32_t)sys_fat16_list((os_fat16_dirent_t*)cpu->ebx, cpu->ecx);
+            break;
+        case SYS_NET_STATUS:
+            cpu->eax = kernel_net_status();
             break;
         case SYS_MKDIR:
             cpu->eax = (uint32_t)sys_mkdir((const char*)cpu->ebx);

--- a/tests/scripts/test_qemu_ne2k_status.py
+++ b/tests/scripts/test_qemu_ne2k_status.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Smoke QEMU du statut NIC dynamique avec un contrôleur NE2000 ISA."""
+import os, socket, subprocess, time
+ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),"..","..")); LOG_DIR=os.path.join(ROOT,"test_logs")
+LOG=os.path.join(LOG_DIR,"ne2k-status.log"); ERR=os.path.join(LOG_DIR,"ne2k-status.err"); MON=os.path.join(LOG_DIR,"ne2k-status-monitor.sock")
+
+def text():
+    try:
+        with open(LOG,errors="replace") as f:return f.read()
+    except OSError:return ""
+def wait(needle,proc,timeout=20):
+    end=time.time()+timeout
+    while time.time()<end:
+        if proc.poll() is not None: raise RuntimeError("QEMU stopped early")
+        if needle in text(): return
+        time.sleep(.1)
+    raise RuntimeError("missing output: "+needle)
+def monitor():
+    end=time.time()+5
+    while time.time()<end:
+        if os.path.exists(MON):
+            s=socket.socket(socket.AF_UNIX,socket.SOCK_STREAM)
+            try:s.connect(MON);s.settimeout(.1);return s
+            except OSError:s.close()
+        time.sleep(.1)
+    raise RuntimeError("monitor unavailable")
+def keys(s,cmd):
+    special={" ":"spc",".":"dot","-":"minus","_":"shift-minus"}
+    for c in [special.get(x,x.lower()) for x in cmd]+["ret"]:
+        s.sendall(("sendkey "+c+"\n").encode());time.sleep(.25)
+def main():
+    os.makedirs(LOG_DIR,exist_ok=True)
+    for p in (LOG,ERR,MON):
+        try:os.remove(p)
+        except OSError:pass
+    cmd=["qemu-system-i386","-kernel",os.path.join(ROOT,"build","ai_os.bin"),"-initrd",os.path.join(ROOT,"my_initrd.tar"),"-m","1024M","-display","none","-vga","none","-serial","file:"+LOG,"-monitor","unix:%s,server,nowait"%MON,"-machine","type=pc,accel=tcg","-netdev","user,id=n0","-device","ne2k_isa,netdev=n0","-no-reboot","-no-shutdown"]
+    with open(ERR,"wb") as err:
+        p=subprocess.Popen(cmd,stdout=err,stderr=err);s=None
+        try:
+            wait("(-.-)",p);s=monitor();time.sleep(.5);before=len(text());keys(s,"net-status json");end=time.time()+15
+            while time.time()<end:
+                if '"nic":"detected"' in text()[before:]:print("QEMU NE2000 status smoke passed.");return 0
+                if p.poll() is not None:raise RuntimeError("QEMU stopped while querying net-status")
+                time.sleep(.1)
+            raise RuntimeError("net-status did not report nic=detected; log tail: "+text()[-500:])
+        finally:
+            if s:s.close()
+            if p.poll() is None:p.terminate();p.wait(timeout=3)
+if __name__=="__main__":
+    try:raise SystemExit(main())
+    except Exception as e: print("NE2000 status smoke failed: "+str(e)); raise SystemExit(1)

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -5,6 +5,7 @@ typedef struct {
     uint8_t reset;
     uint8_t isr;
     uint8_t writes;
+    uint8_t dcr;
 } fake_ne2k_t;
 
 void setUp(void) {}
@@ -14,6 +15,7 @@ static uint8_t fake_inb(void* context, uint16_t port) {
     fake_ne2k_t* fake = (fake_ne2k_t*)context;
     if ((port & 0x1fU) == NE2K_REG_RESET) return fake->reset;
     if ((port & 0x1fU) == NE2K_REG_ISR) return fake->isr;
+    if ((port & 0x1fU) == NE2K_REG_DCR) return fake->dcr;
     return 0U;
 }
 
@@ -21,10 +23,11 @@ static void fake_outb(void* context, uint16_t port, uint8_t value) {
     fake_ne2k_t* fake = (fake_ne2k_t*)context;
     fake->writes++;
     if ((port & 0x1fU) == NE2K_REG_RESET) fake->reset = value;
+    if ((port & 0x1fU) == NE2K_REG_DCR) fake->dcr = value;
 }
 
 void test_probe_and_prepare_use_injected_io(void) {
-    fake_ne2k_t fake = {0x12, NE2K_ISR_RESET, 0};
+    fake_ne2k_t fake = {0x12, NE2K_ISR_RESET, 0, 0};
     ne2k_io_t io = {&fake, fake_inb, fake_outb};
     ne2k_device_t device;
     TEST_ASSERT_EQUAL(0, ne2k_probe(&device, 0x300, &io));
@@ -50,7 +53,7 @@ void test_rx_extract_publishes_bounded_frame(void) {
 
 
 void test_probe_rejects_missing_reset_ack(void) {
-    fake_ne2k_t fake = {0, 0, 0};
+    fake_ne2k_t fake = {0, 0, 0, 0};
     ne2k_io_t io = {&fake, fake_inb, fake_outb};
     ne2k_device_t device;
     TEST_ASSERT_NOT_EQUAL(0, ne2k_probe(&device, 0x300, &io));

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -150,6 +150,12 @@ unsigned int sys_ticks(void) {
     return result;
 }
 
+unsigned int sys_net_status(void) {
+    unsigned int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_NET_STATUS));
+    return result;
+}
+
 int sys_meminfo(os_meminfo_t* info) {
     int result;
     asm volatile("int $0x80" : "=a"(result) : "a"(SYS_MEMINFO), "b"(info));
@@ -4410,12 +4416,13 @@ static void cmd_ai_runtime(shell_context_t* ctx, char args[][128], int arg_count
 static void cmd_net_status(shell_context_t* ctx, char args[][128], int arg_count) {
     (void)ctx;
     if (arg_count > 0 && strcmp(args[0], "json") == 0) {
-        print_string("{\"nic\":\"absent\",\"ethernet\":\"absent\",\"arp\":\"absent\",\"ipv4\":\"absent\",\"dhcp\":\"absent\",\"dns\":\"absent\",\"tcp\":\"absent\",\"tls\":\"absent\",\"openai\":\"blocked\"}\n");
+        unsigned int status = sys_net_status();
+        print_string(status & 1U ? "{\"nic\":\"detected\",\"ethernet\":\"configured\",\"arp\":\"absent\",\"ipv4\":\"absent\",\"dhcp\":\"absent\",\"dns\":\"absent\",\"tcp\":\"absent\",\"tls\":\"absent\",\"openai\":\"blocked\"}\n" : "{\"nic\":\"absent\",\"ethernet\":\"absent\",\"arp\":\"absent\",\"ipv4\":\"absent\",\"dhcp\":\"absent\",\"dns\":\"absent\",\"tcp\":\"absent\",\"tls\":\"absent\",\"openai\":\"blocked\"}\n");
         return;
     }
     (void)args;
     print_colored("\n=== Reseau bare-metal ===\n", COLOR_CYAN);
-    print_string("Carte Ethernet : absente (aucun pilote NIC initialise)\n");
+    print_string(sys_net_status() & 1U ? "Carte Ethernet : detectee (NE2000 initialise)\n" : "Carte Ethernet : absente (aucun pilote NIC initialise)\n");
     print_string("ARP / IPv4 / DHCP : absents\n");
     print_string("DNS / TCP / TLS   : absents\n");
     print_string("OpenAI en ligne   : bloque, aucune requete n'est emise\n");


### PR DESCRIPTION
## Résumé

Ajoute `SYS_NET_STATUS`, raccorde la sonde NE2000 au boot et expose un statut dynamique à `net-status`. Ajoute un smoke QEMU avec `ne2k_isa`.

## Validation

- `make test-all`: 292/292 tests verts;
- `make all`: build i386 et initrd réussis;
- `make qemu-ai-provider`: scénario sans NIC réussi;
- `make qemu-ne2k-status`: scénario avec `-device ne2k_isa` réussi;
- documentation française AOS-132.

Les couches ARP/IPv4/DHCP/DNS/TCP/TLS restent explicitement non connectées au transport matériel.