### PR TITLE
Lot 138: réponse ARP caller-owned

### DIFF
--- a/docs/aos138_arp_reply_caller_owned.md
+++ b/docs/aos138_arp_reply_caller_owned.md
@@ -1,0 +1,17 @@
+# AOS-138 — Réponse ARP caller-owned
+
+Le lot AOS-138 ajoute `net_arp_build_reply`. À partir d’une requête ARP Ethernet/IPv4 déjà décodée, la primitive construit dans un buffer fourni par l’appelant une réponse unicast : la destination Ethernet et la MAC cible deviennent l’émetteur de la requête, tandis que la MAC et l’IPv4 locales deviennent l’émetteur de la réponse. L’opcode passe de REQUEST à REPLY et tous les champs sont réécrits en big-endian ou copiés explicitement.
+
+La fonction refuse les buffers trop courts, les requêtes d’un autre type matériel ou protocole, les tailles d’adresse non conformes et les paquets qui ne sont pas des requêtes ARP. Elle n’alloue aucune mémoire, ne conserve aucun pointeur vers la requête et retourne toujours la taille Ethernet/ARP de 42 octets en cas de succès.
+
+| Élément | État AOS-138 |
+|---|---|
+| Construction réponse ARP Ethernet/IPv4 | Implémentée. |
+| Destination unicast vers le demandeur | Implémentée. |
+| Validation de la requête décodée | Implémentée. |
+| Buffers caller-owned et sans allocation | Respectés. |
+| Orchestration RX → réponse → TX | Non raccordée dans ce lot. |
+| Smoke QEMU d’une requête ARP réelle | Non déclaré. |
+| IPv4/UDP, DHCP, DNS, TCP, TLS, HTTP/OpenAI | Toujours non fonctionnels sur le transport matériel. |
+
+La suite locale atteint **293 tests verts**, sans échec ni test ignoré, et le build i386 réussit.

--- a/kernel/net_ethernet_arp.c
+++ b/kernel/net_ethernet_arp.c
@@ -80,6 +80,32 @@ int net_arp_build_request(uint8_t* frame, uint32_t capacity,
     return (int)(NET_ETHERNET_HEADER_SIZE + NET_ARP_PACKET_SIZE);
 }
 
