### PR TITLE
Lot 139: service ARP RX vers TX NE2000

### DIFF
--- a/docs/aos139_ne2k_arp_service.md
+++ b/docs/aos139_ne2k_arp_service.md
@@ -1,0 +1,16 @@
+# AOS-139 — Service ARP NE2000 RX→réponse→TX
+
+Le lot AOS-139 ajoute `ne2k_arp_service`, une orchestration bornée qui traite au plus une trame reçue. Le pilote effectue le polling RX et le décodage Ethernet/ARP, vérifie que la requête est une demande ARP destinée à l’IPv4 locale, construit la réponse dans un second buffer caller-owned, puis la soumet au TX PIO NE2000.
+
+L’orchestrateur ne conserve aucun pointeur vers les buffers appelant et ne fait aucune allocation. Les buffers RX et TX sont distincts afin d’éviter toute écrasement de la trame reçue pendant la construction de la réponse. L’absence de paquet est retournée sans émission ; les trames non ciblées ou d’un type non pris en charge sont ignorées.
+
+| Élément | État AOS-139 |
+|---|---|
+| RX NE2000 → parse Ethernet/ARP | Raccordé. |
+| Filtrage requête ARP ciblant l’IPv4 locale | Raccordé. |
+| Construction réponse caller-owned | Raccordée. |
+| Soumission TX PIO caller-owned | Raccordée. |
+| Gestion d’une trame ARP réelle injectée sous QEMU | Smoke dédié encore à ajouter. |
+| IPv4/UDP, DHCP, DNS, TCP, TLS, HTTP/OpenAI | Toujours non déclarés fonctionnels sur le transport matériel. |
+
+La non-régression locale reste à **293 tests verts**, avec build i386 réussi. Les smokes QEMU existants vérifient le boot avec et sans NE2000, mais ne constituent pas encore une preuve de bout en bout de réponse ARP sur le réseau virtuel.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -106,6 +106,27 @@ int ne2k_rx_poll_arp(ne2k_device_t* device, const ne2k_io_t* io,
     return 0;
 }
 
+int ne2k_arp_service(ne2k_device_t* device, const ne2k_io_t* io,
+                     uint8_t* rx_frame, uint16_t rx_capacity,
+                     uint8_t* tx_frame, uint16_t tx_capacity,
+                     const uint8_t local_mac[6], const uint8_t local_ipv4[4]) {
+    uint16_t rx_length = 0U;
+    net_ethernet_header_t ethernet;
+    net_arp_packet_t arp;
+    int status;
+    if (!tx_frame || !local_mac || !local_ipv4) return -1;
+    status = ne2k_rx_poll_arp(device, io, rx_frame, rx_capacity, &rx_length,
+                              &ethernet, &arp);
+    if (status != 0) return status;
+    if (arp.opcode != NET_ARP_OPCODE_REQUEST ||
+        arp.target_ipv4[0] != local_ipv4[0] || arp.target_ipv4[1] != local_ipv4[1] ||
+        arp.target_ipv4[2] != local_ipv4[2] || arp.target_ipv4[3] != local_ipv4[3])
+        return 2;
+    status = net_arp_build_reply(tx_frame, tx_capacity, &arp, local_mac, local_ipv4);
+    if (status < 0) return -2;
+    return ne2k_tx_submit(device, io, tx_frame, (uint16_t)status);
+}
+
 int ne2k_i386_io(ne2k_io_t* io) {
     if (!io) return -1;
 #ifdef __i386__

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -89,6 +89,11 @@ int ne2k_rx_poll_arp(ne2k_device_t* device, const ne2k_io_t* io,
                      uint16_t* frame_length,
                      net_ethernet_header_t* ethernet,
                      net_arp_packet_t* arp);
+/* Traite au plus une requête ARP locale et soumet sa réponse au TX caller-owned. */
+int ne2k_arp_service(ne2k_device_t* device, const ne2k_io_t* io,
+                     uint8_t* rx_frame, uint16_t rx_capacity,
+                     uint8_t* tx_frame, uint16_t tx_capacity,
+                     const uint8_t local_mac[6], const uint8_t local_ipv4[4]);
 /* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */
 int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
                     net_nic_queue_t* rx_queue);

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -69,6 +69,11 @@ void test_probe_and_prepare_use_injected_io(void) {
     { uint8_t rx[64] = {0}; uint16_t rx_len = 99U; fake.isr = 0U;
       TEST_ASSERT_EQUAL(1, ne2k_rx_poll(&device, &io, rx, sizeof(rx), &rx_len));
       TEST_ASSERT_EQUAL(0, rx_len); }
+    { uint8_t rx_frame[128] = {0}; uint8_t tx_frame[128] = {0};
+      uint8_t local_mac[6] = {0x02, 0, 0, 0, 0, 1};
+      uint8_t local_ip[4] = {10, 0, 2, 15};
+      TEST_ASSERT_EQUAL(1, ne2k_arp_service(&device, &io, rx_frame, sizeof(rx_frame),
+                                             tx_frame, sizeof(tx_frame), local_mac, local_ip)); }
 }
 
 void test_rx_extract_publishes_bounded_frame(void) {


### PR DESCRIPTION
## Résumé

Ajoute `ne2k_arp_service` pour traiter une requête ARP locale : polling RX, parse Ethernet/ARP, construction de réponse et soumission TX PIO, avec buffers caller-owned distincts.

## Validation

- `make test-all`: 293/293 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-139.

Le smoke d'une requête ARP injectée et IPv4/UDP restent explicitement hors périmètre.