### PR TITLE
Lot 134: émission PIO NE2000 caller-owned

### DIFF
--- a/docs/aos134_ne2k_tx_pio.md
+++ b/docs/aos134_ne2k_tx_pio.md
@@ -1,0 +1,17 @@
+# AOS-134 — Émission PIO NE2000 caller-owned
+
+Le lot AOS-134 ajoute `ne2k_tx_submit`, une primitive d’émission qui configure une écriture distante NE2000 en mode octet, copie une trame fournie par l’appelant dans la page TX `0x40`, attend l’indication `RDC` avec une boucle bornée, puis programme `TPSR` et `TBCR` avant de déclencher `TXP`.
+
+Les limites sont explicites. Les trames de moins de 60 octets sont complétées localement par des zéros jusqu’à la taille Ethernet minimale ; les trames supérieures à 1514 octets sont rejetées. Le pilote ne conserve pas le pointeur de l’appelant, n’alloue aucune mémoire et n’attend pas indéfiniment une interruption matérielle. Le chemin utilise les callbacks `inb/outb`, donc les tests Unity restent indépendants de l’hôte.
+
+| Élément | État AOS-134 |
+|---|---|
+| Écriture distante PIO bornée | Implémentée. |
+| Padding Ethernet minimal | Implémenté à 60 octets. |
+| Limite MTU | Rejet au-delà de 1514 octets. |
+| Attente RDC | Polling borné à 65535 itérations. |
+| IRQ réseau | Non raccordée ; le polling ne remplace pas une gestion d’interruption complète. |
+| Validation QEMU d’une trame reçue | Non déclarée dans ce lot. |
+| DHCP/DNS/TLS/HTTP/OpenAI effectifs | Non implémentés sur le transport matériel. |
+
+La suite Unity reste à **292 tests verts**. Cette primitive prépare l’émission Ethernet nécessaire à ARP et DHCP, mais ne constitue pas encore un transport IP fonctionnel de bout en bout.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -118,6 +118,40 @@ int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
                                  (uint16_t)(packet_length - NE2K_RX_HEADER_SIZE));
 }
 
+int ne2k_tx_submit(ne2k_device_t* device, const ne2k_io_t* io,
+                   const uint8_t* frame, uint16_t length) {
+    uint16_t base;
+    uint16_t wire_length;
+    uint32_t i;
+    if (!device || !io || !io->inb || !io->outb || !frame ||
+        !device->initialized || device->base_port == 0U || length == 0U ||
+        length > NE2K_ETHERNET_MAX_FRAME)
+        return -1;
+    base = device->base_port;
+    wire_length = length < NE2K_ETHERNET_MIN_FRAME ? NE2K_ETHERNET_MIN_FRAME : length;
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_COMMAND),
+             NE2K_COMMAND_STOP | NE2K_COMMAND_PAGE0);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_DCR), NE2K_DCR_BYTE_MODE);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_RBCR0), (uint8_t)wire_length);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_RBCR1), (uint8_t)(wire_length >> 8));
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_RSAR0), 0U);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_RSAR1), NE2K_TX_PAGE);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_COMMAND), NE2K_COMMAND_REMOTE_WRITE);
+    for (i = 0; i < (uint32_t)wire_length; ++i)
+        io->outb(io->context, (uint16_t)(base + NE2K_REG_DATA),
+                 i < length ? frame[i] : 0U);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_ISR), NE2K_ISR_RDC);
+    for (i = 0; i < 65535U; ++i)
+        if ((io->inb(io->context, (uint16_t)(base + NE2K_REG_ISR)) & NE2K_ISR_RDC) != 0U)
+            break;
+    if (i == 65535U) return -2;
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_TPSR), NE2K_TX_PAGE);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_TBCR0), (uint8_t)wire_length);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_TBCR1), (uint8_t)(wire_length >> 8));
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_COMMAND), NE2K_COMMAND_TRANSMIT);
+    return 0;
+}
+
 int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io) {
     uint16_t base;
     if (!device || !io || !io->outb || device->base_port == 0U) return -1;

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -15,6 +15,12 @@
 #define NE2K_REG_RCR     0x0cU
 #define NE2K_REG_TCR    0x0dU
 #define NE2K_REG_DATA   0x10U
+#define NE2K_REG_TBCR0  0x05U
+#define NE2K_REG_TBCR1  0x06U
+#define NE2K_REG_RBCR0  0x0aU
+#define NE2K_REG_RBCR1  0x0bU
+#define NE2K_REG_RSAR0  0x08U
+#define NE2K_REG_RSAR1  0x09U
 
 #define NE2K_REG_CURR    0x07U
 #define NE2K_COMMAND_STOP 0x01U
@@ -22,6 +28,13 @@
 #define NE2K_COMMAND_PAGE1 0x40U
 #define NE2K_DCR_WORD_MODE 0x49U
 #define NE2K_ISR_RESET 0x80U
+#define NE2K_ISR_RDC    0x40U
+#define NE2K_DCR_BYTE_MODE 0x48U
+#define NE2K_COMMAND_REMOTE_WRITE 0x12U
+#define NE2K_COMMAND_TRANSMIT 0x26U
+#define NE2K_TX_PAGE 0x40U
+#define NE2K_ETHERNET_MIN_FRAME 60U
+#define NE2K_ETHERNET_MAX_FRAME 1514U
 #define NE2K_RX_HEADER_SIZE 4U
 #define NE2K_RX_STATUS_OK 0x01U
 
@@ -53,6 +66,9 @@ int ne2k_configure_rings(ne2k_device_t* device, const ne2k_io_t* io);
 int ne2k_set_mac(ne2k_device_t* device, const uint8_t mac[6]);
 /* Lit les six octets pairs de la PROM NE2000 sans conserver de buffer externe. */
 int ne2k_read_mac(ne2k_device_t* device, const ne2k_io_t* io);
+/* Copie une trame caller-owned dans la RAM distante puis déclenche TX. */
+int ne2k_tx_submit(ne2k_device_t* device, const ne2k_io_t* io,
+                   const uint8_t* frame, uint16_t length);
 /* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */
 int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
                     net_nic_queue_t* rx_queue);

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -8,6 +8,8 @@ typedef struct {
     uint8_t dcr;
     uint8_t prom[12];
     uint8_t prom_index;
+    uint8_t tx_data[NE2K_ETHERNET_MAX_FRAME];
+    uint16_t tx_count;
 } fake_ne2k_t;
 
 void setUp(void) {}
