### PR TITLE
Lot 140: RX NE2000 vers IPv4 UDP caller-owned

### DIFF
--- a/docs/aos140_ne2k_rx_ipv4_udp.md
+++ b/docs/aos140_ne2k_rx_ipv4_udp.md
@@ -1,0 +1,16 @@
+# AOS-140 — Raccordement RX NE2000 vers IPv4/UDP
+
+Le lot AOS-140 ajoute `ne2k_rx_poll_udp`. La primitive réutilise le polling RX NE2000, décode l’en-tête Ethernet, filtre l’EtherType IPv4 puis transmet uniquement le paquet IP à `net_udp_parse_ipv4`. La vue UDP expose les adresses, ports et payload dans le buffer caller-owned ; aucune copie de payload et aucune allocation dynamique ne sont effectuées.
+
+Les retours distinguent l’absence de paquet, une trame non-IPv4 et un paquet IPv4/UDP invalide. Le parseur existant continue de vérifier la longueur totale et le checksum IPv4. Les règles Makefile et le runner CI lient explicitement `net_ipv4_udp.c` au test NE2000 pour éviter qu’une dépendance de production soit masquée par une compilation partielle.
+
+| Élément | État AOS-140 |
+|---|---|
+| RX PIO NE2000 vers Ethernet | Réutilisé. |
+| Filtrage IPv4 | Implémenté. |
+| Parse UDP caller-owned | Implémenté. |
+| Émission IPv4/UDP via TX | Non orchestrée dans ce lot. |
+| DHCP/DNS sur transport matériel | Non déclarés fonctionnels. |
+| TCP/TLS/HTTP/OpenAI | Non déclarés fonctionnels. |
+
+La suite locale reste à **293 tests verts**, avec build i386 réussi. Les smokes QEMU existants restent des vérifications de boot et de détection NE2000 ; ils ne démontrent pas encore un échange UDP réel.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -127,6 +127,25 @@ int ne2k_arp_service(ne2k_device_t* device, const ne2k_io_t* io,
     return ne2k_tx_submit(device, io, tx_frame, (uint16_t)status);
 }
 
+int ne2k_rx_poll_udp(ne2k_device_t* device, const ne2k_io_t* io,
+                     uint8_t* frame, uint16_t frame_capacity,
+                     uint16_t* frame_length, net_udp_view_t* udp) {
+    net_ethernet_header_t ethernet;
+    int status;
+    if (!udp) return -1;
+    status = ne2k_rx_poll(device, io, frame, frame_capacity, frame_length);
+    if (status != 0) return status;
+    if (net_ethernet_parse(frame, *frame_length, &ethernet) != 0)
+        return -2;
+    if (ethernet.ethertype != NET_ETHERTYPE_IPV4)
+        return 2;
+    if (*frame_length <= NET_ETHERNET_HEADER_SIZE ||
+        net_udp_parse_ipv4(frame + NET_ETHERNET_HEADER_SIZE,
+                           (uint32_t)(*frame_length - NET_ETHERNET_HEADER_SIZE), udp) != 0)
+        return -3;
+    return 0;
+}
+
 int ne2k_i386_io(ne2k_io_t* io) {
     if (!io) return -1;
 #ifdef __i386__

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include "net_nic.h"
 #include "net_ethernet_arp.h"
+#include "net_ipv4_udp.h"
 
 #define NE2K_REG_COMMAND 0x00U
 #define NE2K_REG_RESET   0x1fU
@@ -94,6 +95,10 @@ int ne2k_arp_service(ne2k_device_t* device, const ne2k_io_t* io,
                      uint8_t* rx_frame, uint16_t rx_capacity,
                      uint8_t* tx_frame, uint16_t tx_capacity,
                      const uint8_t local_mac[6], const uint8_t local_ipv4[4]);
+/* Lit une trame IPv4/UDP et expose une vue payload dans le buffer caller-owned. */
+int ne2k_rx_poll_udp(ne2k_device_t* device, const ne2k_io_t* io,
+                     uint8_t* frame, uint16_t frame_capacity,
+                     uint16_t* frame_length, net_udp_view_t* udp);
 /* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */
 int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
                     net_nic_queue_t* rx_queue);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -149,9 +149,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dhcp: $(UNIT_DIR)/kernel/test_net_dhcp.
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -145,6 +145,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/ne2k.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_nic.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_ethernet_arp.c"
+        extra_src="$extra_src $BASE_DIR/kernel/net_ipv4_udp.c"
     fi
     if [ "$(basename "$test_file")" = "test_pci.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/pci.c"


### PR DESCRIPTION
## Résumé

Ajoute `ne2k_rx_poll_udp` pour décoder Ethernet puis IPv4/UDP depuis une trame RX NE2000 et exposer une vue caller-owned. Met à jour les deux runners de tests pour lier `net_ipv4_udp.c`.

## Validation

- `make test-all`: 293/293 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi après rerun propre;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-140.

L'émission IPv4/UDP, DHCP, DNS, TCP, TLS et HTTP/OpenAI restent explicitement hors périmètre.