### PR TITLE
Lot 135: raccordement IRQ3 NE2000

### DIFF
--- a/boot/isr_stubs.s
+++ b/boot/isr_stubs.s
@@ -1,9 +1,11 @@
 extern keyboard_interrupt_handler
 extern timer_handler
+extern ne2k_irq_handler
 extern syscall_handler
 
 global irq0
 global irq1
+global irq3
 global isr_syscall
 
 ; ISR pour le timer (IRQ 0) - Version robuste
@@ -73,6 +75,28 @@ irq1:
     pop ds
     
     ; Retour d'interruption
+    iret
+
+; ISR pour la carte réseau NE2000 (IRQ 3)
+irq3:
+    push ds
+    push es
+    push fs
+    push gs
+    pushad
+    mov ax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    call ne2k_irq_handler
+    mov al, 0x20
+    out 0x20, al
+    popad
+    pop gs
+    pop fs
+    pop es
+    pop ds
     iret
 
 ; ISR pour le scheduler volontaire (INT 0x30)

--- a/docs/aos135_ne2k_irq3.md
+++ b/docs/aos135_ne2k_irq3.md
@@ -1,0 +1,16 @@
+# AOS-135 — Raccordement IRQ3 NE2000
+
+Le lot AOS-135 raccorde le contrôleur NE2000 ISA de QEMU à l’IRQ3 du PIC maître. Le noyau installe un stub assembleur dédié au vecteur 35, enregistre le handler C `ne2k_irq_handler`, démasque IRQ3 avec IRQ0 et IRQ1, puis attache le périphérique après une sonde et une configuration d’anneaux réussies.
+
+Le pilote conserve uniquement des références statiques vers le périphérique et ses callbacks d’E/S. `ne2k_irq_service` lit l’ISR, acquitte les bits observés par écriture miroir et incrémente un compteur volatil borné par la largeur `uint32_t`. En l’absence de périphérique, le handler reste inoffensif ; aucune allocation et aucun buffer de trame ne sont introduits dans le chemin d’interruption.
+
+| Élément | État AOS-135 |
+|---|---|
+| Stub assembleur IRQ3 / vecteur 35 | Implémenté. |
+| Enregistrement handler et démasquage PIC | Implémenté. |
+| Acquittement ISR NE2000 | Implémenté et testé par callbacks injectés. |
+| Compteur d’événements IRQ | Implémenté. |
+| Extraction RX depuis la RAM distante | Non raccordée à l’IRQ dans ce lot. |
+| DMA distant, DHCP, DNS, TLS et HTTP/OpenAI | Non implémentés comme transport effectif. |
+
+La validation locale reste à **292 tests verts** et le build i386 réussit. Le smoke QEMU vérifie la stabilité du boot avec et sans `ne2k_isa`, mais ne prétend pas observer une trame Ethernet reçue par le noyau.

--- a/kernel/interrupts.c
+++ b/kernel/interrupts.c
@@ -22,6 +22,7 @@ extern void isr24(); extern void isr25(); extern void isr26(); extern void isr27
 extern void isr28(); extern void isr29(); extern void isr30(); extern void isr31();
 extern void irq0(); // ISR pour le timer
 extern void irq1(); // ISR pour le clavier
+extern void irq3(); // ISR pour la NE2000
 extern void isr_syscall(); // ISR pour les appels système
 extern void isr_schedule(); // ISR pour le scheduling volontaire
 
@@ -208,6 +209,8 @@ void install_exception_handlers() {
     idt_set_gate(31, (uint32_t)isr31, 0x08, 0x8E);
 }
 
