### PR TITLE
Lots 151-152: ACK NE2000 et données TCP caller-owned

### DIFF
--- a/docs/aos151_tcp_ack_ne2k_tx.md
+++ b/docs/aos151_tcp_ack_ne2k_tx.md
@@ -1,0 +1,17 @@
+# AOS-151 — Émission du premier ACK TCP via NE2000
+
+AOS-151 raccorde l’état de connexion TCP caller-owned au chemin d’émission NE2000. `ne2k_tcp_ack` recherche la MAC distante dans le cache ARP fourni par l’appelant, construit une trame Ethernet IPv4/TCP de 40 octets de protocole, calcule le checksum TCP sur pseudo-en-tête IPv4, calcule le checksum IPv4 puis soumet la trame au contrôleur NE2000 en PIO.
+
+La primitive exige un périphérique préparé, une MAC locale valide, une entrée ARP déjà résolue, une connexion `ESTABLISHED` et un buffer de trame appartenant à l’appelant. Aucun cache interne, aucune allocation et aucun état global TCP ne sont ajoutés.
+
+| Élément | Statut réel |
+|---|---|
+| Recherche MAC distante via cache ARP | Implémentée. |
+| Trame Ethernet IPv4/TCP ACK | Implémentée. |
+| Checksum TCP pseudo-en-tête IPv4 | Implémenté. |
+| Checksum IPv4 | Implémenté. |
+| Transmission NE2000 PIO | Réutilise `ne2k_tx_submit`. |
+| Retransmission, timer, contrôle de congestion | Non implémentés. |
+| Données TCP et TLS | Lots suivants ; non fonctionnels de bout en bout. |
+
+Le test unitaire NE2000 vérifie les adresses MAC, le protocole IPv4, les ports, les numéros de séquence/acquittement et le drapeau ACK.

--- a/docs/aos152_tcp_data_caller_owned.md
+++ b/docs/aos152_tcp_data_caller_owned.md
@@ -1,0 +1,16 @@
+# AOS-152 — Données TCP caller-owned
+
+AOS-152 ajoute la construction bornée d’un segment TCP `ACK+payload` dans `net_tcp_build_data` et son émission Ethernet/IPv4 via `ne2k_tcp_data`. Le buffer de segment, le payload, le cache ARP et l’état de connexion restent fournis par l’appelant. Le constructeur ne modifie pas `local_sequence` : l’appelant conserve la responsabilité de confirmer l’émission et de faire évoluer son état selon la politique de retransmission future.
+
+La voie NE2000 construit une trame IPv4 de longueur exacte, calcule le checksum TCP sur pseudo-en-tête IPv4, calcule le checksum IPv4 et transmet par `ne2k_tx_submit`. Les contrôles rejettent les ports ou pointeurs invalides, les capacités insuffisantes, les payloads incohérents et les MAC distantes absentes du cache ARP.
+
+| Élément | Statut réel |
+|---|---|
+| Codec TCP ACK+payload | Implémenté et testé. |
+| Parsing caller-owned du payload | Réutilise `net_tcp_parse`. |
+| Émission NE2000 ACK+payload | Implémentée et testée. |
+| Mise à jour automatique du sequence après émission | Non réalisée volontairement. |
+| Retransmission, fenêtre, congestion, FIN/RST | Non implémentés. |
+| TLS, HTTP et client LLM en ligne | Non fonctionnels de bout en bout. |
+
+La non-régression locale atteint **297 tests verts**. Le premier smoke `qemu-ai-provider` a eu un échec ponctuel sans rapport avec TCP, puis a réussi lors de la relance ; le smoke NE2000 est vert.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -72,3 +72,30 @@ Le mode simulation fonctionnait parfaitement mais le passage au mode utilisateur
 
 **Statut 2026 :** ce blocage est levé. Le kernel pose `g_reschedule_needed` puis le timer appelle `schedule()` une fois vers le shell ELF.
 
