### PR TITLE
Lot 150: premier ACK TCP et état caller-owned

### DIFF
--- a/docs/aos150_tcp_first_ack.md
+++ b/docs/aos150_tcp_first_ack.md
@@ -1,0 +1,17 @@
+# AOS-150 — Premier ACK TCP et état de connexion caller-owned
+
+Le lot AOS-150 complète le début du handshake TCP côté client. Il ajoute la construction d’un segment ACK de 20 octets et un état de connexion minimal fourni par l’appelant. L’implémentation ne fait appel à aucune allocation dynamique et ne conserve aucun état global.
+
+Lors de l’ouverture, le numéro de séquence initial fourni par l’appelant est consommé par le SYN et `local_sequence` devient `ISN + 1`. Après réception d’un SYN-ACK validé par AOS-149, le numéro distant devient `remote_sequence + 1`, puis l’état passe de `SYN_SENT` à `ESTABLISHED`. Le premier ACK est alors construit avec ces deux valeurs et les ports local/distant inversés par rapport au SYN entrant.
+
+| Élément | État |
+|---|---|
+| Construction ACK caller-owned | Implémentée. |
+| Contrôle de capacité et ports nuls | Implémenté. |
+| État `CLOSED`, `SYN_SENT`, `ESTABLISHED` | Implémenté dans une structure fournie par l’appelant. |
+| Validation stricte du SYN-ACK | Réutilise AOS-149. |
+| Émission physique du premier ACK | Non raccordée à l’orchestrateur NE2000 dans ce lot. |
+| Données TCP, fenêtres, retransmissions et timers | Non implémentés. |
+| TLS, HTTP et appels LLM en ligne | Non fonctionnels de bout en bout à ce stade. |
+
+La validation locale atteint **295 tests verts**, avec build i386 réussi et smokes QEMU sans NIC et NE2000 réussis.

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -5,75 +5,92 @@ static uint32_t get32(const uint8_t* p) { return ((uint32_t)p[0]<<24)|((uint32_t
 static void put16(uint8_t* p, uint16_t v) { p[0]=(uint8_t)(v>>8); p[1]=(uint8_t)v; }
 static void put32(uint8_t* p, uint32_t v) { p[0]=(uint8_t)(v>>24); p[1]=(uint8_t)(v>>16); p[2]=(uint8_t)(v>>8); p[3]=(uint8_t)v; }
 
-int net_tcp_build_syn(uint8_t* segment, uint32_t capacity,
-                      uint16_t source_port, uint16_t destination_port,
-                      uint32_t sequence) {
+static int build_control(uint8_t* segment, uint32_t capacity, uint16_t source_port,
+                         uint16_t destination_port, uint32_t sequence,
+                         uint32_t acknowledgment, uint8_t flags) {
     uint16_t i;
     if (!segment || capacity < NET_TCP_HEADER_SIZE || source_port == 0U || destination_port == 0U) return -1;
     for (i=0; i<NET_TCP_HEADER_SIZE; ++i) segment[i]=0U;
     put16(segment, source_port); put16(segment+2, destination_port);
-    put32(segment+4, sequence); segment[12]=0x50U; segment[13]=NET_TCP_FLAG_SYN;
-    put16(segment+14, 65535U);
+    put32(segment+4, sequence); put32(segment+8, acknowledgment);
+    segment[12]=0x50U; segment[13]=flags; put16(segment+14, 65535U);
     return NET_TCP_HEADER_SIZE;
+}
+
+int net_tcp_build_syn(uint8_t* segment, uint32_t capacity, uint16_t source_port,
+                      uint16_t destination_port, uint32_t sequence) {
+    return build_control(segment, capacity, source_port, destination_port, sequence, 0U, NET_TCP_FLAG_SYN);
+}
+
+int net_tcp_build_ack(uint8_t* segment, uint32_t capacity, uint16_t source_port,
+                      uint16_t destination_port, uint32_t sequence, uint32_t acknowledgment) {
+    return build_control(segment, capacity, source_port, destination_port, sequence, acknowledgment, NET_TCP_FLAG_ACK);
 }
 
 uint16_t net_tcp_checksum_ipv4(const uint8_t source_ip[4], const uint8_t destination_ip[4],
                                const uint8_t* segment, uint16_t length) {
     uint32_t sum = 0U; uint16_t i;
     if (!source_ip || !destination_ip || !segment || length == 0U) return 0U;
-    sum += ((uint16_t)source_ip[0] << 8) | source_ip[1];
-    sum += ((uint16_t)source_ip[2] << 8) | source_ip[3];
-    sum += ((uint16_t)destination_ip[0] << 8) | destination_ip[1];
-    sum += ((uint16_t)destination_ip[2] << 8) | destination_ip[3];
-    sum += NET_TCP_PROTOCOL;
-    sum += length;
-    for (i = 0; i + 1U < length; i += 2U) {
-        sum += get16(segment + i);
-        while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16);
-    }
-    if (length & 1U) sum += (uint16_t)segment[length - 1U] << 8;
-    while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16);
+    sum += ((uint16_t)source_ip[0] << 8) | source_ip[1]; sum += ((uint16_t)source_ip[2] << 8) | source_ip[3];
+    sum += ((uint16_t)destination_ip[0] << 8) | destination_ip[1]; sum += ((uint16_t)destination_ip[2] << 8) | destination_ip[3];
+    sum += NET_TCP_PROTOCOL; sum += length;
+    for (i=0; i+1U<length; i+=2U) { sum += get16(segment+i); while (sum>>16) sum=(sum&0xffffU)+(sum>>16); }
+    if (length&1U) sum += (uint16_t)segment[length-1U]<<8;
+    while (sum>>16) sum=(sum&0xffffU)+(sum>>16);
     return (uint16_t)~sum;
 }
 
-int net_tcp_build_syn_ipv4(uint8_t* packet, uint32_t capacity,
-                           const uint8_t source_ip[4], const uint8_t destination_ip[4],
-                           uint16_t source_port, uint16_t destination_port,
-                           uint32_t sequence) {
-    uint16_t i, checksum; uint32_t sum = 0U;
+int net_tcp_build_syn_ipv4(uint8_t* packet, uint32_t capacity, const uint8_t source_ip[4],
+                           const uint8_t destination_ip[4], uint16_t source_port,
+                           uint16_t destination_port, uint32_t sequence) {
+    uint16_t i, checksum; uint32_t sum=0U;
     if (!packet || !source_ip || !destination_ip || capacity < 40U) return -1;
-    for (i = 0; i < 40U; ++i) packet[i] = 0U;
-    packet[0] = 0x45U; put16(packet + 2, 40U); packet[8] = 64U; packet[9] = NET_TCP_PROTOCOL;
-    for (i = 0; i < 4U; ++i) { packet[12U+i] = source_ip[i]; packet[16U+i] = destination_ip[i]; }
-    if (net_tcp_build_syn(packet + 20U, capacity - 20U, source_port, destination_port, sequence) < 0) return -2;
-    checksum = net_tcp_checksum_ipv4(source_ip, destination_ip, packet + 20U, 20U);
-    put16(packet + 36U, checksum);
-    for (i = 0; i < 20U; i += 2U) { sum += get16(packet + i); while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16); }
-    put16(packet + 10U, (uint16_t)~sum);
-    return 40;
+    for (i=0;i<40U;++i) packet[i]=0U;
+    packet[0]=0x45U; put16(packet+2,40U); packet[8]=64U; packet[9]=NET_TCP_PROTOCOL;
+    for (i=0;i<4U;++i) { packet[12U+i]=source_ip[i]; packet[16U+i]=destination_ip[i]; }
+    if (net_tcp_build_syn(packet+20U,capacity-20U,source_port,destination_port,sequence)<0) return -2;
+    checksum=net_tcp_checksum_ipv4(source_ip,destination_ip,packet+20U,20U); put16(packet+36U,checksum);
+    for (i=0;i<20U;i+=2U) { sum+=get16(packet+i); while(sum>>16) sum=(sum&0xffffU)+(sum>>16); }
+    put16(packet+10U,(uint16_t)~sum); return 40;
 }
 
-int net_tcp_is_syn_ack_for(const net_tcp_view_t* view, uint16_t local_port,
-                           uint16_t remote_port, uint32_t local_sequence,
-                           uint32_t* remote_sequence) {
-    if (!view || !remote_sequence || local_port == 0U || remote_port == 0U) return -1;
-    if (view->source_port != remote_port || view->destination_port != local_port ||
-        (view->flags & (NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK)) != (NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK) ||
-        view->acknowledgment != local_sequence + 1U) return -2;
-    *remote_sequence = view->sequence;
-    return 0;
+int net_tcp_is_syn_ack_for(const net_tcp_view_t* view,uint16_t local_port,uint16_t remote_port,
+                           uint32_t local_sequence,uint32_t* remote_sequence) {
+    if (!view || !remote_sequence || local_port==0U || remote_port==0U) return -1;
+    if (view->source_port!=remote_port || view->destination_port!=local_port ||
+        (view->flags&(NET_TCP_FLAG_SYN|NET_TCP_FLAG_ACK))!=(NET_TCP_FLAG_SYN|NET_TCP_FLAG_ACK) ||
+        view->acknowledgment!=local_sequence+1U) return -2;
+    *remote_sequence=view->sequence; return 0;
 }
 
-int net_tcp_parse(const uint8_t* segment, uint32_t length, net_tcp_view_t* out) {
-    uint8_t header_words;
-    uint16_t header_size;
-    if (!segment || !out || length < NET_TCP_HEADER_SIZE) return -1;
-    header_words = (uint8_t)(segment[12] >> 4); header_size = (uint16_t)header_words * 4U;
-    if (header_words < 5U || header_size > length) return -2;
+int net_tcp_connection_open(net_tcp_connection_t* connection,uint16_t local_port,uint16_t remote_port,uint32_t local_sequence) {
+    if (!connection || local_port==0U || remote_port==0U) return -1;
+    connection->local_port=local_port; connection->remote_port=remote_port;
+    connection->local_sequence=local_sequence+1U; connection->remote_sequence=0U;
+    connection->state=NET_TCP_STATE_SYN_SENT; return 0;
+}
+
+int net_tcp_connection_accept_syn_ack(net_tcp_connection_t* connection,const net_tcp_view_t* view) {
+    uint32_t remote_sequence;
+    if (!connection || !view || connection->state!=NET_TCP_STATE_SYN_SENT) return -1;
+    if (net_tcp_is_syn_ack_for(view,connection->local_port,connection->remote_port,
+                               connection->local_sequence-1U,&remote_sequence)!=0) return -2;
+    connection->remote_sequence=remote_sequence+1U; connection->state=NET_TCP_STATE_ESTABLISHED; return 0;
+}
+
+int net_tcp_connection_build_ack(const net_tcp_connection_t* connection,uint8_t* segment,uint32_t capacity) {
+    if (!connection || connection->state!=NET_TCP_STATE_ESTABLISHED) return -1;
+    return net_tcp_build_ack(segment,capacity,connection->local_port,connection->remote_port,
+                             connection->local_sequence,connection->remote_sequence);
+}
+
+int net_tcp_parse(const uint8_t* segment,uint32_t length,net_tcp_view_t* out) {
+    uint8_t header_words; uint16_t header_size;
+    if (!segment || !out || length<NET_TCP_HEADER_SIZE) return -1;
+    header_words=(uint8_t)(segment[12]>>4); header_size=(uint16_t)header_words*4U;
+    if (header_words<5U || header_size>length) return -2;
     out->source_port=get16(segment); out->destination_port=get16(segment+2);
-    if (out->source_port == 0U || out->destination_port == 0U) return -3;
-    out->sequence=get32(segment+4); out->acknowledgment=get32(segment+8);
-    out->flags=(uint8_t)(segment[13] & 0x3fU);
-    out->payload=segment+header_size; out->payload_length=(uint16_t)(length-header_size);
-    return 0;
+    if (out->source_port==0U || out->destination_port==0U) return -3;
+    out->sequence=get32(segment+4); out->acknowledgment=get32(segment+8); out->flags=(uint8_t)(segment[13]&0x3fU);
+    out->payload=segment+header_size; out->payload_length=(uint16_t)(length-header_size); return 0;
 }

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -10,6 +10,10 @@
 #define NET_TCP_FLAG_RST 0x04U
 #define NET_TCP_FLAG_ACK 0x10U
 
+#define NET_TCP_STATE_CLOSED 0U
+#define NET_TCP_STATE_SYN_SENT 1U
+#define NET_TCP_STATE_ESTABLISHED 2U
+
 typedef struct {
     uint16_t source_port;
     uint16_t destination_port;
@@ -20,9 +24,20 @@ typedef struct {
     uint16_t payload_length;
 } net_tcp_view_t;
 
+typedef struct {
+    uint16_t local_port;
+    uint16_t remote_port;
+    uint32_t local_sequence;
+    uint32_t remote_sequence;
+    uint8_t state;
+} net_tcp_connection_t;
+
 int net_tcp_build_syn(uint8_t* segment, uint32_t capacity,
                       uint16_t source_port, uint16_t destination_port,
                       uint32_t sequence);
+int net_tcp_build_ack(uint8_t* segment, uint32_t capacity,
+                      uint16_t source_port, uint16_t destination_port,
+                      uint32_t sequence, uint32_t acknowledgment);
 int net_tcp_parse(const uint8_t* segment, uint32_t length,
                   net_tcp_view_t* out);
 /* Calcule le checksum TCP IPv4 sur le segment caller-owned. */
@@ -35,5 +50,12 @@ int net_tcp_build_syn_ipv4(uint8_t* packet, uint32_t capacity,
 int net_tcp_is_syn_ack_for(const net_tcp_view_t* view, uint16_t local_port,
                            uint16_t remote_port, uint32_t local_sequence,
                            uint32_t* remote_sequence);
+int net_tcp_connection_open(net_tcp_connection_t* connection,
+                            uint16_t local_port, uint16_t remote_port,
+                            uint32_t local_sequence);
+int net_tcp_connection_accept_syn_ack(net_tcp_connection_t* connection,
+                                      const net_tcp_view_t* view);
+int net_tcp_connection_build_ack(const net_tcp_connection_t* connection,
+                                 uint8_t* segment, uint32_t capacity);
 
 #endif

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -27,7 +27,25 @@ void test_build_and_parse_syn_ack(void) {
       TEST_ASSERT_EQUAL(49152, (packet[20] << 8) | packet[21]); TEST_ASSERT_EQUAL(NET_TCP_FLAG_SYN, packet[33] & 0x3f); }
 }
 
+void test_connection_builds_first_ack(void) {
+    uint8_t segment[20] = {0}; net_tcp_view_t view; net_tcp_connection_t connection;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_SYN_SENT, connection.state);
+    view.source_port = 443; view.destination_port = 49152; view.sequence = 700U;
+    view.acknowledgment = 101U; view.flags = NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &view));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_ESTABLISHED, connection.state);
+    TEST_ASSERT_EQUAL(701U, connection.remote_sequence);
+    TEST_ASSERT_EQUAL(20, net_tcp_connection_build_ack(&connection, segment, sizeof(segment)));
+    TEST_ASSERT_EQUAL(0, net_tcp_parse(segment, 20, &view));
+    TEST_ASSERT_EQUAL(49152, view.source_port); TEST_ASSERT_EQUAL(443, view.destination_port);
+    TEST_ASSERT_EQUAL(101U, view.sequence); TEST_ASSERT_EQUAL(701U, view.acknowledgment);
+    TEST_ASSERT_EQUAL(NET_TCP_FLAG_ACK, view.flags);
+    view.acknowledgment = 102U;
+    TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &view));
+}
+
 int main(void) {
-    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); unity_print_results(); unity_cleanup();
+    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); unity_print_results(); unity_cleanup();
     return (unity_stats.tests_failed == 0) ? 0 : 1;
 }


### PR DESCRIPTION
## Résumé

Ajoute la construction d'un ACK TCP et un état de connexion minimal caller-owned, sans kmalloc ni état global. La transition SYN-SENT vers ESTABLISHED réutilise la validation SYN-ACK du lot 149.

## Validation

- `make test-all`: 295/295 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke sans NIC réussi;
- `make qemu-ne2k-status`: smoke NE2000 réussi;
- documentation française AOS-150.

L'ACK est construit en mémoire caller-owned; son émission physique via NE2000, les données TCP, les retransmissions et TLS restent les prochains lots.