### PR TITLE
Lot 143: résolution ARP active caller-owned

### DIFF
--- a/docs/aos143_arp_active_resolution.md
+++ b/docs/aos143_arp_active_resolution.md
@@ -1,0 +1,17 @@
+# AOS-143 — Résolution ARP active caller-owned
+
+Le lot AOS-143 ajoute `ne2k_arp_resolve`. La primitive consulte d’abord le cache ARP statique. En cas d’absence, elle construit une requête ARP dans un buffer caller-owned, la transmet par TX PIO, puis effectue un nombre d’essais RX borné. Chaque réponse reçue est décodée par le chemin Ethernet/ARP existant ; seule une réponse destinée à l’IPv4 locale et correspondant à la cible demandée alimente le cache.
+
+`ne2k_tx_udp_resolve` réutilise ensuite cette résolution pour retrouver la MAC destination avant d’appeler `ne2k_tx_udp`. Les buffers de requête ARP, réception, émission UDP et cache restent fournis par l’appelant. Une absence de réponse retourne une erreur explicite après la limite d’essais, sans boucle infinie ni allocation dynamique.
+
+| Élément | État AOS-143 |
+|---|---|
+| Lookup cache avant émission ARP | Implémenté. |
+| Requête ARP caller-owned | Implémentée. |
+| Attente RX bornée | Implémentée. |
+| Validation et alimentation du cache | Implémentées. |
+| Émission UDP après résolution | Intégrée. |
+| Échange ARP réel observable sous QEMU | Non déclaré par les smokes actuels. |
+| DHCP/DNS/TCP/TLS/HTTP/OpenAI | Toujours non déclarés fonctionnels sur le transport matériel. |
+
+La validation locale reste à **294 tests verts**, avec build i386 réussi.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -44,6 +44,55 @@ int ne2k_tx_udp(ne2k_device_t* device, const ne2k_io_t* io,
     return ne2k_tx_submit(device, io, frame, (uint16_t)(NET_ETHERNET_HEADER_SIZE + ip_length));
 }
 
