### PR TITLE
Lot 148: polling RX TCP caller-owned

### DIFF
--- a/docs/aos148_tcp_rx_poll.md
+++ b/docs/aos148_tcp_rx_poll.md
@@ -1,0 +1,17 @@
+# AOS-148 — Réception TCP caller-owned sur NE2000
+
+Le lot AOS-148 ajoute `ne2k_rx_poll_tcp`. La primitive lit une trame depuis la RAM distante NE2000, vérifie l’EtherType IPv4, valide la longueur de l’en-tête IPv4 et filtre le protocole TCP avant d’exposer une `net_tcp_view_t` directement dans le buffer caller-owned.
+
+Aucune copie de payload n’est réalisée et aucun état de connexion n’est conservé. Les codes distinguent l’absence de paquet, une trame non IPv4, un en-tête IPv4 invalide et un segment TCP mal formé.
+
+| Élément | État AOS-148 |
+|---|---|
+| Polling RX Ethernet/IPv4/TCP | Implémenté. |
+| Vue TCP caller-owned | Implémentée. |
+| Filtrage protocole TCP | Implémenté. |
+| Validation checksum TCP reçu | À ajouter dans un lot dédié. |
+| Validation SYN-ACK et état de connexion | À ajouter. |
+| ACK, retransmission et temporisation | Non implémentés. |
+| TLS, HTTP et OpenAI | Toujours non déclarés fonctionnels sur le transport matériel. |
+
+La validation locale reste à **294 tests verts**, avec build i386 réussi. Les smokes QEMU existants valident le boot et la détection NE2000, mais n’injectent pas encore de segment TCP réel.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -316,6 +316,25 @@ int ne2k_arp_service(ne2k_device_t* device, const ne2k_io_t* io,
     return ne2k_tx_submit(device, io, tx_frame, (uint16_t)status);
 }
 
+int ne2k_rx_poll_tcp(ne2k_device_t* device, const ne2k_io_t* io,
+                     uint8_t* frame, uint16_t frame_capacity,
+                     uint16_t* frame_length, net_tcp_view_t* tcp) {
+    net_ethernet_header_t ethernet; uint16_t ip_header_size; int status;
+    if (!tcp) return -1;
+    status = ne2k_rx_poll(device, io, frame, frame_capacity, frame_length);
+    if (status != 0) return status;
+    if (net_ethernet_parse(frame, *frame_length, &ethernet) != 0) return -2;
+    if (ethernet.ethertype != NET_ETHERTYPE_IPV4) return 2;
+    if (*frame_length < NET_ETHERNET_HEADER_SIZE + 20U) return -3;
+    ip_header_size = (uint16_t)(frame[NET_ETHERNET_HEADER_SIZE] & 0x0fU) * 4U;
+    if (ip_header_size < 20U || frame[NET_ETHERNET_HEADER_SIZE + 9U] != NET_TCP_PROTOCOL ||
+        *frame_length < NET_ETHERNET_HEADER_SIZE + ip_header_size) return -3;
+    if (net_tcp_parse(frame + NET_ETHERNET_HEADER_SIZE + ip_header_size,
+                      (uint32_t)(*frame_length - NET_ETHERNET_HEADER_SIZE - ip_header_size), tcp) != 0)
+        return -4;
+    return 0;
+}
+
 int ne2k_rx_poll_udp(ne2k_device_t* device, const ne2k_io_t* io,
                      uint8_t* frame, uint16_t frame_capacity,
                      uint16_t* frame_length, net_udp_view_t* udp) {

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -151,6 +151,10 @@ int ne2k_arp_service(ne2k_device_t* device, const ne2k_io_t* io,
 int ne2k_rx_poll_udp(ne2k_device_t* device, const ne2k_io_t* io,
                      uint8_t* frame, uint16_t frame_capacity,
                      uint16_t* frame_length, net_udp_view_t* udp);
+/* Lit une trame IPv4/TCP et expose une vue TCP dans le buffer caller-owned. */
+int ne2k_rx_poll_tcp(ne2k_device_t* device, const ne2k_io_t* io,
+                     uint8_t* frame, uint16_t frame_capacity,
+                     uint16_t* frame_length, net_tcp_view_t* tcp);
 /* Extrait une trame reçue depuis un buffer DMA caller-owned vers la file RX. */
 int ne2k_rx_extract(const uint8_t* dma_buffer, uint16_t dma_length,
                     net_nic_queue_t* rx_queue);


### PR DESCRIPTION
## Résumé

Ajoute `ne2k_rx_poll_tcp` pour lire et décoder les trames Ethernet/IPv4/TCP dans un buffer caller-owned, sans copie ni allocation.

## Validation

- `make test-all`: 294/294 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-148.

Le checksum TCP reçu, le handshake SYN-ACK/ACK et les retransmissions restent hors périmètre.