+
+## Mise à jour réseau TCP — août 2026
+
+Les lots réseau AOS-132 à AOS-150 sont désormais intégrés progressivement et validés par CI. Le pilote NE2000 sait lire la PROM MAC, émettre en PIO, sonder la réception et traiter IRQ3 ; ARP statique et actif, DHCP et DNS A sont disponibles dans leurs chemins caller-owned. AOS-147 construit un SYN IPv4 TCP, AOS-148 expose les segments TCP reçus, AOS-149 valide strictement un SYN-ACK et AOS-150 construit le premier ACK avec un état `SYN_SENT`/`ESTABLISHED` appartenant à l’appelant.
+
+| Domaine | Statut réel |
+|---|---|
+| Ethernet, ARP, DHCP, DNS A | Implémentés et couverts par tests/smokes. |
+| TCP SYN, réception, validation SYN-ACK, premier ACK en mémoire | Implémentés ; 295 tests verts sur AOS-150. |
+| Émission physique de l’ACK via l’orchestrateur NE2000 | Prochain lot. |
+| Segments TCP avec données caller-owned | Prochain lot. |
+| Retransmissions, timers, congestion et fermeture complète | Non implémentés. |
+| TLS et appels LLM en ligne | Non fonctionnels de bout en bout à ce stade. |
+
+Cette section remplace toute interprétation de la ligne générique « Pilote NIC, DHCP, DNS, TCP/TLS et client OpenAI effectif » : les sous-composants réalisés sont précisés ci-dessus, tandis que TCP/TLS et le client LLM restent partiels.
+
+Références détaillées : [AOS-149](aos149_tcp_synack_validation.md) et [AOS-150](aos150_tcp_first_ack.md).
+
+### AOS-151 — émission du premier ACK via NE2000
+
+AOS-151 est implémenté localement : `ne2k_tcp_ack` utilise le cache ARP caller-owned, construit Ethernet/IPv4/TCP, calcule les checksums et transmet via `ne2k_tx_submit`. Le test NE2000 valide les ports, séquences, ACK et adresses MAC. La validation complète et la PR restent à effectuer après la non-régression.
+
+Le prochain lot logique est AOS-152 : codec TCP avec données caller-owned et émission bornée d’un segment ACK+payload. Cela ne constitue pas encore un client HTTP, TLS ou LLM fonctionnel.
+
+### AOS-152 — données TCP caller-owned
+
+AOS-152 ajoute le codec `ACK+payload` et `ne2k_tcp_data`, avec longueur IPv4 exacte, checksums TCP/IPv4 et contrôles de capacité. La suite locale atteint 297 tests verts. Le smoke `qemu-ai-provider` a échoué une première fois sur l’absence de sortie `Runtime IA bare-metal`, puis a réussi lors d’une relance immédiate ; le smoke `qemu-ne2k-status` est vert. Cette anomalie de smoke IA reste à surveiller séparément du chemin TCP.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -171,6 +171,63 @@ int ne2k_tcp_syn(ne2k_device_t* device, const ne2k_io_t* io,
       return ne2k_tx_submit(device, io, frame, (uint16_t)(NET_ETHERNET_HEADER_SIZE + tcp_length)); }
 }
 
