### PR TITLE
Lot 146: DHCP REQUEST/ACK et DNS UDP

### DIFF
--- a/docs/aos146_dhcp_request_dns_transport.md
+++ b/docs/aos146_dhcp_request_dns_transport.md
@@ -1,0 +1,18 @@
+# AOS-146 — DHCP REQUEST/ACK et DNS sur UDP
+
+Le lot AOS-146 complète le chemin DHCP avec la construction d’un DHCP REQUEST et le parsing borné d’un DHCP ACK. La requête reprend le XID, la MAC locale, l’adresse IPv4 proposée et l’identifiant du serveur. L’ACK est accepté uniquement si le message, le XID, le cookie et l’option serveur sont cohérents ; l’adresse offerte est alors copiée dans un bail caller-owned.
+
+Le même lot ajoute `ne2k_dns_query` et `ne2k_dns_poll_a`. La requête DNS A est construite dans un buffer caller-owned, émise en UDP vers le port 53 après résolution ARP, puis les réponses reçues sont filtrées sur les ports 53 vers 49152 et transmises au parseur DNS existant. Le nombre d’essais RX reste borné.
+
+| Élément | État AOS-146 |
+|---|---|
+| DHCP REQUEST caller-owned | Implémenté. |
+| Parsing DHCP ACK | Implémenté et borné. |
+| Requête DNS A sur UDP | Implémentée. |
+| Résolution ARP avant DNS | Réutilisée via `ne2k_tx_udp_resolve`. |
+| Parsing DNS A RX | Implémenté via polling borné. |
+| DHCP réel injecté sous QEMU | Non couvert par les smokes actuels. |
+| Résolution DNS réelle | Non déclarée fonctionnelle avant smoke d’injection. |
+| TCP, TLS, HTTP et OpenAI | Toujours non déclarés fonctionnels sur le transport matériel. |
+
+La validation locale reste à **294 tests verts**, avec build i386 réussi.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -115,6 +115,58 @@ int ne2k_dhcp_discover(ne2k_device_t* device, const ne2k_io_t* io,
                        NET_UDP_HEADER_SIZE, (uint16_t)payload_length);
 }
 
