### PR TITLE
Lot 147: SYN TCP IPv4 via NE2000

### DIFF
--- a/docs/aos147_tcp_syn_transport.md
+++ b/docs/aos147_tcp_syn_transport.md
@@ -1,0 +1,17 @@
+# AOS-147 — SYN TCP IPv4 sur NE2000
+
+Le lot AOS-147 ajoute la construction d’un segment SYN TCP encapsulé dans IPv4. Le paquet est écrit dans un buffer caller-owned, avec ports, numéro de séquence, TTL et protocole TCP explicitement définis. Le checksum TCP inclut le pseudo-en-tête IPv4 ; le checksum IPv4 est ensuite calculé sur l’en-tête construit.
+
+`ne2k_tcp_syn` réutilise le cache ARP caller-owned et le chemin de résolution borné. Lorsque la MAC distante est connue, il construit l’en-tête Ethernet et soumet la trame par TX PIO NE2000. Le lot ne conserve aucun buffer ni état global de connexion.
+
+| Élément | État AOS-147 |
+|---|---|
+| Construction SYN IPv4 | Implémentée. |
+| Checksum TCP pseudo-en-tête | Implémenté. |
+| Émission Ethernet NE2000 | Implémentée avec cache ARP. |
+| Handshake SYN/SYN-ACK/ACK | Non implémenté. |
+| État de connexion TCP persistant | Non implémenté. |
+| Retransmission et temporisation | Non implémentées. |
+| TLS, HTTP et OpenAI | Toujours non déclarés fonctionnels sur le transport matériel. |
+
+La validation locale reste à **294 tests verts**, avec build i386 réussi. Les smokes QEMU existants valident le boot et la détection NE2000, mais n’injectent pas encore de SYN distant.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -153,6 +153,24 @@ int ne2k_dns_query(ne2k_device_t* device, const ne2k_io_t* io,
         (uint16_t)payload_length, 8U);
 }
 
