### PR TITLE
Lot 133: lecture PROM MAC NE2000 caller-owned

### DIFF
--- a/docs/aos133_ne2k_prom_mac.md
+++ b/docs/aos133_ne2k_prom_mac.md
@@ -1,0 +1,18 @@
+# AOS-133 — Lecture caller-owned de la PROM MAC NE2000
+
+Le lot AOS-133 ajoute `ne2k_read_mac`, une primitive de pilote qui lit douze octets depuis le port de données NE2000 et extrait les six octets pairs de la PROM, conformément au format historique de la carte. La MAC est copiée dans `ne2k_device_t`, puis marquée valide uniquement si elle n’est pas nulle et n’est pas multicast. Aucun pointeur vers un buffer externe n’est conservé et aucune allocation dynamique n’est effectuée.
+
+La primitive invalide explicitement `mac_valid` lorsque la PROM expose une valeur nulle ou multicast. Cette règle évite de publier une adresse partiellement lue comme identité réseau. Les callbacks d’E/S restent injectables afin que les tests Unity n’accèdent jamais aux ports physiques.
+
+## Portée et limites
+
+| Élément | État AOS-133 |
+|---|---|
+| Lecture PROM via callback `inb` | Implémentée et testée sur faux périphérique. |
+| Validation MAC unicast non nulle | Implémentée. |
+| Conservation d’un buffer PROM | Interdite : tableau local borné de 12 octets uniquement. |
+| Lecture PROM au boot réel | Non raccordée dans ce lot ; nécessite une validation QEMU avec lecture distante. |
+| Émission TX, DMA distant et IRQ | Non implémentés. |
+| DHCP, DNS, TLS et HTTP/OpenAI effectifs | Non implémentés sur le transport matériel. |
+
+La suite Unity reste à **292 tests verts** après l’ajout du scénario PROM. Cette étape prépare l’identité Ethernet nécessaire au futur raccordement de la file TX/RX, sans surestimer l’état de la pile réseau.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -29,6 +29,7 @@ int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io) {
     device->initialized = 0U;
     device->mac[0] = device->mac[1] = device->mac[2] = 0U;
     device->mac[3] = device->mac[4] = device->mac[5] = 0U;
+    device->mac_valid = 0U;
     io->outb(io->context, (uint16_t)(base_port + NE2K_REG_COMMAND),
              NE2K_COMMAND_STOP | NE2K_COMMAND_PAGE0);
     reset_value = io->inb(io->context, (uint16_t)(base_port + NE2K_REG_RESET));
@@ -66,7 +67,32 @@ int ne2k_set_mac(ne2k_device_t* device, const uint8_t mac[6]) {
         device->mac[i] = mac[i];
         if (mac[i] != 0U) nonzero = 1U;
     }
+    device->mac_valid = nonzero;
     return nonzero ? 0 : -2;
+}
+
+int ne2k_read_mac(ne2k_device_t* device, const ne2k_io_t* io) {
+    uint8_t prom[12];
+    uint16_t base;
+    uint32_t i;
+    if (!device || !io || !io->inb || !io->outb || device->base_port == 0U)
+        return -1;
+    base = device->base_port;
+    /* La PROM NE2000 expose la MAC sur les octets pairs d’une lecture 16 bits. */
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_COMMAND),
+             NE2K_COMMAND_STOP | NE2K_COMMAND_PAGE0);
+    for (i = 0; i < 12U; ++i)
+        prom[i] = io->inb(io->context, (uint16_t)(base + NE2K_REG_DATA));
+    for (i = 0; i < 6U; ++i)
+        device->mac[i] = prom[i * 2U];
+    device->mac_valid = 0U;
+    for (i = 0; i < 6U; ++i)
+        if (device->mac[i] != 0U) device->mac_valid = 1U;
+    if ((device->mac[0] & 1U) != 0U || device->mac_valid == 0U) {
+        device->mac_valid = 0U;
+        return -2;
+    }
+    return 0;
 }
 
 int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -13,7 +13,9 @@
 #define NE2K_REG_PSTOP   0x02U
 #define NE2K_REG_BNRY    0x03U
 #define NE2K_REG_RCR     0x0cU
-#define NE2K_REG_TCR     0x0dU
+#define NE2K_REG_TCR    0x0dU
+#define NE2K_REG_DATA   0x10U
+
 #define NE2K_REG_CURR    0x07U
 #define NE2K_COMMAND_STOP 0x01U
 #define NE2K_COMMAND_PAGE0 0x00U
