### PR TITLE
Lots 153-154: séquences TCP et retransmission bornée

### DIFF
--- a/docs/aos153_154_tcp_sequence_retransmit.md
+++ b/docs/aos153_154_tcp_sequence_retransmit.md
@@ -1,0 +1,17 @@
+# AOS-153/AOS-154 — Progression TCP et retransmission bornée
+
+AOS-153 ajoute la progression explicite des numéros de séquence. Après émission confirmée par l’appelant, `net_tcp_connection_commit_send` avance `local_sequence` de la longueur du payload. Pour la réception, `net_tcp_connection_accept_data` vérifie les ports, le drapeau ACK, le numéro de séquence attendu et l’acquittement compatible avant d’avancer `remote_sequence` et de retourner la longueur acceptée.
+
+AOS-154 ajoute uniquement les métadonnées nécessaires à une retransmission bornée : pointeur vers le payload appartenant à l’appelant, longueur, compteur courant et limite de tentatives. Aucune donnée n’est copiée et aucun timer n’est créé. L’appelant doit piloter la temporisation, reconstruire le segment avec la vue caller-owned et appeler `net_tcp_connection_note_retransmit` après une tentative autorisée.
+
+| Élément | État réel |
+|---|---|
+| Progression du sequence local après envoi confirmé | Implémentée. |
+| Acceptation de données en séquence | Implémentée. |
+| Rejet d’un segment hors séquence | Implémenté. |
+| Métadonnées de retransmission caller-owned | Implémentées. |
+| Limite stricte de tentatives | Implémentée. |
+| Timer, RTO, fast retransmit et congestion | Non implémentés. |
+| TLS, HTTP et LLM en ligne | Non fonctionnels de bout en bout. |
+
+Les tests ciblés TCP passent après ces ajouts. La validation globale et la publication de la PR correspondante restent obligatoires avant fusion.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -99,3 +99,7 @@ Le prochain lot logique est AOS-152 : codec TCP avec données caller-owned et é
 ### AOS-152 — données TCP caller-owned
 
 AOS-152 ajoute le codec `ACK+payload` et `ne2k_tcp_data`, avec longueur IPv4 exacte, checksums TCP/IPv4 et contrôles de capacité. La suite locale atteint 297 tests verts. Le smoke `qemu-ai-provider` a échoué une première fois sur l’absence de sortie `Runtime IA bare-metal`, puis a réussi lors d’une relance immédiate ; le smoke `qemu-ne2k-status` est vert. Cette anomalie de smoke IA reste à surveiller séparément du chemin TCP.
