### PR TITLE
Lot 149: validation SYN-ACK caller-owned

### DIFF
--- a/docs/aos149_tcp_synack_validation.md
+++ b/docs/aos149_tcp_synack_validation.md
@@ -1,0 +1,17 @@
+# AOS-149 — Validation SYN-ACK caller-owned
+
+Le lot AOS-149 ajoute `net_tcp_is_syn_ack_for`. À partir d’une vue TCP caller-owned, la primitive vérifie les ports inversés attendus, la présence simultanée des drapeaux SYN et ACK et un acquittement égal au numéro de séquence local augmenté de un. Le numéro de séquence distant est copié vers une sortie fournie par l’appelant.
+
+Cette validation prépare l’émission du premier ACK mais ne crée pas encore d’état de connexion persistant. Aucun timer, aucune retransmission et aucune allocation ne sont introduits.
+
+| Élément | État AOS-149 |
+|---|---|
+| Validation des ports SYN-ACK | Implémentée. |
+| Validation SYN et ACK | Implémentée. |
+| Validation de l’acquittement | Implémentée. |
+| Capture du sequence distant | Caller-owned et implémentée. |
+| Construction du premier ACK | Prochain lot. |
+| État TCP persistant/retransmission | Non implémenté. |
+| TLS, HTTP et OpenAI | Toujours non déclarés fonctionnels sur le transport matériel. |
+
+La validation locale atteint **294 tests verts**, avec build i386 réussi.

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -53,6 +53,17 @@ int net_tcp_build_syn_ipv4(uint8_t* packet, uint32_t capacity,
     return 40;
 }
 
+int net_tcp_is_syn_ack_for(const net_tcp_view_t* view, uint16_t local_port,
+                           uint16_t remote_port, uint32_t local_sequence,
+                           uint32_t* remote_sequence) {
+    if (!view || !remote_sequence || local_port == 0U || remote_port == 0U) return -1;
+    if (view->source_port != remote_port || view->destination_port != local_port ||
+        (view->flags & (NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK)) != (NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK) ||
+        view->acknowledgment != local_sequence + 1U) return -2;
+    *remote_sequence = view->sequence;
+    return 0;
+}
+
 int net_tcp_parse(const uint8_t* segment, uint32_t length, net_tcp_view_t* out) {
     uint8_t header_words;
     uint16_t header_size;

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -32,5 +32,8 @@ int net_tcp_build_syn_ipv4(uint8_t* packet, uint32_t capacity,
                            const uint8_t source_ip[4], const uint8_t destination_ip[4],
                            uint16_t source_port, uint16_t destination_port,
                            uint32_t sequence);
+int net_tcp_is_syn_ack_for(const net_tcp_view_t* view, uint16_t local_port,
+                           uint16_t remote_port, uint32_t local_sequence,
+                           uint32_t* remote_sequence);
 
 #endif

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -15,6 +15,11 @@ void test_build_and_parse_syn_ack(void) {
     TEST_ASSERT_EQUAL(NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, view.flags);
     { uint8_t source[4] = {10,0,2,15}; uint8_t destination[4] = {10,0,2,2}; uint16_t checksum = net_tcp_checksum_ipv4(source, destination, segment, 20); TEST_ASSERT_NOT_EQUAL(0, checksum); TEST_ASSERT_EQUAL(checksum, net_tcp_checksum_ipv4(source, destination, segment, 20)); }
     TEST_ASSERT_EQUAL(0x10203041U, view.acknowledgment);
+    { uint32_t remote_sequence = 0U;
+      view.source_port = 443; view.destination_port = 49152;
+      TEST_ASSERT_EQUAL(0, net_tcp_is_syn_ack_for(&view, 49152, 443, 0x10203040U, &remote_sequence));
+      TEST_ASSERT_EQUAL(0x10203040U, remote_sequence);
+      view.acknowledgment = 7U; TEST_ASSERT_NOT_EQUAL(0, net_tcp_is_syn_ack_for(&view, 49152, 443, 0x10203040U, &remote_sequence)); }
     segment[0] = 0; segment[1] = 0; TEST_ASSERT_NOT_EQUAL(0, net_tcp_parse(segment, 20, &view));
     { uint8_t packet[48] = {0}; uint8_t src[4] = {10,0,2,15}; uint8_t dst[4] = {10,0,2,2};
       TEST_ASSERT_EQUAL(40, net_tcp_build_syn_ipv4(packet, sizeof(packet), src, dst, 49152, 443, 0x10203040U));


### PR DESCRIPTION
## Résumé

Ajoute la validation stricte d'un SYN-ACK : ports inversés, drapeaux SYN/ACK et acquittement attendu, avec capture caller-owned du sequence distant.

## Validation

- `make test-all`: 294/294 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-149.

La construction du premier ACK, l'état de connexion et les retransmissions restent hors périmètre.