### PR TITLE
Lot 136: polling RX PIO NE2000 caller-owned

### DIFF
--- a/docs/aos136_ne2k_rx_poll.md
+++ b/docs/aos136_ne2k_rx_poll.md
@@ -1,0 +1,17 @@
+# AOS-136 — Polling RX PIO NE2000 caller-owned
+
+Le lot AOS-136 ajoute `ne2k_rx_poll`, une primitive de réception par polling PIO. Elle vérifie `PRX`, calcule la page suivante à partir de `BNRY`, lit l’en-tête de quatre octets par remote-read, valide le statut, la page suivante et la longueur Ethernet, puis lit uniquement la charge utile dans le buffer fourni par l’appelant. Après succès, `BNRY` est avancé sans allocation ni pointeur conservé.
+
+La primitive remet la longueur de sortie à zéro avant tout traitement. Elle retourne `1` lorsqu’aucun paquet n’est disponible, rejette une charge utile qui dépasse la capacité fournie et borne la longueur maximale à 1514 octets. Le service IRQ reste séparé : AOS-136 fournit le polling PIO, mais ne prétend pas encore exposer une réception Ethernet observable de bout en bout dans QEMU.
+
+| Élément | État AOS-136 |
+|---|---|
+| Détection `PRX` et lecture remote-read | Implémentée. |
+| Validation header/page/longueur | Implémentée. |
+| Copie vers buffer caller-owned | Implémentée sans allocation. |
+| Avancement BNRY | Implémenté après copie réussie. |
+| Test Unity sans paquet | Ajouté ; longueur de sortie remise à zéro. |
+| Test QEMU d’une trame RX réelle | Non déclaré dans ce lot. |
+| ARP/IP/DHCP/DNS/TLS/HTTP/OpenAI | Toujours non raccordés au transport matériel. |
+
+Le build i386 et les **292 tests Unity** restent la porte de non-régression du lot.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -40,6 +40,54 @@ uint32_t ne2k_irq_count(void) {
     return ne2k_irq_events;
 }
 