+extern void ne2k_irq_handler(void);
+
 // Initialise toutes nos interruptions
 void interrupts_init() {
     print_string_serial("=== INITIALISATION SYSTEME INTERRUPTIONS ===\n");
@@ -235,12 +238,14 @@ void interrupts_init() {
     print_string_serial("Step 5: Enregistrement des handlers IRQ...\n");
     register_interrupt_handler(32, timer_handler);    // IRQ 0 - Timer
     register_interrupt_handler(33, keyboard_interrupt_handler); // IRQ 1 - Clavier
+    register_interrupt_handler(35, ne2k_irq_handler); // IRQ 3 - NE2000 ISA
     print_string_serial("Step 5: Handlers IRQ enregistrés\n");
     
     // 6. Associer les entrées de l'IDT aux routines assembleur
     print_string_serial("Step 6: Configuration des entrées IDT...\n");
     idt_set_gate(32, (uint32_t)irq0, 0x08, 0x8E);        // Timer
     idt_set_gate(33, (uint32_t)irq1, 0x08, 0x8E);        // Clavier
+    idt_set_gate(35, (uint32_t)irq3, 0x08, 0x8E);        // NE2000 ISA
     idt_set_gate(0x30, (uint32_t)isr_schedule, 0x08, 0xEE); // Scheduler (Ring 3)
     idt_set_gate(0x80, (uint32_t)isr_syscall, 0x08, 0xEE); // Syscalls (Ring 3 accessible)
     print_string_serial("Step 6: Entrées IDT configurées\n");
@@ -251,7 +256,7 @@ void interrupts_init() {
 
     // 8. Forcer l'unmask des IRQ critiques
     print_string_serial("Step 8: Activation forcée des IRQ critiques...\n");
-    outb(0x21, 0xFC);   // 11111100b : IRQ0, IRQ1 activées
+    outb(0x21, 0xF4);   // IRQ0, IRQ1 et IRQ3 activées
     outb(0xA1, 0xFF);   // Toutes les IRQ du PIC2 désactivées
     
     // Vérification finale

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -32,6 +32,7 @@ void print_string(const char* str);
 
 static ne2k_device_t boot_ne2k_device;
 static uint8_t boot_ne2k_present;
+void ne2k_irq_handler(void) { ne2k_irq_service(); }
 
 static void ne2k_boot_probe(void) {
     ne2k_io_t io;
@@ -44,6 +45,10 @@ static void ne2k_boot_probe(void) {
     if (ne2k_prepare(&boot_ne2k_device, &io) != 0 ||
         ne2k_configure_rings(&boot_ne2k_device, &io) != 0) {
         print_string("NE2000 detecte mais initialisation incomplete.\\n");
+        return;
+    }
+    if (ne2k_irq_attach(&boot_ne2k_device, &io) != 0) {
+        print_string("NE2000 detecte mais IRQ non attachee.\\n");
         return;
     }
     boot_ne2k_present = 1U;

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -12,6 +12,34 @@ static void ne2k_i386_outb(void* context, uint16_t port, uint8_t value) {
 }
 #endif
 
+static ne2k_device_t* ne2k_irq_device;
+static const ne2k_io_t* ne2k_irq_io;
+static volatile uint32_t ne2k_irq_events;
+
+int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io) {
+    if (!device || !io || !io->inb || !io->outb || device->base_port == 0U)
+        return -1;
+    ne2k_irq_device = device;
+    ne2k_irq_io = io;
+    ne2k_irq_events = 0U;
+    return 0;
+}
+
+void ne2k_irq_service(void) {
+    uint8_t status;
+    if (!ne2k_irq_device || !ne2k_irq_io) return;
+    status = ne2k_irq_io->inb(ne2k_irq_io->context,
+                              (uint16_t)(ne2k_irq_device->base_port + NE2K_REG_ISR));
+    if (status == 0U) return;
+    ne2k_irq_io->outb(ne2k_irq_io->context,
+                      (uint16_t)(ne2k_irq_device->base_port + NE2K_REG_ISR), status);
+    ++ne2k_irq_events;
+}
+
+uint32_t ne2k_irq_count(void) {
+    return ne2k_irq_events;
+}
+
 int ne2k_i386_io(ne2k_io_t* io) {
     if (!io) return -1;
 #ifdef __i386__

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -69,6 +69,11 @@ int ne2k_read_mac(ne2k_device_t* device, const ne2k_io_t* io);
 /* Copie une trame caller-owned dans la RAM distante puis déclenche TX. */
 int ne2k_tx_submit(ne2k_device_t* device, const ne2k_io_t* io,
                    const uint8_t* frame, uint16_t length);
+/* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
+int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
+/* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */
+void ne2k_irq_service(void);
+uint32_t ne2k_irq_count(void);
 /* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */
 int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
                     net_nic_queue_t* rx_queue);

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -63,6 +63,9 @@ void test_probe_and_prepare_use_injected_io(void) {
       TEST_ASSERT_EQUAL(1, fake.tx_data[0]); TEST_ASSERT_EQUAL(10, fake.tx_data[9]);
       TEST_ASSERT_EQUAL(0, fake.tx_data[59]);
       TEST_ASSERT_NOT_EQUAL(0, ne2k_tx_submit(&device, &io, frame, NE2K_ETHERNET_MAX_FRAME + 1U)); }
+    fake.isr = NE2K_ISR_RDC; TEST_ASSERT_EQUAL(0, ne2k_irq_attach(&device, &io));
+    TEST_ASSERT_EQUAL(0, ne2k_irq_count()); ne2k_irq_service();
+    TEST_ASSERT_EQUAL(1, ne2k_irq_count());
 }
 
 void test_rx_extract_publishes_bounded_frame(void) {


### PR DESCRIPTION
## Résumé

Ajoute le stub assembleur IRQ3, l'enregistrement du vecteur 35, le démasquage PIC et le service ISR NE2000 caller-owned. Le handler acquitte l'ISR observée et compte les événements sans allocation.

## Validation

- `make test-all`: 292/292 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: scénario sans NIC réussi;
- `make qemu-ne2k-status`: scénario NE2000 QEMU réussi;
- documentation française AOS-135.

La réception RX, le DMA distant, DHCP, TLS et HTTP/OpenAI restent explicitement non déclarés comme fonctionnels.