### PR TITLE
Lot 145: offre DHCP et bail caller-owned

### DIFF
--- a/docs/aos145_dhcp_offer_lease.md
+++ b/docs/aos145_dhcp_offer_lease.md
@@ -1,0 +1,17 @@
+# AOS-145 — Offre DHCP reçue et état de bail caller-owned
+
+Le lot AOS-145 ajoute `ne2k_dhcp_poll_offer`. Cette primitive effectue un polling RX borné, réutilise le parseur IPv4/UDP, filtre les datagrammes UDP source 67 vers destination 68, puis valide le XID et les options DHCP avant de publier une `net_dhcp_offer_t` caller-owned.
+
+Un état `net_dhcp_lease_t` fixe permet ensuite d’appliquer ou d’effacer l’offre sans allocation. L’application copie l’adresse IPv4 proposée, l’adresse du serveur et le XID, puis publie le champ `valid`. Cette structure reste fournie et détenue par l’appelant ; aucune configuration globale de l’interface n’est modifiée automatiquement dans ce lot.
+
+| Élément | État AOS-145 |
+|---|---|
+| Réception d’offre via RX NE2000 | Implémentée par polling borné. |
+| Filtrage UDP DHCP 67 → 68 | Implémenté. |
+| Validation XID et options | Réutilise `net_dhcp_parse_offer`. |
+| État IPv4 caller-owned | Implémenté par `net_dhcp_lease_t`. |
+| Application globale du bail au noyau | Non déclarée. |
+| DHCP REQUEST/ACK et renouvellement | Prochains lots. |
+| DNS sur transport matériel | Prochain groupe. |
+
+La validation locale reste à **294 tests verts**, avec build i386 réussi. Les smokes QEMU existants valident le boot et la détection NE2000, mais n’injectent pas encore une offre DHCP réelle.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -115,6 +115,26 @@ int ne2k_dhcp_discover(ne2k_device_t* device, const ne2k_io_t* io,
                        NET_UDP_HEADER_SIZE, (uint16_t)payload_length);
 }
 
+int ne2k_dhcp_poll_offer(ne2k_device_t* device, const ne2k_io_t* io,
+                         uint8_t* frame, uint16_t frame_capacity,
+                         uint32_t expected_xid, uint16_t attempts,
+                         net_dhcp_offer_t* offer) {
+    uint16_t frame_length, i; net_udp_view_t udp; int status;
+    if (!device || !io || !frame || !offer || attempts == 0U) return -1;
+    for (i = 0; i < attempts; ++i) {
+        status = ne2k_rx_poll_udp(device, io, frame, frame_capacity,
+                                  &frame_length, &udp);
+        if (status == 1) continue;
+        if (status != 0) continue;
+        if (udp.source_port != 67U || udp.destination_port != 68U ||
+            udp.payload_length < 244U) continue;
+        status = net_dhcp_parse_offer(udp.payload, udp.payload_length,
+                                      expected_xid, offer);
+        if (status == 0) return 0;
+    }
+    return -2;
+}
+
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io) {
     if (!device || !io || !io->inb || !io->outb || device->base_port == 0U)
         return -1;

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -103,6 +103,11 @@ int ne2k_tx_udp_resolve(ne2k_device_t* device, const ne2k_io_t* io,
 /* Construit et diffuse un DHCP Discover dans un buffer Ethernet caller-owned. */
 int ne2k_dhcp_discover(ne2k_device_t* device, const ne2k_io_t* io,
                        uint8_t* frame, uint16_t frame_capacity, uint32_t xid);
+/* Polling RX borné d’une offre DHCP via UDP 67->68. */
+int ne2k_dhcp_poll_offer(ne2k_device_t* device, const ne2k_io_t* io,
+                         uint8_t* frame, uint16_t frame_capacity,
+                         uint32_t expected_xid, uint16_t attempts,
+                         net_dhcp_offer_t* offer);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/kernel/net_dhcp.c
+++ b/kernel/net_dhcp.c
@@ -56,3 +56,18 @@ int net_dhcp_parse_offer(const uint8_t* packet, uint32_t length,
     out->message_type = type;
     return 0;
 }
+int net_dhcp_lease_apply(net_dhcp_lease_t* lease, const net_dhcp_offer_t* offer) {
+    uint32_t i;
+    if (!lease || !offer || offer->message_type != NET_DHCP_OFFER) return -1;
+    for (i = 0; i < 4U; ++i) {
+        lease->ipv4[i] = offer->offered_ip[i];
+        lease->server_ipv4[i] = offer->server_ip[i];
+    }
+    lease->xid = offer->xid;
+    lease->valid = 1U;
+    return 0;
+}
+void net_dhcp_lease_clear(net_dhcp_lease_t* lease) {
+    if (!lease) return;
+    lease->valid = 0U;
+}

--- a/kernel/net_dhcp.h
+++ b/kernel/net_dhcp.h
@@ -18,10 +18,18 @@ typedef struct {
     uint8_t server_ip[4];
     uint8_t message_type;
 } net_dhcp_offer_t;
+typedef struct {
+    uint8_t valid;
+    uint8_t ipv4[4];
+    uint8_t server_ipv4[4];
+    uint32_t xid;
+} net_dhcp_lease_t;
 
 int net_dhcp_build_discover(uint8_t* packet, uint32_t capacity,
                             uint32_t xid, const uint8_t mac[6]);
 int net_dhcp_parse_offer(const uint8_t* packet, uint32_t length,
                          uint32_t expected_xid, net_dhcp_offer_t* out);
+int net_dhcp_lease_apply(net_dhcp_lease_t* lease, const net_dhcp_offer_t* offer);
+void net_dhcp_lease_clear(net_dhcp_lease_t* lease);
 
 #endif

--- a/tests/unit/kernel/test_net_dhcp.c
+++ b/tests/unit/kernel/test_net_dhcp.c
@@ -20,6 +20,11 @@ void test_build_and_parse_dhcp_offer(void) {
     TEST_ASSERT_EQUAL(0, net_dhcp_parse_offer(packet, 250, 0x12345678U, &offer));
     TEST_ASSERT_EQUAL(10, offer.offered_ip[0]);
     TEST_ASSERT_EQUAL(2, offer.server_ip[3]);
+    { net_dhcp_lease_t lease = {0};
+      TEST_ASSERT_EQUAL(0, net_dhcp_lease_apply(&lease, &offer));
+      TEST_ASSERT_EQUAL(1, lease.valid); TEST_ASSERT_EQUAL(10, lease.ipv4[0]);
+      TEST_ASSERT_EQUAL(2, lease.server_ipv4[3]);
+      net_dhcp_lease_clear(&lease); TEST_ASSERT_EQUAL(0, lease.valid); }
     TEST_ASSERT_NOT_EQUAL(0, net_dhcp_parse_offer(packet, 250, 0x87654321U, &offer));
 }
 


### PR DESCRIPTION
## Résumé

Ajoute le polling borné d'une offre DHCP via RX UDP NE2000, le filtrage UDP 67->68 et l'application caller-owned d'un état de bail IPv4.

## Validation

- `make test-all`: 294/294 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-145.

L'injection d'une offre DHCP réelle et l'application globale du bail restent explicitement hors périmètre.