+static void ne2k_remote_read_setup(const ne2k_io_t* io, uint16_t base,
+                                   uint16_t address, uint16_t length) {
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_RBCR0), (uint8_t)length);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_RBCR1), (uint8_t)(length >> 8));
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_RSAR0), (uint8_t)address);
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_RSAR1), (uint8_t)(address >> 8));
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_COMMAND),
+             NE2K_COMMAND_REMOTE_READ);
+}
+
+int ne2k_rx_poll(ne2k_device_t* device, const ne2k_io_t* io,
+                 uint8_t* frame, uint16_t frame_capacity,
+                 uint16_t* frame_length) {
+    uint16_t base, page, packet_length, payload_length;
+    uint8_t header[NE2K_RX_HEADER_SIZE];
+    uint8_t next_page;
+    uint32_t i;
+    if (!device || !io || !io->inb || !io->outb || !frame || !frame_length ||
+        !device->initialized || frame_capacity == 0U || device->base_port == 0U)
+        return -1;
+    *frame_length = 0U;
+    base = device->base_port;
+    if ((io->inb(io->context, (uint16_t)(base + NE2K_REG_ISR)) & NE2K_ISR_PRX) == 0U)
+        return 1;
+    page = (uint16_t)io->inb(io->context, (uint16_t)(base + NE2K_REG_BNRY)) + 1U;
+    if (page >= NE2K_RX_PAGE_STOP) page = NE2K_RX_PAGE_START;
+    ne2k_remote_read_setup(io, base, (uint16_t)(page << 8), NE2K_RX_HEADER_SIZE);
+    for (i = 0; i < NE2K_RX_HEADER_SIZE; ++i)
+        header[i] = io->inb(io->context, (uint16_t)(base + NE2K_REG_DATA));
+    if ((header[0] & NE2K_RX_STATUS_OK) == 0U) return -2;
+    next_page = header[1];
+    packet_length = (uint16_t)(header[2] | ((uint16_t)header[3] << 8));
+    if (packet_length < NE2K_RX_HEADER_SIZE || packet_length > NE2K_ETHERNET_MAX_FRAME)
+        return -3;
+    payload_length = (uint16_t)(packet_length - NE2K_RX_HEADER_SIZE);
+    if (payload_length > frame_capacity) return -4;
+    ne2k_remote_read_setup(io, base, (uint16_t)((page << 8) + NE2K_RX_HEADER_SIZE),
+                           payload_length);
+    for (i = 0; i < payload_length; ++i)
+        frame[i] = io->inb(io->context, (uint16_t)(base + NE2K_REG_DATA));
+    if (next_page < NE2K_RX_PAGE_START || next_page >= NE2K_RX_PAGE_STOP)
+        return -5;
+    io->outb(io->context, (uint16_t)(base + NE2K_REG_BNRY),
+             (uint8_t)(next_page == NE2K_RX_PAGE_START ? NE2K_RX_PAGE_STOP - 1U : next_page - 1U));
+    *frame_length = payload_length;
+    return 0;
+}
+
 int ne2k_i386_io(ne2k_io_t* io) {
     if (!io) return -1;
 #ifdef __i386__

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -29,12 +29,16 @@
 #define NE2K_DCR_WORD_MODE 0x49U
 #define NE2K_ISR_RESET 0x80U
 #define NE2K_ISR_RDC    0x40U
+#define NE2K_ISR_PRX    0x01U
 #define NE2K_DCR_BYTE_MODE 0x48U
 #define NE2K_COMMAND_REMOTE_WRITE 0x12U
+#define NE2K_COMMAND_REMOTE_READ  0x0aU
 #define NE2K_COMMAND_TRANSMIT 0x26U
 #define NE2K_TX_PAGE 0x40U
 #define NE2K_ETHERNET_MIN_FRAME 60U
 #define NE2K_ETHERNET_MAX_FRAME 1514U
+#define NE2K_RX_PAGE_START 0x46U
+#define NE2K_RX_PAGE_STOP  0x60U
 #define NE2K_RX_HEADER_SIZE 4U
 #define NE2K_RX_STATUS_OK 0x01U
 
@@ -74,6 +78,10 @@ int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */
 void ne2k_irq_service(void);
 uint32_t ne2k_irq_count(void);
+/* Polling RX borné: lit une trame depuis la RAM distante vers un buffer appelant. */
+int ne2k_rx_poll(ne2k_device_t* device, const ne2k_io_t* io,
+                 uint8_t* frame, uint16_t frame_capacity,
+                 uint16_t* frame_length);
 /* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */
 int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
                     net_nic_queue_t* rx_queue);

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -66,6 +66,9 @@ void test_probe_and_prepare_use_injected_io(void) {
     fake.isr = NE2K_ISR_RDC; TEST_ASSERT_EQUAL(0, ne2k_irq_attach(&device, &io));
     TEST_ASSERT_EQUAL(0, ne2k_irq_count()); ne2k_irq_service();
     TEST_ASSERT_EQUAL(1, ne2k_irq_count());
+    { uint8_t rx[64] = {0}; uint16_t rx_len = 99U; fake.isr = 0U;
+      TEST_ASSERT_EQUAL(1, ne2k_rx_poll(&device, &io, rx, sizeof(rx), &rx_len));
+      TEST_ASSERT_EQUAL(0, rx_len); }
 }
 
 void test_rx_extract_publishes_bounded_frame(void) {


### PR DESCRIPTION
## Résumé

Ajoute `ne2k_rx_poll` pour lire un en-tête et une charge utile depuis la RAM distante NE2000 par PIO, valider les bornes, copier vers un buffer appelant et avancer BNRY.

## Validation

- `make test-all`: 292/292 tests verts;
- `make all`: build i386 réussi;
- test Unity d'absence de paquet et remise à zéro de la longueur;
- documentation française AOS-136.

La réception d'une trame observable sous QEMU, ARP/IP, DHCP, DNS, TLS et HTTP/OpenAI restent explicitement hors périmètre.