### PR TITLE
Lot 142: cache ARP statique caller-owned

### DIFF
--- a/docs/aos142_arp_static_cache.md
+++ b/docs/aos142_arp_static_cache.md
@@ -1,0 +1,17 @@
+# AOS-142 — Cache ARP statique caller-owned
+
+Le lot AOS-142 ajoute un cache ARP de capacité fixe (`NET_ARP_CACHE_CAPACITY`), stocké par l’appelant. Chaque entrée contient une IPv4, une MAC et un indicateur de validité. Les opérations d’initialisation, insertion, mise à jour, recherche et invalidation n’utilisent aucune allocation dynamique.
+
+Une insertion met à jour l’entrée existante lorsque l’IPv4 est déjà présente ; sinon, elle utilise la première entrée libre. Lorsque le cache est plein, l’insertion échoue explicitement au lieu d’évincer silencieusement une entrée. Cette politique rend la consommation mémoire et le comportement déterministes dans le chemin réseau bare-metal.
+
+| Élément | État AOS-142 |
+|---|---|
+| Cache à capacité fixe | Implémenté. |
+| Lookup IPv4 → MAC | Implémenté. |
+| Mise à jour et invalidation | Implémentées. |
+| Allocation dynamique | Aucune. |
+| Requête ARP et attente RX | Prochain sous-lot. |
+| Intégration automatique à `ne2k_tx_udp` | Prochain sous-lot. |
+| DHCP/DNS/TCP/TLS/HTTP/OpenAI | Toujours non déclarés fonctionnels sur le transport matériel. |
+
+La validation locale atteint **294 tests verts**, avec build i386 réussi. Les smokes QEMU de boot et de détection NE2000 restent à rejouer avant publication.

--- a/kernel/net_ethernet_arp.c
+++ b/kernel/net_ethernet_arp.c
@@ -106,6 +106,49 @@ int net_arp_build_reply(uint8_t* frame, uint32_t capacity,
     return (int)(NET_ETHERNET_HEADER_SIZE + NET_ARP_PACKET_SIZE);
 }
 