+int ne2k_arp_resolve(ne2k_device_t* device, const ne2k_io_t* io,
+                     net_arp_cache_t* cache,
+                     uint8_t* request_frame, uint16_t request_capacity,
+                     uint8_t* rx_frame, uint16_t rx_capacity,
+                     const uint8_t local_mac[6], const uint8_t local_ipv4[4],
+                     const uint8_t target_ipv4[4], uint16_t attempts) {
+    uint8_t destination_mac[6]; uint16_t request_length, rx_length, i;
+    net_ethernet_header_t ethernet; net_arp_packet_t arp; int status;
+    if (!device || !io || !cache || !request_frame || !rx_frame || !local_mac ||
+        !local_ipv4 || !target_ipv4 || attempts == 0U) return -1;
+    if (net_arp_cache_lookup(cache, target_ipv4, destination_mac) == 0) return 0;
+    request_length = (uint16_t)net_arp_build_request(request_frame, request_capacity,
+                                                      local_mac, local_ipv4, target_ipv4);
+    if (request_length == 0U) return -2;
+    status = ne2k_tx_submit(device, io, request_frame, request_length);
+    if (status != 0) return -3;
+    for (i = 0; i < attempts; ++i) {
+        status = ne2k_rx_poll_arp(device, io, rx_frame, rx_capacity, &rx_length,
+                                  &ethernet, &arp);
+        if (status == 1) continue;
+        if (status != 0) continue;
+        if (net_arp_is_reply_for(&arp, local_ipv4, target_ipv4)) {
+            if (net_arp_cache_put(cache, target_ipv4, arp.sender_mac) != 0) return -4;
+            return 0;
+        }
+    }
+    return -5;
+}
+
+int ne2k_tx_udp_resolve(ne2k_device_t* device, const ne2k_io_t* io,
+                        net_arp_cache_t* cache,
+                        uint8_t* request_frame, uint16_t request_capacity,
+                        uint8_t* rx_frame, uint16_t rx_capacity,
+                        uint8_t* tx_frame, uint16_t tx_capacity,
+                        const uint8_t local_ipv4[4], const uint8_t target_ipv4[4],
+                        uint16_t source_port, uint16_t destination_port,
+                        const uint8_t* payload, uint16_t payload_length,
+                        uint16_t attempts) {
+    uint8_t destination_mac[6]; int status;
+    status = ne2k_arp_resolve(device, io, cache, request_frame, request_capacity,
+                              rx_frame, rx_capacity, device ? device->mac : 0,
+                              local_ipv4, target_ipv4, attempts);
+    if (status != 0) return status;
+    if (net_arp_cache_lookup(cache, target_ipv4, destination_mac) != 0) return -6;
+    return ne2k_tx_udp(device, io, tx_frame, tx_capacity, destination_mac,
+                       local_ipv4, target_ipv4, source_port, destination_port,
+                       payload, payload_length);
+}
+
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io) {
     if (!device || !io || !io->inb || !io->outb || device->base_port == 0U)
         return -1;

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -82,6 +82,23 @@ int ne2k_tx_udp(ne2k_device_t* device, const ne2k_io_t* io,
                 const uint8_t source_ipv4[4], const uint8_t destination_ipv4[4],
                 uint16_t source_port, uint16_t destination_port,
                 const uint8_t* payload, uint16_t payload_length);
+/* Résout une IPv4 par ARP avec nombre d’essais borné et cache caller-owned. */
+int ne2k_arp_resolve(ne2k_device_t* device, const ne2k_io_t* io,
+                     net_arp_cache_t* cache,
+                     uint8_t* request_frame, uint16_t request_capacity,
+                     uint8_t* rx_frame, uint16_t rx_capacity,
+                     const uint8_t local_mac[6], const uint8_t local_ipv4[4],
+                     const uint8_t target_ipv4[4], uint16_t attempts);
+/* Résout la MAC puis construit et émet un paquet IPv4/UDP. */
+int ne2k_tx_udp_resolve(ne2k_device_t* device, const ne2k_io_t* io,
+                        net_arp_cache_t* cache,
+                        uint8_t* request_frame, uint16_t request_capacity,
+                        uint8_t* rx_frame, uint16_t rx_capacity,
+                        uint8_t* tx_frame, uint16_t tx_capacity,
+                        const uint8_t local_ipv4[4], const uint8_t target_ipv4[4],
+                        uint16_t source_port, uint16_t destination_port,
+                        const uint8_t* payload, uint16_t payload_length,
+                        uint16_t attempts);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -80,7 +80,15 @@ void test_probe_and_prepare_use_injected_io(void) {
       uint8_t local_mac[6] = {0x02, 0, 0, 0, 0, 1};
       uint8_t local_ip[4] = {10, 0, 2, 15};
       TEST_ASSERT_EQUAL(1, ne2k_arp_service(&device, &io, rx_frame, sizeof(rx_frame),
-                                             tx_frame, sizeof(tx_frame), local_mac, local_ip)); }
+                                             tx_frame, sizeof(tx_frame), local_mac, local_ip));
+      { net_arp_cache_t cache; uint8_t target_ip[4] = {10, 0, 2, 2};
+        uint8_t target_mac[6] = {0x52, 0x54, 0, 0, 0, 2};
+        TEST_ASSERT_EQUAL(0, net_arp_cache_init(&cache));
+        TEST_ASSERT_EQUAL(0, net_arp_cache_put(&cache, target_ip, target_mac));
+        TEST_ASSERT_EQUAL(0, ne2k_arp_resolve(&device, &io, &cache, rx_frame, sizeof(rx_frame),
+                                              tx_frame, sizeof(tx_frame), local_mac, local_ip,
+                                              target_ip, 2)); }
+    }
 }
 
 void test_rx_extract_publishes_bounded_frame(void) {


### PR DESCRIPTION
## Résumé

Ajoute `ne2k_arp_resolve` avec cache-hit, émission de requête ARP, polling RX borné et alimentation du cache. Ajoute `ne2k_tx_udp_resolve` pour utiliser automatiquement la MAC résolue avant l'émission IPv4/UDP.

## Validation

- `make test-all`: 294/294 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-143.

La preuve d'un échange ARP réel avec la NIC QEMU, DHCP, DNS, TCP, TLS et HTTP/OpenAI reste explicitement hors périmètre.