@@ -36,6 +38,7 @@ typedef struct {
     uint16_t base_port;
     uint8_t initialized;
     uint8_t mac[6];
+    uint8_t mac_valid;
 } ne2k_device_t;
 
 /* Sonde le registre reset et prépare le mode arrêt/word pour une init ultérieure. */
@@ -48,6 +51,8 @@ int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io);
 int ne2k_configure_rings(ne2k_device_t* device, const ne2k_io_t* io);
 /* Définit une MAC locale valide: non nulle et non multicast. */
 int ne2k_set_mac(ne2k_device_t* device, const uint8_t mac[6]);
+/* Lit les six octets pairs de la PROM NE2000 sans conserver de buffer externe. */
+int ne2k_read_mac(ne2k_device_t* device, const ne2k_io_t* io);
 /* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */
 int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
                     net_nic_queue_t* rx_queue);

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -6,6 +6,8 @@ typedef struct {
     uint8_t isr;
     uint8_t writes;
     uint8_t dcr;
+    uint8_t prom[12];
+    uint8_t prom_index;
 } fake_ne2k_t;
 
 void setUp(void) {}
@@ -16,6 +18,8 @@ static uint8_t fake_inb(void* context, uint16_t port) {
     if ((port & 0x1fU) == NE2K_REG_RESET) return fake->reset;
     if ((port & 0x1fU) == NE2K_REG_ISR) return fake->isr;
     if ((port & 0x1fU) == NE2K_REG_DCR) return fake->dcr;
+    if ((port & 0x1fU) == NE2K_REG_DATA && fake->prom_index < 12U)
+        return fake->prom[fake->prom_index++];
     return 0U;
 }
 
@@ -38,6 +42,16 @@ void test_probe_and_prepare_use_injected_io(void) {
     { uint8_t mac[6] = {0x02, 0, 0, 0, 0, 1}; TEST_ASSERT_EQUAL(0, ne2k_set_mac(&device, mac)); TEST_ASSERT_EQUAL(0x02, device.mac[0]); }
     { uint8_t zero[6] = {0, 0, 0, 0, 0, 0}; TEST_ASSERT_NOT_EQUAL(0, ne2k_set_mac(&device, zero)); }
     { uint8_t multicast[6] = {0x01, 0, 0, 0, 0, 1}; TEST_ASSERT_NOT_EQUAL(0, ne2k_set_mac(&device, multicast)); }
+    fake.prom[0] = 0x02; fake.prom[1] = 0xaa; fake.prom[2] = 0x10;
+    fake.prom[3] = 0xbb; fake.prom[4] = 0x20; fake.prom[5] = 0xcc;
+    fake.prom[6] = 0x30; fake.prom[7] = 0xdd; fake.prom[8] = 0x40;
+    fake.prom[9] = 0xee; fake.prom[10] = 0x50; fake.prom[11] = 0xff;
+    fake.prom_index = 0U;
+    TEST_ASSERT_EQUAL(0, ne2k_read_mac(&device, &io));
+    TEST_ASSERT_EQUAL(1, device.mac_valid); TEST_ASSERT_EQUAL(0x02, device.mac[0]);
+    TEST_ASSERT_EQUAL(0x10, device.mac[1]); TEST_ASSERT_EQUAL(0x20, device.mac[2]);
+    TEST_ASSERT_EQUAL(0x30, device.mac[3]); TEST_ASSERT_EQUAL(0x40, device.mac[4]);
+    TEST_ASSERT_EQUAL(0x50, device.mac[5]);
 }
 
 void test_rx_extract_publishes_bounded_frame(void) {


### PR DESCRIPTION
## Résumé

Ajoute `ne2k_read_mac` pour lire les octets pairs de la PROM NE2000 via les callbacks d'E/S et valider une MAC unicast non nulle. L'état `mac_valid` est publié uniquement après lecture complète.

## Validation

- `make test-all`: 292/292 tests verts;
- `make all`: build i386 et initrd réussis;
- tests Unity avec faux périphérique PROM;
- documentation française AOS-133.

La lecture PROM n'est pas encore raccordée au boot réel; DMA distant, émission TX, IRQ, DHCP, TLS et HTTP/OpenAI restent non implémentés.