+int net_arp_build_reply(uint8_t* frame, uint32_t capacity,
+                        const net_arp_packet_t* request,
+                        const uint8_t local_mac[6], const uint8_t local_ipv4[4]) {
+    uint8_t* arp;
+    if (!frame || !request || !local_mac || !local_ipv4 ||
+        capacity < NET_ETHERNET_HEADER_SIZE + NET_ARP_PACKET_SIZE ||
+        request->opcode != NET_ARP_OPCODE_REQUEST ||
+        request->hardware_type != NET_ARP_HTYPE_ETHERNET ||
+        request->protocol_type != NET_ARP_PTYPE_IPV4 ||
+        request->hardware_size != 6U || request->protocol_size != 4U)
+        return -1;
+    copy_bytes(frame, request->sender_mac, 6);
+    copy_bytes(frame + 6, local_mac, 6);
+    write_be16(frame + 12, NET_ETHERTYPE_ARP);
+    arp = frame + NET_ETHERNET_HEADER_SIZE;
+    write_be16(arp + 0, NET_ARP_HTYPE_ETHERNET);
+    write_be16(arp + 2, NET_ARP_PTYPE_IPV4);
+    arp[4] = 6U; arp[5] = 4U;
+    write_be16(arp + 6, NET_ARP_OPCODE_REPLY);
+    copy_bytes(arp + 8, local_mac, 6);
+    copy_bytes(arp + 14, local_ipv4, 4);
+    copy_bytes(arp + 18, request->sender_mac, 6);
+    copy_bytes(arp + 24, request->sender_ipv4, 4);
+    return (int)(NET_ETHERNET_HEADER_SIZE + NET_ARP_PACKET_SIZE);
+}
+
 int net_arp_is_reply_for(const net_arp_packet_t* packet,
                          const uint8_t local_ipv4[4],
                          const uint8_t requested_ipv4[4]) {

--- a/kernel/net_ethernet_arp.h
+++ b/kernel/net_ethernet_arp.h
@@ -41,6 +41,10 @@ int net_arp_parse(const uint8_t* frame, uint32_t length,
 int net_arp_build_request(uint8_t* frame, uint32_t capacity,
                           const uint8_t sender_mac[6], const uint8_t sender_ipv4[4],
                           const uint8_t target_ipv4[4]);
+/* Construit une réponse ARP à partir d’une requête décodée, sans allocation. */
+int net_arp_build_reply(uint8_t* frame, uint32_t capacity,
+                        const net_arp_packet_t* request,
+                        const uint8_t local_mac[6], const uint8_t local_ipv4[4]);
 /* Reconnaît uniquement une réponse ARP destinée à l’adresse IPv4 fournie. */
 int net_arp_is_reply_for(const net_arp_packet_t* packet,
                          const uint8_t local_ipv4[4],

--- a/tests/unit/kernel/test_net_ethernet_arp.c
+++ b/tests/unit/kernel/test_net_ethernet_arp.c
@@ -20,6 +20,24 @@ void test_build_and_parse_arp_request(void) {
     TEST_ASSERT_EQUAL_MEMORY(target, packet.target_ipv4, 4);
 }
 
+void test_builds_reply_from_request(void) {
+    uint8_t request_frame[64] = {0}; uint8_t reply_frame[64] = {0};
+    uint8_t local_mac[6] = {0x02, 0, 0, 0, 0, 0x10};
+    uint8_t local_ip[4] = {10, 0, 2, 15};
+    uint8_t sender_mac[6] = {0x52, 0x54, 0, 0x12, 0x34, 0x56};
+    uint8_t sender_ip[4] = {10, 0, 2, 2}; net_arp_packet_t request, reply;
+    int length;
+    length = net_arp_build_request(request_frame, sizeof(request_frame), sender_mac, sender_ip, local_ip);
+    TEST_ASSERT_EQUAL(42, length); TEST_ASSERT_EQUAL(0, net_arp_parse(request_frame, length, &request));
+    TEST_ASSERT_EQUAL(42, net_arp_build_reply(reply_frame, sizeof(reply_frame), &request, local_mac, local_ip));
+    TEST_ASSERT_EQUAL(0, net_arp_parse(reply_frame, 42, &reply));
+    TEST_ASSERT_EQUAL(NET_ARP_OPCODE_REPLY, reply.opcode);
+    TEST_ASSERT_EQUAL_MEMORY(local_mac, reply.sender_mac, 6);
+    TEST_ASSERT_EQUAL_MEMORY(local_ip, reply.sender_ipv4, 4);
+    TEST_ASSERT_EQUAL_MEMORY(sender_mac, reply.target_mac, 6);
+    TEST_ASSERT_EQUAL_MEMORY(sender_ip, reply.target_ipv4, 4);
+}
+
 void test_rejects_short_or_non_arp_frame(void) {
     uint8_t frame[42] = {0};
     net_arp_packet_t packet;
@@ -46,6 +64,7 @@ void test_reply_matches_local_and_requested_addresses(void) {
 int main(void) {
     unity_init();
     RUN_TEST(test_build_and_parse_arp_request);
+    RUN_TEST(test_builds_reply_from_request);
     RUN_TEST(test_rejects_short_or_non_arp_frame);
     RUN_TEST(test_reply_matches_local_and_requested_addresses);
     unity_print_results();


### PR DESCRIPTION
## Résumé

Ajoute `net_arp_build_reply` pour construire une réponse Ethernet/ARP unicast à partir d'une requête décodée, sans allocation et sans conserver de pointeur.

## Validation

- `make test-all`: 293/293 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-138.

L'orchestration RX→réponse→TX et IPv4/UDP restent explicitement hors périmètre.