+int ne2k_tcp_ack(ne2k_device_t* device, const ne2k_io_t* io,
+                 const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
+                 const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                 const net_tcp_connection_t* connection) {
+    uint8_t destination_mac[6]; uint16_t tcp_length, i; uint32_t sum = 0U;
+    if (!device || !io || !cache || !frame || !local_ip || !remote_ip || !connection ||
+        !device->mac_valid || frame_capacity < NET_ETHERNET_HEADER_SIZE + 40U) return -1;
+    if (net_arp_cache_lookup(cache, remote_ip, destination_mac) != 0) return -2;
+    for (i = 0; i < 6U; ++i) { frame[i] = destination_mac[i]; frame[6U+i] = device->mac[i]; }
+    frame[12] = 0x08U; frame[13] = 0x00U;
+    for (i = 0; i < 40U; ++i) frame[NET_ETHERNET_HEADER_SIZE+i] = 0U;
+    frame[NET_ETHERNET_HEADER_SIZE] = 0x45U;
+    frame[NET_ETHERNET_HEADER_SIZE+2U] = 0U; frame[NET_ETHERNET_HEADER_SIZE+3U] = 40U;
+    frame[NET_ETHERNET_HEADER_SIZE+8U] = 64U; frame[NET_ETHERNET_HEADER_SIZE+9U] = NET_TCP_PROTOCOL;
+    for (i = 0; i < 4U; ++i) { frame[NET_ETHERNET_HEADER_SIZE+12U+i] = local_ip[i]; frame[NET_ETHERNET_HEADER_SIZE+16U+i] = remote_ip[i]; }
+    tcp_length = (uint16_t)net_tcp_connection_build_ack(connection, frame + NET_ETHERNET_HEADER_SIZE + 20U,
+                                                         frame_capacity - NET_ETHERNET_HEADER_SIZE - 20U);
+    if ((int16_t)tcp_length < 0) return -3;
+    /* Le segment TCP est construit dans la zone caller-owned; calculer son checksum. */
+    frame[NET_ETHERNET_HEADER_SIZE+36U] = 0U; frame[NET_ETHERNET_HEADER_SIZE+37U] = 0U;
+    { uint16_t checksum = net_tcp_checksum_ipv4(local_ip, remote_ip, frame + NET_ETHERNET_HEADER_SIZE + 20U, tcp_length);
+      frame[NET_ETHERNET_HEADER_SIZE+36U] = (uint8_t)(checksum >> 8); frame[NET_ETHERNET_HEADER_SIZE+37U] = (uint8_t)checksum; }
+    for (i = 0; i < 20U; i += 2U) { sum += ((uint16_t)frame[NET_ETHERNET_HEADER_SIZE+i] << 8) | frame[NET_ETHERNET_HEADER_SIZE+i+1U]; while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16); }
+    sum = (~sum) & 0xffffU; frame[NET_ETHERNET_HEADER_SIZE+10U] = (uint8_t)(sum >> 8); frame[NET_ETHERNET_HEADER_SIZE+11U] = (uint8_t)sum;
+    return ne2k_tx_submit(device, io, frame, (uint16_t)(NET_ETHERNET_HEADER_SIZE + 40U));
+}
+
+int ne2k_tcp_data(ne2k_device_t* device, const ne2k_io_t* io,
+                  const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
+                  const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                  const net_tcp_connection_t* connection, const uint8_t* payload,
+                  uint16_t payload_length) {
+    uint8_t destination_mac[6]; uint16_t tcp_length, i, ip_length; uint32_t sum = 0U;
+    if (!device || !io || !cache || !frame || !local_ip || !remote_ip || !connection ||
+        (!payload && payload_length != 0U) || !device->mac_valid) return -1;
+    if (net_arp_cache_lookup(cache, remote_ip, destination_mac) != 0) return -2;
+    ip_length = (uint16_t)(20U + NET_TCP_HEADER_SIZE + payload_length);
+    if ((uint32_t)NET_ETHERNET_HEADER_SIZE + ip_length > frame_capacity ||
+        (uint32_t)NET_ETHERNET_HEADER_SIZE + ip_length > NE2K_ETHERNET_MAX_FRAME) return -3;
+    for (i = 0; i < 6U; ++i) { frame[i] = destination_mac[i]; frame[6U+i] = device->mac[i]; }
+    frame[12] = 0x08U; frame[13] = 0x00U;
+    for (i = 0; i < ip_length; ++i) frame[NET_ETHERNET_HEADER_SIZE+i] = 0U;
+    frame[14] = 0x45U; frame[16] = (uint8_t)(ip_length >> 8); frame[17] = (uint8_t)ip_length;
+    frame[22] = 64U; frame[23] = NET_TCP_PROTOCOL;
+    for (i = 0; i < 4U; ++i) { frame[26U+i] = local_ip[i]; frame[30U+i] = remote_ip[i]; }
+    tcp_length = (uint16_t)net_tcp_build_data(frame + 34U, frame_capacity - 34U,
+                                               connection->local_port, connection->remote_port,
+                                               connection->local_sequence, connection->remote_sequence,
+                                               payload, payload_length);
+    if ((int16_t)tcp_length < 0) return -4;
+    { uint16_t checksum = net_tcp_checksum_ipv4(local_ip, remote_ip, frame + 34U, tcp_length);
+      frame[50U] = (uint8_t)(checksum >> 8); frame[51U] = (uint8_t)checksum; }
+    for (i = 0; i < 20U; i += 2U) { sum += ((uint16_t)frame[14U+i] << 8) | frame[15U+i]; while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16); }
+    sum = (~sum) & 0xffffU; frame[24] = (uint8_t)(sum >> 8); frame[25] = (uint8_t)sum;
+    return ne2k_tx_submit(device, io, frame, (uint16_t)(NET_ETHERNET_HEADER_SIZE + ip_length));
+}
+
 int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,
                     uint8_t* frame, uint16_t frame_capacity, uint16_t attempts,
                     uint16_t expected_id, net_dns_a_result_t* result) {

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -127,6 +127,17 @@ int ne2k_tcp_syn(ne2k_device_t* device, const ne2k_io_t* io,
                  uint8_t* arp_rx, uint16_t arp_rx_capacity, uint8_t* frame, uint16_t frame_capacity,
                  const uint8_t local_ip[4], const uint8_t remote_ip[4],
                  uint16_t local_port, uint16_t remote_port, uint32_t sequence);
+/* Construit et émet le premier ACK TCP depuis une connexion caller-owned. */
+int ne2k_tcp_ack(ne2k_device_t* device, const ne2k_io_t* io,
+                 const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
+                 const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                 const net_tcp_connection_t* connection);
+/* Construit et émet un segment TCP ACK+payload caller-owned. */
+int ne2k_tcp_data(ne2k_device_t* device, const ne2k_io_t* io,
+                  const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
+                  const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                  const net_tcp_connection_t* connection, const uint8_t* payload,
+                  uint16_t payload_length);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -27,6 +27,16 @@ int net_tcp_build_ack(uint8_t* segment, uint32_t capacity, uint16_t source_port,
     return build_control(segment, capacity, source_port, destination_port, sequence, acknowledgment, NET_TCP_FLAG_ACK);
 }
 
+int net_tcp_build_data(uint8_t* segment, uint32_t capacity, uint16_t source_port,
+                       uint16_t destination_port, uint32_t sequence, uint32_t acknowledgment,
+                       const uint8_t* payload, uint16_t payload_length) {
+    uint16_t i; uint32_t total = NET_TCP_HEADER_SIZE + payload_length;
+    if (!segment || (!payload && payload_length != 0U) || total > capacity) return -1;
+    if (build_control(segment, capacity, source_port, destination_port, sequence, acknowledgment, NET_TCP_FLAG_ACK) < 0) return -2;
+    for (i = 0; i < payload_length; ++i) segment[NET_TCP_HEADER_SIZE + i] = payload[i];
+    return (int)total;
+}
+
 uint16_t net_tcp_checksum_ipv4(const uint8_t source_ip[4], const uint8_t destination_ip[4],
                                const uint8_t* segment, uint16_t length) {
     uint32_t sum = 0U; uint16_t i;

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -38,6 +38,10 @@ int net_tcp_build_syn(uint8_t* segment, uint32_t capacity,
 int net_tcp_build_ack(uint8_t* segment, uint32_t capacity,
                       uint16_t source_port, uint16_t destination_port,
                       uint32_t sequence, uint32_t acknowledgment);
+int net_tcp_build_data(uint8_t* segment, uint32_t capacity,
+                       uint16_t source_port, uint16_t destination_port,
+                       uint32_t sequence, uint32_t acknowledgment,
+                       const uint8_t* payload, uint16_t payload_length);
 int net_tcp_parse(const uint8_t* segment, uint32_t length,
                   net_tcp_view_t* out);
 /* Calcule le checksum TCP IPv4 sur le segment caller-owned. */

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -95,6 +95,36 @@ void test_probe_and_prepare_use_injected_io(void) {
     }
 }
 
+void test_tcp_ack_is_emitted_from_connection_state(void) {
+    fake_ne2k_t fake = {0x12, 0, 0, 0}; ne2k_io_t io = {&fake, fake_inb, fake_outb}; ne2k_device_t device;
+    net_arp_cache_t cache; net_tcp_connection_t connection; uint8_t frame[128] = {0};
+    uint8_t local_ip[4] = {10, 0, 2, 15}; uint8_t remote_ip[4] = {10, 0, 2, 2};
+    uint8_t remote_mac[6] = {0x52, 0x54, 0, 0, 0, 2}; uint8_t local_mac[6] = {0x02, 0, 0, 0, 0, 1};
+    fake.isr = (uint8_t)(NE2K_ISR_RESET | NE2K_ISR_RDC);
+    TEST_ASSERT_EQUAL(0, ne2k_probe(&device, 0x300, &io));
+    TEST_ASSERT_EQUAL(0, ne2k_prepare(&device, &io));
+    TEST_ASSERT_EQUAL(0, ne2k_configure_rings(&device, &io));
+    TEST_ASSERT_EQUAL(0, ne2k_set_mac(&device, local_mac));
+    TEST_ASSERT_EQUAL(0, net_arp_cache_init(&cache));
+    TEST_ASSERT_EQUAL(0, net_arp_cache_put(&cache, remote_ip, remote_mac));
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    { net_tcp_view_t syn_ack = {443, 49152, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &syn_ack)); }
+    TEST_ASSERT_EQUAL(0, ne2k_tcp_ack(&device, &io, &cache, frame, sizeof(frame), local_ip, remote_ip, &connection));
+    TEST_ASSERT_EQUAL(0x52, frame[0]); TEST_ASSERT_EQUAL(0x02, frame[6]);
+    TEST_ASSERT_EQUAL(0x08, frame[12]); TEST_ASSERT_EQUAL(0x00, frame[13]);
+    TEST_ASSERT_EQUAL(0x45, frame[14]); TEST_ASSERT_EQUAL(NET_TCP_PROTOCOL, frame[23]);
+    TEST_ASSERT_EQUAL(49152, ((uint16_t)frame[34] << 8) | frame[35]);
+    TEST_ASSERT_EQUAL(443, ((uint16_t)frame[36] << 8) | frame[37]);
+    TEST_ASSERT_EQUAL(101U, ((uint32_t)frame[38] << 24) | ((uint32_t)frame[39] << 16) | ((uint32_t)frame[40] << 8) | frame[41]);
+    TEST_ASSERT_EQUAL(701U, ((uint32_t)frame[42] << 24) | ((uint32_t)frame[43] << 16) | ((uint32_t)frame[44] << 8) | frame[45]);
+    TEST_ASSERT_EQUAL(NET_TCP_FLAG_ACK, frame[47]);
+    { uint8_t payload[4] = {'P','I','N','G'};
+      TEST_ASSERT_EQUAL(0, ne2k_tcp_data(&device, &io, &cache, frame, sizeof(frame), local_ip, remote_ip, &connection, payload, sizeof(payload)));
+      TEST_ASSERT_EQUAL(44, ((uint16_t)frame[16] << 8) | frame[17]);
+      TEST_ASSERT_EQUAL('P', frame[54]); TEST_ASSERT_EQUAL('G', frame[57]); }
+}
+
 void test_rx_extract_publishes_bounded_frame(void) {
     uint8_t storage[NET_NIC_QUEUE_CAPACITY * 64U] = {0};
     uint8_t dma[9] = {NE2K_RX_STATUS_OK, 0, 9, 0, 1, 2, 3, 4, 5};
@@ -117,6 +147,7 @@ void test_probe_rejects_missing_reset_ack(void) {
 int main(void) {
     unity_init();
     RUN_TEST(test_probe_and_prepare_use_injected_io);
+    RUN_TEST(test_tcp_ack_is_emitted_from_connection_state);
     RUN_TEST(test_rx_extract_publishes_bounded_frame);
     RUN_TEST(test_probe_rejects_missing_reset_ack);
     unity_print_results();

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -45,7 +45,17 @@ void test_connection_builds_first_ack(void) {
     TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &view));
 }
 
+void test_build_and_parse_ack_payload(void) {
+    uint8_t segment[32] = {0}; uint8_t payload[4] = {'P','I','N','G'}; net_tcp_view_t view;
+    TEST_ASSERT_EQUAL(24, net_tcp_build_data(segment, sizeof(segment), 49152, 443, 101U, 701U, payload, sizeof(payload)));
+    TEST_ASSERT_EQUAL(0, net_tcp_parse(segment, 24, &view));
+    TEST_ASSERT_EQUAL(NET_TCP_FLAG_ACK, view.flags); TEST_ASSERT_EQUAL(101U, view.sequence);
+    TEST_ASSERT_EQUAL(701U, view.acknowledgment); TEST_ASSERT_EQUAL(4, view.payload_length);
+    TEST_ASSERT_EQUAL('P', view.payload[0]); TEST_ASSERT_EQUAL('G', view.payload[3]);
+    TEST_ASSERT_NOT_EQUAL(0, net_tcp_build_data(segment, 23, 49152, 443, 101U, 701U, payload, sizeof(payload)));
+}
+
 int main(void) {
-    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); unity_print_results(); unity_cleanup();
+    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); unity_print_results(); unity_cleanup();
     return (unity_stats.tests_failed == 0) ? 0 : 1;
 }


### PR DESCRIPTION
## Résumé

- AOS-151 raccorde l'état TCP caller-owned à l'émission du premier ACK via NE2000;
- AOS-152 ajoute les segments TCP ACK+payload caller-owned;
- checksums TCP pseudo-en-tête IPv4 et IPv4;
- documentation française et suivi `docs/todo.md`.

## Validation locale

- `make test-all`: 297/297 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ne2k-status`: réussi;
- `make qemu-ai-provider`: un premier smoke a échoué sans sortie `Runtime IA bare-metal`, puis a réussi à la relance immédiate.

## Limites explicites

Pas encore de retransmission, fenêtre/congestion, fermeture TCP, TLS, HTTP ni appel LLM en ligne de bout en bout. L'état et les buffers restent caller-owned.