+int ne2k_dhcp_request(ne2k_device_t* device, const ne2k_io_t* io,
+                      uint8_t* frame, uint16_t frame_capacity,
+                      uint32_t xid, const uint8_t requested_ip[4],
+                      const uint8_t server_ip[4]) {
+    static const uint8_t broadcast_mac[6] = {0xff,0xff,0xff,0xff,0xff,0xff};
+    static const uint8_t zero_ip[4] = {0,0,0,0};
+    static const uint8_t broadcast_ip[4] = {255,255,255,255};
+    int payload_length;
+    if (!device || !io || !frame || !requested_ip || !server_ip ||
+        frame_capacity < NET_ETHERNET_HEADER_SIZE + NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE + 255U)
+        return -1;
+    payload_length = net_dhcp_build_request(frame + NET_ETHERNET_HEADER_SIZE + NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE,
+        frame_capacity - NET_ETHERNET_HEADER_SIZE - NET_IPV4_HEADER_SIZE - NET_UDP_HEADER_SIZE,
+        xid, device->mac, requested_ip, server_ip);
+    if (payload_length < 0) return -2;
+    return ne2k_tx_udp(device, io, frame, frame_capacity, broadcast_mac, zero_ip, broadcast_ip,
+                       68U, 67U, frame + NET_ETHERNET_HEADER_SIZE + NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE,
+                       (uint16_t)payload_length);
+}
+
+int ne2k_dns_query(ne2k_device_t* device, const ne2k_io_t* io,
+                   net_arp_cache_t* cache, uint8_t* arp_request, uint16_t arp_request_capacity,
+                   uint8_t* arp_rx, uint16_t arp_rx_capacity, uint8_t* frame, uint16_t frame_capacity,
+                   const uint8_t local_ip[4], const uint8_t dns_ip[4], uint16_t id,
+                   const char* hostname) {
+    int payload_length;
+    if (!device || !io || !cache || !arp_request || !arp_rx || !frame || !local_ip || !dns_ip || !hostname ||
+        frame_capacity < NET_ETHERNET_HEADER_SIZE + NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE + 12U)
+        return -1;
+    payload_length = net_dns_build_a_query(frame + NET_ETHERNET_HEADER_SIZE + NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE,
+        frame_capacity - NET_ETHERNET_HEADER_SIZE - NET_IPV4_HEADER_SIZE - NET_UDP_HEADER_SIZE, id, hostname);
+    if (payload_length < 0) return -2;
+    return ne2k_tx_udp_resolve(device, io, cache, arp_request, arp_request_capacity, arp_rx, arp_rx_capacity,
+        frame, frame_capacity, local_ip, dns_ip, 49152U, 53U,
+        frame + NET_ETHERNET_HEADER_SIZE + NET_IPV4_HEADER_SIZE + NET_UDP_HEADER_SIZE,
+        (uint16_t)payload_length, 8U);
+}
+
+int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,
+                    uint8_t* frame, uint16_t frame_capacity, uint16_t attempts,
+                    uint16_t expected_id, net_dns_a_result_t* result) {
+    uint16_t frame_length, i; net_udp_view_t udp; int status;
+    if (!device || !io || !frame || !result || attempts == 0U) return -1;
+    for (i = 0; i < attempts; ++i) {
+        status = ne2k_rx_poll_udp(device, io, frame, frame_capacity, &frame_length, &udp);
+        if (status != 0) continue;
+        if (udp.source_port != 53U || udp.destination_port != 49152U) continue;
+        if (net_dns_parse_a_response(udp.payload, udp.payload_length, expected_id, result) == 0) return 0;
+    }
+    return -2;
+}
+
 int ne2k_dhcp_poll_offer(ne2k_device_t* device, const ne2k_io_t* io,
                          uint8_t* frame, uint16_t frame_capacity,
                          uint32_t expected_xid, uint16_t attempts,

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -6,6 +6,7 @@
 #include "net_ethernet_arp.h"
 #include "net_ipv4_udp.h"
 #include "net_dhcp.h"
+#include "net_dns.h"
 
 #define NE2K_REG_COMMAND 0x00U
 #define NE2K_REG_RESET   0x1fU
@@ -108,6 +109,18 @@ int ne2k_dhcp_poll_offer(ne2k_device_t* device, const ne2k_io_t* io,
                          uint8_t* frame, uint16_t frame_capacity,
                          uint32_t expected_xid, uint16_t attempts,
                          net_dhcp_offer_t* offer);
+int ne2k_dhcp_request(ne2k_device_t* device, const ne2k_io_t* io,
+                      uint8_t* frame, uint16_t frame_capacity,
+                      uint32_t xid, const uint8_t requested_ip[4],
+                      const uint8_t server_ip[4]);
+int ne2k_dns_query(ne2k_device_t* device, const ne2k_io_t* io,
+                   net_arp_cache_t* cache, uint8_t* arp_request, uint16_t arp_request_capacity,
+                   uint8_t* arp_rx, uint16_t arp_rx_capacity, uint8_t* frame, uint16_t frame_capacity,
+                   const uint8_t local_ip[4], const uint8_t dns_ip[4], uint16_t id,
+                   const char* hostname);
+int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,
+                    uint8_t* frame, uint16_t frame_capacity, uint16_t attempts,
+                    uint16_t expected_id, net_dns_a_result_t* result);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/kernel/net_dhcp.c
+++ b/kernel/net_dhcp.c
@@ -26,6 +26,20 @@ int net_dhcp_build_discover(uint8_t* packet, uint32_t capacity,
     return 244;
 }
 
