### PR TITLE
Lot 137: raccordement RX NE2000 Ethernet ARP

### DIFF
--- a/docs/aos137_ne2k_rx_ethernet_arp.md
+++ b/docs/aos137_ne2k_rx_ethernet_arp.md
@@ -1,0 +1,18 @@
+# AOS-137 — Raccordement RX NE2000 vers Ethernet/ARP
+
+Le lot AOS-137 relie le polling RX PIO NE2000 aux codecs Ethernet et ARP caller-owned. `ne2k_rx_poll_arp` lit une trame dans le buffer fourni par l’appelant, décode l’en-tête Ethernet, distingue les trames non-ARP et parse les paquets ARP Ethernet/IPv4 valides dans une structure de sortie sans pointeur vers la trame.
+
+Les codes de retour séparent l’absence de paquet, une trame non-ARP et une trame Ethernet/ARP invalide. La chaîne n’alloue aucune mémoire et ne conserve aucun buffer matériel. La règle du runner Unity a également été mise à jour pour lier `net_ethernet_arp.c` au test NE2000 ; cette correction est nécessaire pour que la CI compile réellement le nouveau chemin.
+
+| Élément | État AOS-137 |
+|---|---|
+| Polling RX PIO NE2000 | Réutilisé. |
+| Décodage Ethernet | Raccordé. |
+| Décodage ARP Ethernet/IPv4 | Raccordé. |
+| Buffer et sorties caller-owned | Respectés. |
+| Runner Unity et dépendances | Corrigés. |
+| Réponse ARP automatique | Non implémentée. |
+| Émission ARP via TX | Préparée par AOS-134, non orchestrée ici. |
+| IPv4/UDP/DHCP/DNS/TCP/TLS/HTTP/OpenAI | Non déclarés fonctionnels sur le transport matériel. |
+
+La non-régression locale est de **292 tests verts**, avec build i386 réussi. La validation QEMU confirme le boot avec et sans matériel NE2000, mais ne prétend pas encore injecter puis observer une requête ARP de bout en bout.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -88,6 +88,24 @@ int ne2k_rx_poll(ne2k_device_t* device, const ne2k_io_t* io,
     return 0;
 }
 
+int ne2k_rx_poll_arp(ne2k_device_t* device, const ne2k_io_t* io,
+                     uint8_t* frame, uint16_t frame_capacity,
+                     uint16_t* frame_length,
+                     net_ethernet_header_t* ethernet,
+                     net_arp_packet_t* arp) {
+    int status;
+    if (!ethernet || !arp) return -1;
+    status = ne2k_rx_poll(device, io, frame, frame_capacity, frame_length);
+    if (status != 0) return status;
+    if (net_ethernet_parse(frame, *frame_length, ethernet) != 0)
+        return -2;
+    if (ethernet->ethertype != NET_ETHERTYPE_ARP)
+        return 2;
+    if (net_arp_parse(frame, *frame_length, arp) != 0)
+        return -3;
+    return 0;
+}
+
 int ne2k_i386_io(ne2k_io_t* io) {
     if (!io) return -1;
 #ifdef __i386__

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "net_nic.h"
+#include "net_ethernet_arp.h"
 
 #define NE2K_REG_COMMAND 0x00U
 #define NE2K_REG_RESET   0x1fU
@@ -82,6 +83,12 @@ uint32_t ne2k_irq_count(void);
 int ne2k_rx_poll(ne2k_device_t* device, const ne2k_io_t* io,
                  uint8_t* frame, uint16_t frame_capacity,
                  uint16_t* frame_length);
+/* Lit une trame puis décode son en-tête Ethernet et son ARP caller-owned. */
+int ne2k_rx_poll_arp(ne2k_device_t* device, const ne2k_io_t* io,
+                     uint8_t* frame, uint16_t frame_capacity,
+                     uint16_t* frame_length,
+                     net_ethernet_header_t* ethernet,
+                     net_arp_packet_t* arp);
 /* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */
 int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
                     net_nic_queue_t* rx_queue);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -149,9 +149,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dhcp: $(UNIT_DIR)/kernel/test_net_dhcp.
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -144,6 +144,7 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_ne2k.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/ne2k.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_nic.c"
+        extra_src="$extra_src $BASE_DIR/kernel/net_ethernet_arp.c"
     fi
     if [ "$(basename "$test_file")" = "test_pci.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/pci.c"


### PR DESCRIPTION
## Résumé

Relie `ne2k_rx_poll` au décodage Ethernet/ARP caller-owned avec `ne2k_rx_poll_arp`. Corrige également les dépendances du runner Unity afin que `test_ne2k` lie le codec Ethernet/ARP.

## Validation

- `make test-all`: 292/292 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-137.

La réponse ARP automatique, IPv4/UDP, DHCP, DNS, TLS et HTTP/OpenAI restent explicitement hors périmètre.