+int net_arp_cache_init(net_arp_cache_t* cache) {
+    uint32_t i;
+    if (!cache) return -1;
+    for (i = 0; i < NET_ARP_CACHE_CAPACITY; ++i) cache->entries[i].valid = 0U;
+    return 0;
+}
+
+int net_arp_cache_put(net_arp_cache_t* cache, const uint8_t ipv4[4], const uint8_t mac[6]) {
+    uint32_t i; uint32_t free_index = NET_ARP_CACHE_CAPACITY;
+    if (!cache || !ipv4 || !mac) return -1;
+    for (i = 0; i < NET_ARP_CACHE_CAPACITY; ++i) {
+        if (cache->entries[i].valid && bytes_equal(cache->entries[i].ipv4, ipv4, 4U)) {
+            copy_bytes(cache->entries[i].mac, mac, 6U); return 0;
+        }
+        if (!cache->entries[i].valid && free_index == NET_ARP_CACHE_CAPACITY) free_index = i;
+    }
+    if (free_index == NET_ARP_CACHE_CAPACITY) return -2;
+    cache->entries[free_index].valid = 1U;
+    copy_bytes(cache->entries[free_index].ipv4, ipv4, 4U);
+    copy_bytes(cache->entries[free_index].mac, mac, 6U);
+    return 0;
+}
+
+int net_arp_cache_lookup(const net_arp_cache_t* cache, const uint8_t ipv4[4], uint8_t mac[6]) {
+    uint32_t i;
+    if (!cache || !ipv4 || !mac) return -1;
+    for (i = 0; i < NET_ARP_CACHE_CAPACITY; ++i)
+        if (cache->entries[i].valid && bytes_equal(cache->entries[i].ipv4, ipv4, 4U)) {
+            copy_bytes(mac, cache->entries[i].mac, 6U); return 0;
+        }
+    return -2;
+}
+
+int net_arp_cache_invalidate(net_arp_cache_t* cache, const uint8_t ipv4[4]) {
+    uint32_t i;
+    if (!cache || !ipv4) return -1;
+    for (i = 0; i < NET_ARP_CACHE_CAPACITY; ++i)
+        if (cache->entries[i].valid && bytes_equal(cache->entries[i].ipv4, ipv4, 4U)) {
+            cache->entries[i].valid = 0U; return 0;
+        }
+    return -2;
+}
+
 int net_arp_is_reply_for(const net_arp_packet_t* packet,
                          const uint8_t local_ipv4[4],
                          const uint8_t requested_ipv4[4]) {

--- a/kernel/net_ethernet_arp.h
+++ b/kernel/net_ethernet_arp.h
@@ -11,6 +11,7 @@
 #define NET_ARP_PTYPE_IPV4 0x0800U
 #define NET_ARP_OPCODE_REQUEST 1U
 #define NET_ARP_OPCODE_REPLY 2U
+#define NET_ARP_CACHE_CAPACITY 8U
 
 /* Aucune structure ne pointe dans une trame reçue: les adresses sont copiées. */
 typedef struct {
@@ -18,6 +19,16 @@ typedef struct {
     uint8_t source[6];
     uint16_t ethertype;
 } net_ethernet_header_t;
+
+typedef struct {
+    uint8_t valid;
+    uint8_t ipv4[4];
+    uint8_t mac[6];
+} net_arp_cache_entry_t;
+
+typedef struct {
+    net_arp_cache_entry_t entries[NET_ARP_CACHE_CAPACITY];
+} net_arp_cache_t;
 
 typedef struct {
     uint16_t hardware_type;
@@ -49,5 +60,10 @@ int net_arp_build_reply(uint8_t* frame, uint32_t capacity,
 int net_arp_is_reply_for(const net_arp_packet_t* packet,
                          const uint8_t local_ipv4[4],
                          const uint8_t requested_ipv4[4]);
+/* Cache ARP caller-owned de capacité fixe, sans allocation dynamique. */
+int net_arp_cache_init(net_arp_cache_t* cache);
+int net_arp_cache_put(net_arp_cache_t* cache, const uint8_t ipv4[4], const uint8_t mac[6]);
+int net_arp_cache_lookup(const net_arp_cache_t* cache, const uint8_t ipv4[4], uint8_t mac[6]);
+int net_arp_cache_invalidate(net_arp_cache_t* cache, const uint8_t ipv4[4]);
 
 #endif

--- a/tests/unit/kernel/test_net_ethernet_arp.c
+++ b/tests/unit/kernel/test_net_ethernet_arp.c
@@ -38,6 +38,21 @@ void test_builds_reply_from_request(void) {
     TEST_ASSERT_EQUAL_MEMORY(sender_ip, reply.target_ipv4, 4);
 }
 
+void test_arp_cache_put_lookup_update_invalidate(void) {
+    net_arp_cache_t cache; uint8_t ip[4] = {10, 0, 2, 2};
+    uint8_t mac[6] = {0x52, 0x54, 0, 0, 0, 2}; uint8_t out[6] = {0};
+    TEST_ASSERT_EQUAL(0, net_arp_cache_init(&cache));
+    TEST_ASSERT_EQUAL(-2, net_arp_cache_lookup(&cache, ip, out));
+    TEST_ASSERT_EQUAL(0, net_arp_cache_put(&cache, ip, mac));
+    TEST_ASSERT_EQUAL(0, net_arp_cache_lookup(&cache, ip, out));
+    TEST_ASSERT_EQUAL_MEMORY(mac, out, 6);
+    mac[5] = 3; TEST_ASSERT_EQUAL(0, net_arp_cache_put(&cache, ip, mac));
+    TEST_ASSERT_EQUAL(0, net_arp_cache_lookup(&cache, ip, out));
+    TEST_ASSERT_EQUAL(3, out[5]);
+    TEST_ASSERT_EQUAL(0, net_arp_cache_invalidate(&cache, ip));
+    TEST_ASSERT_EQUAL(-2, net_arp_cache_lookup(&cache, ip, out));
+}
+
 void test_rejects_short_or_non_arp_frame(void) {
     uint8_t frame[42] = {0};
     net_arp_packet_t packet;
@@ -65,6 +80,7 @@ int main(void) {
     unity_init();
     RUN_TEST(test_build_and_parse_arp_request);
     RUN_TEST(test_builds_reply_from_request);
+    RUN_TEST(test_arp_cache_put_lookup_update_invalidate);
     RUN_TEST(test_rejects_short_or_non_arp_frame);
     RUN_TEST(test_reply_matches_local_and_requested_addresses);
     unity_print_results();


### PR DESCRIPTION
## Résumé

Ajoute un cache ARP fixe de 8 entrées avec lookup, insertion, mise à jour et invalidation sans allocation dynamique. Le cache refuse explicitement l'insertion lorsque toutes les entrées sont occupées.

## Validation

- `make test-all`: 294/294 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi après rerun propre;
- documentation française AOS-142.

La requête ARP active et son intégration à l'émission IPv4/UDP restent les prochains sous-lots.