+int net_dhcp_build_request(uint8_t* packet, uint32_t capacity,
+                           uint32_t xid, const uint8_t mac[6],
+                           const uint8_t requested_ip[4], const uint8_t server_ip[4]) {
+    uint32_t i;
+    if (!packet || !mac || !requested_ip || !server_ip || capacity < 252U) return -1;
+    for (i = 0; i < 252U; ++i) packet[i] = 0U;
+    packet[0] = 1U; packet[1] = 1U; packet[2] = 6U; put_be32(packet + 4, xid);
+    copy_bytes(packet + 28, mac, 6U); put_be32(packet + 236, NET_DHCP_MAGIC_COOKIE);
+    packet[240] = NET_DHCP_OPTION_MESSAGE_TYPE; packet[241] = 1U; packet[242] = NET_DHCP_REQUEST;
+    packet[243] = NET_DHCP_OPTION_SERVER_ID; packet[244] = 4U; copy_bytes(packet + 245, server_ip, 4U);
+    packet[249] = 50U; packet[250] = 4U; copy_bytes(packet + 251, requested_ip, 4U);
+    return 255;
+}
+
 int net_dhcp_parse_offer(const uint8_t* packet, uint32_t length,
                          uint32_t expected_xid, net_dhcp_offer_t* out) {
     uint32_t pos;
@@ -70,4 +84,24 @@ int net_dhcp_lease_apply(net_dhcp_lease_t* lease, const net_dhcp_offer_t* offer)
 void net_dhcp_lease_clear(net_dhcp_lease_t* lease) {
     if (!lease) return;
     lease->valid = 0U;
+}
+int net_dhcp_parse_ack(const uint8_t* packet, uint32_t length,
+                       uint32_t expected_xid, net_dhcp_lease_t* lease) {
+    uint32_t pos; uint8_t type = 0U; uint8_t server_seen = 0U;
+    if (!packet || !lease || length < 244U || packet[0] != 2U ||
+        get_be32(packet + 4) != expected_xid || get_be32(packet + 236) != NET_DHCP_MAGIC_COOKIE)
+        return -1;
+    for (pos = 240U; pos < length;) {
+        uint8_t code = packet[pos++], size;
+        if (code == NET_DHCP_OPTION_END) break;
+        if (code == 0U) continue;
+        if (pos >= length) return -2;
+        size = packet[pos++]; if (pos + size > length) return -2;
+        if (code == NET_DHCP_OPTION_MESSAGE_TYPE && size == 1U) type = packet[pos];
+        if (code == NET_DHCP_OPTION_SERVER_ID && size == 4U) { copy_bytes(lease->server_ipv4, packet + pos, 4U); server_seen = 1U; }
+        pos += size;
+    }
+    if (type != NET_DHCP_ACK || !server_seen) return -3;
+    copy_bytes(lease->ipv4, packet + 16, 4U); lease->xid = expected_xid; lease->valid = 1U;
+    return 0;
 }

--- a/kernel/net_dhcp.h
+++ b/kernel/net_dhcp.h
@@ -11,6 +11,8 @@
 #define NET_DHCP_OPTION_END 255U
 #define NET_DHCP_DISCOVER 1U
 #define NET_DHCP_OFFER 2U
+#define NET_DHCP_REQUEST 3U
+#define NET_DHCP_ACK 5U
 
 typedef struct {
     uint32_t xid;
@@ -27,9 +29,14 @@ typedef struct {
 
 int net_dhcp_build_discover(uint8_t* packet, uint32_t capacity,
                             uint32_t xid, const uint8_t mac[6]);
+int net_dhcp_build_request(uint8_t* packet, uint32_t capacity,
+                           uint32_t xid, const uint8_t mac[6],
+                           const uint8_t requested_ip[4], const uint8_t server_ip[4]);
 int net_dhcp_parse_offer(const uint8_t* packet, uint32_t length,
                          uint32_t expected_xid, net_dhcp_offer_t* out);
 int net_dhcp_lease_apply(net_dhcp_lease_t* lease, const net_dhcp_offer_t* offer);
 void net_dhcp_lease_clear(net_dhcp_lease_t* lease);
+int net_dhcp_parse_ack(const uint8_t* packet, uint32_t length,
+                       uint32_t expected_xid, net_dhcp_lease_t* lease);
 
 #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -149,9 +149,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dhcp: $(UNIT_DIR)/kernel/test_net_dhcp.
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -147,6 +147,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/net_ethernet_arp.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_ipv4_udp.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_dhcp.c"
+        extra_src="$extra_src $BASE_DIR/kernel/net_dns.c"
     fi
     if [ "$(basename "$test_file")" = "test_pci.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/pci.c"

--- a/tests/unit/kernel/test_net_dhcp.c
+++ b/tests/unit/kernel/test_net_dhcp.c
@@ -26,6 +26,14 @@ void test_build_and_parse_dhcp_offer(void) {
       TEST_ASSERT_EQUAL(2, lease.server_ipv4[3]);
       net_dhcp_lease_clear(&lease); TEST_ASSERT_EQUAL(0, lease.valid); }
     TEST_ASSERT_NOT_EQUAL(0, net_dhcp_parse_offer(packet, 250, 0x87654321U, &offer));
+    { uint8_t request[260] = {0}; uint8_t requested[4] = {10,0,2,15}; uint8_t server[4] = {10,0,2,2};
+      net_dhcp_lease_t ack = {0};
+      TEST_ASSERT_EQUAL(255, net_dhcp_build_request(request, sizeof(request), 0x12345678U, mac, requested, server));
+      TEST_ASSERT_EQUAL(NET_DHCP_REQUEST, request[242]);
+      request[0] = 2; request[16] = 10; request[17] = 0; request[18] = 2; request[19] = 15;
+      request[242] = NET_DHCP_ACK;
+      TEST_ASSERT_EQUAL(0, net_dhcp_parse_ack(request, 255, 0x12345678U, &ack));
+      TEST_ASSERT_EQUAL(1, ack.valid); TEST_ASSERT_EQUAL(10, ack.ipv4[0]); }
 }
 
 int main(void) {


### PR DESCRIPTION
## Résumé

Ajoute DHCP REQUEST/ACK caller-owned, requête DNS A sur UDP après résolution ARP et polling borné des réponses DNS. Corrige les dépendances DNS des runners de tests.

## Validation

- `make test-all`: 294/294 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-146.

Les échanges DHCP/DNS réels injectés sous QEMU ne sont pas encore couverts par un smoke dédié.