### PR TITLE
Lot 144: DHCP Discover via NE2000

### DIFF
--- a/docs/aos144_dhcp_discover_transport.md
+++ b/docs/aos144_dhcp_discover_transport.md
@@ -1,0 +1,17 @@
+# AOS-144 — DHCP Discover sur le transport NE2000
+
+Le lot AOS-144 raccorde `net_dhcp_build_discover` au transport Ethernet/IPv4/UDP du pilote NE2000. `ne2k_dhcp_discover` construit une requête DHCP Discover avec la MAC locale, l’embarque dans un paquet UDP source port 68 vers port 67, utilise les adresses IPv4 0.0.0.0 et 255.255.255.255, puis diffuse la trame Ethernet via la MAC broadcast.
+
+Le chemin reste entièrement caller-owned. Le payload DHCP est construit directement après les en-têtes IPv4/UDP afin d’éviter tout chevauchement entre la zone source et la zone destination du constructeur UDP. La capacité minimale est vérifiée avant écriture et le TX NE2000 conserve son padding Ethernet et ses limites existantes.
+
+| Élément | État AOS-144 |
+|---|---|
+| DHCP Discover caller-owned | Implémenté. |
+| Diffusion Ethernet/IP/UDP | Implémentée. |
+| Ports DHCP 68 → 67 | Implémentés. |
+| Parsing d’offre DHCP | Codec existant validé séparément. |
+| Réception d’offre via NIC et état de bail | Prochain sous-lot. |
+| Configuration IPv4 effective dans le noyau | Non déclarée. |
+| DNS, TCP, TLS, HTTP/OpenAI | Toujours non déclarés fonctionnels sur le transport matériel. |
+
+La validation locale atteint **294 tests verts**, avec build i386 réussi. Les smokes QEMU de boot et de détection NE2000 restent nécessaires avant publication.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -93,6 +93,28 @@ int ne2k_tx_udp_resolve(ne2k_device_t* device, const ne2k_io_t* io,
                        payload, payload_length);
 }
 
+int ne2k_dhcp_discover(ne2k_device_t* device, const ne2k_io_t* io,
+                       uint8_t* frame, uint16_t frame_capacity, uint32_t xid) {
+    static const uint8_t broadcast_mac[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    static const uint8_t zero_ip[4] = {0, 0, 0, 0};
+    static const uint8_t broadcast_ip[4] = {255, 255, 255, 255};
+    int payload_length;
+    if (!device || !io || !frame ||
+        frame_capacity < NET_ETHERNET_HEADER_SIZE + NET_IPV4_HEADER_SIZE +
+                          NET_UDP_HEADER_SIZE + 244U)
+        return -1;
+    payload_length = net_dhcp_build_discover(frame + NET_ETHERNET_HEADER_SIZE +
+                                              NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE,
+                                              frame_capacity - NET_ETHERNET_HEADER_SIZE -
+                                              NET_IPV4_HEADER_SIZE - NET_UDP_HEADER_SIZE,
+                                              xid, device->mac);
+    if (payload_length < 0) return -2;
+    return ne2k_tx_udp(device, io, frame, frame_capacity, broadcast_mac,
+                       zero_ip, broadcast_ip, 68U, 67U,
+                       frame + NET_ETHERNET_HEADER_SIZE + NET_IPV4_HEADER_SIZE +
+                       NET_UDP_HEADER_SIZE, (uint16_t)payload_length);
+}
+
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io) {
     if (!device || !io || !io->inb || !io->outb || device->base_port == 0U)
         return -1;

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -5,6 +5,7 @@
 #include "net_nic.h"
 #include "net_ethernet_arp.h"
 #include "net_ipv4_udp.h"
+#include "net_dhcp.h"
 
 #define NE2K_REG_COMMAND 0x00U
 #define NE2K_REG_RESET   0x1fU
@@ -99,6 +100,9 @@ int ne2k_tx_udp_resolve(ne2k_device_t* device, const ne2k_io_t* io,
                         uint16_t source_port, uint16_t destination_port,
                         const uint8_t* payload, uint16_t payload_length,
                         uint16_t attempts);
+/* Construit et diffuse un DHCP Discover dans un buffer Ethernet caller-owned. */
+int ne2k_dhcp_discover(ne2k_device_t* device, const ne2k_io_t* io,
+                       uint8_t* frame, uint16_t frame_capacity, uint32_t xid);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -149,9 +149,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dhcp: $(UNIT_DIR)/kernel/test_net_dhcp.
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -146,6 +146,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/net_nic.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_ethernet_arp.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_ipv4_udp.c"
+        extra_src="$extra_src $BASE_DIR/kernel/net_dhcp.c"
     fi
     if [ "$(basename "$test_file")" = "test_pci.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/pci.c"

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -70,6 +70,10 @@ void test_probe_and_prepare_use_injected_io(void) {
                                        source_ip, destination_ip, 4000, 4001, payload, sizeof(payload)));
       TEST_ASSERT_EQUAL(0x52, frame[0]); TEST_ASSERT_EQUAL(0x08, frame[12]);
       TEST_ASSERT_EQUAL(0x00, frame[13]); }
+    { uint8_t frame[300] = {0}; fake.isr = NE2K_ISR_RDC;
+      TEST_ASSERT_EQUAL(0, ne2k_dhcp_discover(&device, &io, frame, sizeof(frame), 0x12345678U));
+      TEST_ASSERT_EQUAL(0xff, frame[0]); TEST_ASSERT_EQUAL(0x08, frame[12]);
+      TEST_ASSERT_EQUAL(0x63, frame[42U + 236U]); TEST_ASSERT_EQUAL(0x82, frame[43U + 236U]); }
     fake.isr = NE2K_ISR_RDC; TEST_ASSERT_EQUAL(0, ne2k_irq_attach(&device, &io));
     TEST_ASSERT_EQUAL(0, ne2k_irq_count()); ne2k_irq_service();
     TEST_ASSERT_EQUAL(1, ne2k_irq_count());


### PR DESCRIPTION
## Résumé

Ajoute `ne2k_dhcp_discover` pour construire et diffuser un DHCP Discover dans une trame Ethernet/IPv4/UDP caller-owned via NE2000. Corrige également le chevauchement entre payload DHCP et construction UDP.

## Validation

- `make test-all`: 294/294 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-144.

La réception d'offre via la NIC et l'application d'un bail IPv4 restent explicitement hors périmètre.