@@ -28,6 +30,8 @@ static void fake_outb(void* context, uint16_t port, uint8_t value) {
     fake->writes++;
     if ((port & 0x1fU) == NE2K_REG_RESET) fake->reset = value;
     if ((port & 0x1fU) == NE2K_REG_DCR) fake->dcr = value;
+    if ((port & 0x1fU) == NE2K_REG_DATA && fake->tx_count < NE2K_ETHERNET_MAX_FRAME)
+        fake->tx_data[fake->tx_count++] = value;
 }
 
 void test_probe_and_prepare_use_injected_io(void) {
@@ -52,6 +56,13 @@ void test_probe_and_prepare_use_injected_io(void) {
     TEST_ASSERT_EQUAL(0x10, device.mac[1]); TEST_ASSERT_EQUAL(0x20, device.mac[2]);
     TEST_ASSERT_EQUAL(0x30, device.mac[3]); TEST_ASSERT_EQUAL(0x40, device.mac[4]);
     TEST_ASSERT_EQUAL(0x50, device.mac[5]);
+    { uint8_t frame[10] = {1,2,3,4,5,6,7,8,9,10};
+      fake.isr = (uint8_t)(NE2K_ISR_RESET | NE2K_ISR_RDC); fake.tx_count = 0U;
+      TEST_ASSERT_EQUAL(0, ne2k_tx_submit(&device, &io, frame, sizeof(frame)));
+      TEST_ASSERT_EQUAL(NE2K_ETHERNET_MIN_FRAME, fake.tx_count);
+      TEST_ASSERT_EQUAL(1, fake.tx_data[0]); TEST_ASSERT_EQUAL(10, fake.tx_data[9]);
+      TEST_ASSERT_EQUAL(0, fake.tx_data[59]);
+      TEST_ASSERT_NOT_EQUAL(0, ne2k_tx_submit(&device, &io, frame, NE2K_ETHERNET_MAX_FRAME + 1U)); }
 }
 
 void test_rx_extract_publishes_bounded_frame(void) {


### PR DESCRIPTION
## Résumé

Ajoute `ne2k_tx_submit`: écriture distante PIO en mode octet, padding Ethernet minimal, limite MTU, attente RDC bornée et déclenchement TX. Aucun buffer externe n'est conservé.

## Validation

- `make test-all`: 292/292 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: scénario sans NIC réussi;
- `make qemu-ne2k-status`: scénario NE2000 QEMU réussi;
- documentation française AOS-134.

La transmission d'une trame observable sous QEMU, les IRQ, DHCP, TLS et HTTP/OpenAI restent explicitement non déclarés.