+int ne2k_tcp_syn(ne2k_device_t* device, const ne2k_io_t* io,
+                 net_arp_cache_t* cache, uint8_t* arp_request, uint16_t arp_request_capacity,
+                 uint8_t* arp_rx, uint16_t arp_rx_capacity, uint8_t* frame, uint16_t frame_capacity,
+                 const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                 uint16_t local_port, uint16_t remote_port, uint32_t sequence) {
+    int tcp_length;
+    if (!device || !io || !cache || !arp_request || !arp_rx || !frame || !local_ip || !remote_ip ||
+        frame_capacity < NET_ETHERNET_HEADER_SIZE + 40U) return -1;
+    tcp_length = net_tcp_build_syn_ipv4(frame + NET_ETHERNET_HEADER_SIZE,
+        frame_capacity - NET_ETHERNET_HEADER_SIZE, local_ip, remote_ip, local_port, remote_port, sequence);
+    if (tcp_length < 0) return -2;
+    { uint8_t destination_mac[6]; uint16_t i;
+      if (net_arp_cache_lookup(cache, remote_ip, destination_mac) != 0) return -3;
+      for (i = 0; i < 6U; ++i) { frame[i] = destination_mac[i]; frame[6U+i] = device->mac[i]; }
+      frame[12] = 0x08U; frame[13] = 0x00U;
+      return ne2k_tx_submit(device, io, frame, (uint16_t)(NET_ETHERNET_HEADER_SIZE + tcp_length)); }
+}
+
 int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,
                     uint8_t* frame, uint16_t frame_capacity, uint16_t attempts,
                     uint16_t expected_id, net_dns_a_result_t* result) {

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -7,6 +7,7 @@
 #include "net_ipv4_udp.h"
 #include "net_dhcp.h"
 #include "net_dns.h"
+#include "net_tcp.h"
 
 #define NE2K_REG_COMMAND 0x00U
 #define NE2K_REG_RESET   0x1fU
@@ -121,6 +122,11 @@ int ne2k_dns_query(ne2k_device_t* device, const ne2k_io_t* io,
 int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,
                     uint8_t* frame, uint16_t frame_capacity, uint16_t attempts,
                     uint16_t expected_id, net_dns_a_result_t* result);
+int ne2k_tcp_syn(ne2k_device_t* device, const ne2k_io_t* io,
+                 net_arp_cache_t* cache, uint8_t* arp_request, uint16_t arp_request_capacity,
+                 uint8_t* arp_rx, uint16_t arp_rx_capacity, uint8_t* frame, uint16_t frame_capacity,
+                 const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                 uint16_t local_port, uint16_t remote_port, uint32_t sequence);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -36,6 +36,23 @@ uint16_t net_tcp_checksum_ipv4(const uint8_t source_ip[4], const uint8_t destina
     return (uint16_t)~sum;
 }
 
+int net_tcp_build_syn_ipv4(uint8_t* packet, uint32_t capacity,
+                           const uint8_t source_ip[4], const uint8_t destination_ip[4],
+                           uint16_t source_port, uint16_t destination_port,
+                           uint32_t sequence) {
+    uint16_t i, checksum; uint32_t sum = 0U;
+    if (!packet || !source_ip || !destination_ip || capacity < 40U) return -1;
+    for (i = 0; i < 40U; ++i) packet[i] = 0U;
+    packet[0] = 0x45U; put16(packet + 2, 40U); packet[8] = 64U; packet[9] = NET_TCP_PROTOCOL;
+    for (i = 0; i < 4U; ++i) { packet[12U+i] = source_ip[i]; packet[16U+i] = destination_ip[i]; }
+    if (net_tcp_build_syn(packet + 20U, capacity - 20U, source_port, destination_port, sequence) < 0) return -2;
+    checksum = net_tcp_checksum_ipv4(source_ip, destination_ip, packet + 20U, 20U);
+    put16(packet + 36U, checksum);
+    for (i = 0; i < 20U; i += 2U) { sum += get16(packet + i); while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16); }
+    put16(packet + 10U, (uint16_t)~sum);
+    return 40;
+}
+
 int net_tcp_parse(const uint8_t* segment, uint32_t length, net_tcp_view_t* out) {
     uint8_t header_words;
     uint16_t header_size;

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -28,5 +28,9 @@ int net_tcp_parse(const uint8_t* segment, uint32_t length,
 /* Calcule le checksum TCP IPv4 sur le segment caller-owned. */
 uint16_t net_tcp_checksum_ipv4(const uint8_t source_ip[4], const uint8_t destination_ip[4],
                                const uint8_t* segment, uint16_t length);
+int net_tcp_build_syn_ipv4(uint8_t* packet, uint32_t capacity,
+                           const uint8_t source_ip[4], const uint8_t destination_ip[4],
+                           uint16_t source_port, uint16_t destination_port,
+                           uint32_t sequence);
 
 #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -149,9 +149,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dhcp: $(UNIT_DIR)/kernel/test_net_dhcp.
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -148,6 +148,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/net_ipv4_udp.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_dhcp.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_dns.c"
+        extra_src="$extra_src $BASE_DIR/kernel/net_tcp.c"
     fi
     if [ "$(basename "$test_file")" = "test_pci.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/pci.c"

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -16,6 +16,10 @@ void test_build_and_parse_syn_ack(void) {
     { uint8_t source[4] = {10,0,2,15}; uint8_t destination[4] = {10,0,2,2}; uint16_t checksum = net_tcp_checksum_ipv4(source, destination, segment, 20); TEST_ASSERT_NOT_EQUAL(0, checksum); TEST_ASSERT_EQUAL(checksum, net_tcp_checksum_ipv4(source, destination, segment, 20)); }
     TEST_ASSERT_EQUAL(0x10203041U, view.acknowledgment);
     segment[0] = 0; segment[1] = 0; TEST_ASSERT_NOT_EQUAL(0, net_tcp_parse(segment, 20, &view));
+    { uint8_t packet[48] = {0}; uint8_t src[4] = {10,0,2,15}; uint8_t dst[4] = {10,0,2,2};
+      TEST_ASSERT_EQUAL(40, net_tcp_build_syn_ipv4(packet, sizeof(packet), src, dst, 49152, 443, 0x10203040U));
+      TEST_ASSERT_EQUAL(0x45, packet[0]); TEST_ASSERT_EQUAL(NET_TCP_PROTOCOL, packet[9]);
+      TEST_ASSERT_EQUAL(49152, (packet[20] << 8) | packet[21]); TEST_ASSERT_EQUAL(NET_TCP_FLAG_SYN, packet[33] & 0x3f); }
 }
 
 int main(void) {


### PR DESCRIPTION
## Résumé

Ajoute la construction SYN IPv4 caller-owned avec checksum TCP et l'émission Ethernet via le cache ARP/NE2000.

## Validation

- `make test-all`: 294/294 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi après rerun;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-147.

Le handshake TCP complet, les retransmissions, TLS, HTTP et OpenAI restent explicitement hors périmètre.