+
+### AOS-153/AOS-154 — séquences, ACK reçus et retransmission bornée
+
+AOS-153 fait progresser explicitement `local_sequence` après envoi confirmé et `remote_sequence` après acceptation d’un payload en séquence. AOS-154 conserve une vue caller-owned du dernier payload et borne le nombre de retransmissions autorisées. Aucun timer, RTO, mécanisme de congestion ou stockage copié n’est introduit. La validation complète atteint désormais 299 tests verts, avec build i386 et deux smokes QEMU réussis.

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -77,7 +77,8 @@ int net_tcp_connection_open(net_tcp_connection_t* connection,uint16_t local_port
     if (!connection || local_port==0U || remote_port==0U) return -1;
     connection->local_port=local_port; connection->remote_port=remote_port;
     connection->local_sequence=local_sequence+1U; connection->remote_sequence=0U;
-    connection->state=NET_TCP_STATE_SYN_SENT; return 0;
+    connection->pending_payload=0; connection->pending_length=0U; connection->retransmit_count=0U;
+    connection->retransmit_limit=0U; connection->state=NET_TCP_STATE_SYN_SENT; return 0;
 }
 
 int net_tcp_connection_accept_syn_ack(net_tcp_connection_t* connection,const net_tcp_view_t* view) {
@@ -92,6 +93,39 @@ int net_tcp_connection_build_ack(const net_tcp_connection_t* connection,uint8_t*
     if (!connection || connection->state!=NET_TCP_STATE_ESTABLISHED) return -1;
     return net_tcp_build_ack(segment,capacity,connection->local_port,connection->remote_port,
                              connection->local_sequence,connection->remote_sequence);
+}
+
+int net_tcp_connection_commit_send(net_tcp_connection_t* connection,uint16_t payload_length) {
+    if (!connection || connection->state!=NET_TCP_STATE_ESTABLISHED || payload_length == 0U) return -1;
+    connection->local_sequence += payload_length; return 0;
+}
+
+int net_tcp_connection_accept_data(net_tcp_connection_t* connection,const net_tcp_view_t* view,
+                                   uint16_t* accepted_length) {
+    if (!connection || !view || !accepted_length || connection->state != NET_TCP_STATE_ESTABLISHED) return -1;
+    if (view->source_port != connection->remote_port || view->destination_port != connection->local_port ||
+        (view->flags & NET_TCP_FLAG_ACK) == 0U || view->sequence != connection->remote_sequence ||
+        view->acknowledgment > connection->local_sequence) return -2;
+    *accepted_length = view->payload_length;
+    connection->remote_sequence += view->payload_length;
+    return 0;
+}
+
+int net_tcp_connection_track_send(net_tcp_connection_t* connection,const uint8_t* payload,
+                                  uint16_t payload_length,uint8_t retransmit_limit) {
+    if (!connection || !payload || payload_length == 0U || connection->state != NET_TCP_STATE_ESTABLISHED) return -1;
+    connection->pending_payload=payload; connection->pending_length=payload_length;
+    connection->retransmit_count=0U; connection->retransmit_limit=retransmit_limit; return 0;
+}
+
+int net_tcp_connection_retransmit_allowed(const net_tcp_connection_t* connection) {
+    if (!connection || !connection->pending_payload || connection->pending_length == 0U) return 0;
+    return connection->retransmit_count < connection->retransmit_limit;
+}
+
+int net_tcp_connection_note_retransmit(net_tcp_connection_t* connection) {
+    if (!net_tcp_connection_retransmit_allowed(connection)) return -1;
+    connection->retransmit_count++; return 0;
 }
 
 int net_tcp_parse(const uint8_t* segment,uint32_t length,net_tcp_view_t* out) {

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -29,6 +29,10 @@ typedef struct {
     uint16_t remote_port;
     uint32_t local_sequence;
     uint32_t remote_sequence;
+    const uint8_t* pending_payload;
+    uint16_t pending_length;
+    uint8_t retransmit_count;
+    uint8_t retransmit_limit;
     uint8_t state;
 } net_tcp_connection_t;
 
@@ -61,5 +65,14 @@ int net_tcp_connection_accept_syn_ack(net_tcp_connection_t* connection,
                                       const net_tcp_view_t* view);
 int net_tcp_connection_build_ack(const net_tcp_connection_t* connection,
                                  uint8_t* segment, uint32_t capacity);
+int net_tcp_connection_commit_send(net_tcp_connection_t* connection, uint16_t payload_length);
+int net_tcp_connection_accept_data(net_tcp_connection_t* connection,
+                                   const net_tcp_view_t* view,
+                                   uint16_t* accepted_length);
+int net_tcp_connection_track_send(net_tcp_connection_t* connection,
+                                  const uint8_t* payload, uint16_t payload_length,
+                                  uint8_t retransmit_limit);
+int net_tcp_connection_retransmit_allowed(const net_tcp_connection_t* connection);
+int net_tcp_connection_note_retransmit(net_tcp_connection_t* connection);
 
 #endif

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -55,7 +55,35 @@ void test_build_and_parse_ack_payload(void) {
     TEST_ASSERT_NOT_EQUAL(0, net_tcp_build_data(segment, 23, 49152, 443, 101U, 701U, payload, sizeof(payload)));
 }
 
+void test_connection_advances_sequences_and_accepts_data(void) {
+    net_tcp_connection_t connection; net_tcp_view_t view; uint16_t accepted = 0U;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    view.source_port = 443; view.destination_port = 49152; view.sequence = 700U; view.acknowledgment = 101U;
+    view.flags = NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &view));
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_commit_send(&connection, 4U));
+    TEST_ASSERT_EQUAL(105U, connection.local_sequence);
+    view.flags = NET_TCP_FLAG_ACK; view.sequence = 701U; view.acknowledgment = 105U; view.payload_length = 3U;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_data(&connection, &view, &accepted));
+    TEST_ASSERT_EQUAL(3U, accepted); TEST_ASSERT_EQUAL(704U, connection.remote_sequence);
+    view.sequence = 703U; TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_accept_data(&connection, &view, &accepted));
+    TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_commit_send(&connection, 0U));
+}
+
+void test_bounded_retransmission_metadata(void) {
+    net_tcp_connection_t connection; uint8_t payload[2] = {'O','K'};
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    { net_tcp_view_t syn_ack = {443, 49152, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &syn_ack)); }
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_track_send(&connection, payload, sizeof(payload), 2U));
+    TEST_ASSERT_EQUAL(1, net_tcp_connection_retransmit_allowed(&connection));
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_note_retransmit(&connection));
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_note_retransmit(&connection));
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_retransmit_allowed(&connection));
+    TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_note_retransmit(&connection));
+}
+
 int main(void) {
-    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); unity_print_results(); unity_cleanup();
+    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); RUN_TEST(test_connection_advances_sequences_and_accepts_data); RUN_TEST(test_bounded_retransmission_metadata); unity_print_results(); unity_cleanup();
     return (unity_stats.tests_failed == 0) ? 0 : 1;
 }


### PR DESCRIPTION
## Résumé

- AOS-153 : progression explicite des séquences locales et distantes, acceptation stricte des données en séquence;
- AOS-154 : métadonnées caller-owned pour retransmission bornée, sans copie ni allocation;
- documentation française et suivi du backlog.

## Validation

- `make test-all`: 299/299 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: smoke réussi;
- `make qemu-ne2k-status`: smoke réussi.

Les timers, RTO, congestion, fermeture TCP, TLS, HTTP et LLM en ligne restent hors périmètre.