### PR TITLE
Lot 141: émission IPv4 UDP via NE2000

### DIFF
--- a/docs/aos141_ne2k_tx_ipv4_udp.md
+++ b/docs/aos141_ne2k_tx_ipv4_udp.md
@@ -1,0 +1,16 @@
+# AOS-141 — Émission IPv4/UDP Ethernet caller-owned
+
+Le lot AOS-141 ajoute `ne2k_tx_udp`. La primitive construit dans un buffer fourni par l’appelant l’en-tête Ethernet, le paquet IPv4/UDP et son payload, puis réutilise `ne2k_tx_submit` pour le transfert PIO vers la RAM distante du NE2000 et le déclenchement TX.
+
+La MAC source provient de l’identité locale validée du périphérique, tandis que la MAC destination est fournie par l’appelant. Les adresses IPv4, ports et payload sont transmis au codec UDP existant, qui calcule le checksum IPv4. La capacité maximale Ethernet est vérifiée avant toute émission ; le padding Ethernet minimal reste assuré par le TX NE2000.
+
+| Élément | État AOS-141 |
+|---|---|
+| Construction Ethernet + IPv4/UDP | Implémentée. |
+| Émission PIO NE2000 | Réutilisée et validée. |
+| Buffers caller-owned | Respectés. |
+| Résolution automatique ARP avant émission | Non orchestrée dans ce lot. |
+| Échange UDP réel sous QEMU | Non déclaré. |
+| DHCP/DNS/TCP/TLS/HTTP/OpenAI | Toujours non déclarés fonctionnels sur le transport matériel. |
+
+La suite locale reste à **293 tests verts**, avec build i386 réussi. Les smokes QEMU vérifient le boot, l’absence de fournisseur matériel et la détection NE2000, mais pas encore la transmission UDP sur un réseau virtuel.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -16,6 +16,34 @@ static ne2k_device_t* ne2k_irq_device;
 static const ne2k_io_t* ne2k_irq_io;
 static volatile uint32_t ne2k_irq_events;
 
+int ne2k_tx_udp(ne2k_device_t* device, const ne2k_io_t* io,
+                uint8_t* frame, uint16_t frame_capacity,
+                const uint8_t destination_mac[6],
+                const uint8_t source_ipv4[4], const uint8_t destination_ipv4[4],
+                uint16_t source_port, uint16_t destination_port,
+                const uint8_t* payload, uint16_t payload_length) {
+    uint16_t ip_length;
+    uint32_t total_length;
+    uint8_t i;
+    if (!device || !io || !frame || !destination_mac || !source_ipv4 ||
+        !destination_ipv4 || (!payload && payload_length != 0U) ||
+        !device->mac_valid) return -1;
+    total_length = NET_ETHERNET_HEADER_SIZE + NET_IPV4_HEADER_SIZE +
+                   NET_UDP_HEADER_SIZE + payload_length;
+    if (total_length > frame_capacity || total_length > NE2K_ETHERNET_MAX_FRAME)
+        return -2;
+    for (i = 0; i < 6U; ++i) { frame[i] = destination_mac[i]; frame[6U + i] = device->mac[i]; }
+    frame[12] = (uint8_t)(NET_ETHERTYPE_IPV4 >> 8);
+    frame[13] = (uint8_t)NET_ETHERTYPE_IPV4;
+    ip_length = (uint16_t)net_udp_build_ipv4(frame + NET_ETHERNET_HEADER_SIZE,
+                                             frame_capacity - NET_ETHERNET_HEADER_SIZE,
+                                             source_ipv4, destination_ipv4,
+                                             source_port, destination_port,
+                                             payload, payload_length);
+    if (ip_length == 0U) return -3;
+    return ne2k_tx_submit(device, io, frame, (uint16_t)(NET_ETHERNET_HEADER_SIZE + ip_length));
+}
+
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io) {
     if (!device || !io || !io->inb || !io->outb || device->base_port == 0U)
         return -1;

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -75,6 +75,13 @@ int ne2k_read_mac(ne2k_device_t* device, const ne2k_io_t* io);
 /* Copie une trame caller-owned dans la RAM distante puis déclenche TX. */
 int ne2k_tx_submit(ne2k_device_t* device, const ne2k_io_t* io,
                    const uint8_t* frame, uint16_t length);
+/* Construit puis émet une trame Ethernet IPv4/UDP caller-owned. */
+int ne2k_tx_udp(ne2k_device_t* device, const ne2k_io_t* io,
+                uint8_t* frame, uint16_t frame_capacity,
+                const uint8_t destination_mac[6],
+                const uint8_t source_ipv4[4], const uint8_t destination_ipv4[4],
+                uint16_t source_port, uint16_t destination_port,
+                const uint8_t* payload, uint16_t payload_length);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -63,6 +63,13 @@ void test_probe_and_prepare_use_injected_io(void) {
       TEST_ASSERT_EQUAL(1, fake.tx_data[0]); TEST_ASSERT_EQUAL(10, fake.tx_data[9]);
       TEST_ASSERT_EQUAL(0, fake.tx_data[59]);
       TEST_ASSERT_NOT_EQUAL(0, ne2k_tx_submit(&device, &io, frame, NE2K_ETHERNET_MAX_FRAME + 1U)); }
+    { uint8_t frame[128] = {0}; uint8_t destination_mac[6] = {0x52, 0x54, 0, 0, 0, 2};
+      uint8_t source_ip[4] = {10, 0, 2, 15}; uint8_t destination_ip[4] = {10, 0, 2, 2};
+      uint8_t payload[3] = {1, 2, 3}; fake.isr = NE2K_ISR_RDC;
+      TEST_ASSERT_EQUAL(0, ne2k_tx_udp(&device, &io, frame, sizeof(frame), destination_mac,
+                                       source_ip, destination_ip, 4000, 4001, payload, sizeof(payload)));
+      TEST_ASSERT_EQUAL(0x52, frame[0]); TEST_ASSERT_EQUAL(0x08, frame[12]);
+      TEST_ASSERT_EQUAL(0x00, frame[13]); }
     fake.isr = NE2K_ISR_RDC; TEST_ASSERT_EQUAL(0, ne2k_irq_attach(&device, &io));
     TEST_ASSERT_EQUAL(0, ne2k_irq_count()); ne2k_irq_service();
     TEST_ASSERT_EQUAL(1, ne2k_irq_count());


### PR DESCRIPTION
## Résumé

Ajoute `ne2k_tx_udp` pour construire une trame Ethernet IPv4/UDP caller-owned puis la soumettre au TX PIO NE2000. La MAC destination est fournie par l'appelant et la MAC source provient de l'identité locale validée.

## Validation

- `make test-all`: 293/293 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-141.

La résolution ARP automatique, DHCP, DNS, TCP, TLS et HTTP/OpenAI restent explicitement hors périmètre.