### PR TITLE
Lots 155-158: retransmission et fermeture TCP NE2000

### DIFF
--- a/docs/aos155_158_tcp_retransmit_close.md
+++ b/docs/aos155_158_tcp_retransmit_close.md
@@ -1,0 +1,19 @@
+# AOS-155 à AOS-158 — Retransmission et fermeture TCP caller-owned
+
+AOS-155 raccorde la retransmission bornée au chemin NE2000. `ne2k_tcp_retransmit` réutilise le pointeur et la longueur conservés dans `net_tcp_connection_t`, reconstruit le segment avec le même numéro de séquence logique, transmet la trame et incrémente le compteur seulement après succès de la transmission. La temporisation reste pilotée par l’appelant ; aucun timer noyau n’est introduit.
+
+AOS-156 ajoute la validation d’un ACK distant. Les ports, le drapeau ACK et la borne d’acquittement sont contrôlés. Lorsqu’un payload pending est confirmé, seules ses métadonnées sont réinitialisées ; aucune libération mémoire n’est effectuée puisque le stockage appartient à l’appelant.
+
+AOS-157 et AOS-158 ajoutent le codec FIN+ACK, les états `FIN_WAIT_1`, `FIN_WAIT_2`, `CLOSE_WAIT` et `CLOSED`, ainsi que l’émission NE2000 du FIN. La transition vers `FIN_WAIT_1` est publiée après succès TX. Un ACK distant fait progresser `FIN_WAIT_1` vers `FIN_WAIT_2`, et un FIN reçu dans `FIN_WAIT_2` clôt la connexion après consommation de son numéro de séquence. Les états `CLOSE_WAIT` et `FIN_WAIT_2` peuvent construire un ACK caller-owned.
+
+| Fonctionnalité | Statut |
+|---|---|
+| Retransmission NE2000 bornée | Implémentée. |
+| Confirmation et purge du pending | Implémentée. |
+| Codec FIN+ACK | Implémenté. |
+| Émission FIN+ACK via NE2000 | Implémentée. |
+| États FIN_WAIT_1/2, CLOSE_WAIT/CLOSED | Implémentés minimalement. |
+| Timers/RTO/congestion | Non implémentés. |
+| TLS, HTTP et appels LLM en ligne | Non fonctionnels de bout en bout. |
+
+Les tests ciblés TCP et NE2000 couvrent la reprise du sequence, la limite de retransmission, l’ACK final, les transitions FIN et l’ACK après FIN distant.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -103,3 +103,7 @@ AOS-152 ajoute le codec `ACK+payload` et `ne2k_tcp_data`, avec longueur IPv4 exa
 ### AOS-153/AOS-154 — séquences, ACK reçus et retransmission bornée
 
 AOS-153 fait progresser explicitement `local_sequence` après envoi confirmé et `remote_sequence` après acceptation d’un payload en séquence. AOS-154 conserve une vue caller-owned du dernier payload et borne le nombre de retransmissions autorisées. Aucun timer, RTO, mécanisme de congestion ou stockage copié n’est introduit. La validation complète atteint désormais 299 tests verts, avec build i386 et deux smokes QEMU réussis.
+
+### AOS-155 à AOS-158 — retransmission, ACK final et fermeture TCP
+
+Les lots ajoutent la retransmission NE2000 caller-owned, la confirmation et purge du payload pending, le codec et l’émission FIN+ACK, puis les transitions FIN_WAIT_1, FIN_WAIT_2, CLOSE_WAIT et CLOSED. La validation complète atteint 301 tests verts, avec build i386, smoke IA et smoke NE2000 réussis. Les timers RTO, la congestion, TLS, HTTP et l’appel LLM en ligne restent hors périmètre fonctionnel.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -198,6 +198,32 @@ int ne2k_tcp_ack(ne2k_device_t* device, const ne2k_io_t* io,
     return ne2k_tx_submit(device, io, frame, (uint16_t)(NET_ETHERNET_HEADER_SIZE + 40U));
 }
 
+int ne2k_tcp_fin(ne2k_device_t* device, const ne2k_io_t* io,
+                 const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
+                 const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                 net_tcp_connection_t* connection) {
+    uint8_t destination_mac[6]; uint16_t i; uint32_t sum = 0U; int tcp_length, status; net_tcp_connection_t next;
+    if (!device || !io || !cache || !frame || !local_ip || !remote_ip || !connection || !device->mac_valid ||
+        frame_capacity < NET_ETHERNET_HEADER_SIZE + 40U || connection->state != NET_TCP_STATE_ESTABLISHED) return -1;
+    if (net_arp_cache_lookup(cache, remote_ip, destination_mac) != 0) return -2;
+    for (i = 0; i < 6U; ++i) { frame[i] = destination_mac[i]; frame[6U+i] = device->mac[i]; }
+    frame[12] = 0x08U; frame[13] = 0x00U;
+    for (i = 0; i < 40U; ++i) frame[NET_ETHERNET_HEADER_SIZE+i] = 0U;
+    frame[14] = 0x45U; frame[16] = 0U; frame[17] = 40U; frame[22] = 64U; frame[23] = NET_TCP_PROTOCOL;
+    for (i = 0; i < 4U; ++i) { frame[26U+i] = local_ip[i]; frame[30U+i] = remote_ip[i]; }
+    next = *connection;
+    tcp_length = net_tcp_connection_begin_close(&next, frame + 34U, frame_capacity - 34U);
+    if (tcp_length < 0) return -3;
+    { uint16_t checksum = net_tcp_checksum_ipv4(local_ip, remote_ip, frame + 34U, (uint16_t)tcp_length);
+      frame[50U] = (uint8_t)(checksum >> 8); frame[51U] = (uint8_t)checksum; }
+    for (i = 0; i < 20U; i += 2U) { sum += ((uint16_t)frame[14U+i] << 8) | frame[15U+i]; while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16); }
+    sum = (~sum) & 0xffffU; frame[24] = (uint8_t)(sum >> 8); frame[25] = (uint8_t)sum;
+    status = ne2k_tx_submit(device, io, frame, NET_ETHERNET_HEADER_SIZE + 40U);
+    if (status != 0) return status;
+    *connection = next;
+    return 0;
+}
+
 int ne2k_tcp_data(ne2k_device_t* device, const ne2k_io_t* io,
                   const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
                   const uint8_t local_ip[4], const uint8_t remote_ip[4],
@@ -226,6 +252,20 @@ int ne2k_tcp_data(ne2k_device_t* device, const ne2k_io_t* io,
     for (i = 0; i < 20U; i += 2U) { sum += ((uint16_t)frame[14U+i] << 8) | frame[15U+i]; while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16); }
     sum = (~sum) & 0xffffU; frame[24] = (uint8_t)(sum >> 8); frame[25] = (uint8_t)sum;
     return ne2k_tx_submit(device, io, frame, (uint16_t)(NET_ETHERNET_HEADER_SIZE + ip_length));
+}
+
+int ne2k_tcp_retransmit(ne2k_device_t* device, const ne2k_io_t* io,
+                        const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
+                        const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                        net_tcp_connection_t* connection) {
+    net_tcp_connection_t retransmit_view; int status;
+    if (!connection || !net_tcp_connection_retransmit_allowed(connection)) return -1;
+    retransmit_view = *connection;
+    retransmit_view.local_sequence = connection->local_sequence - connection->pending_length;
+    status = ne2k_tcp_data(device, io, cache, frame, frame_capacity, local_ip, remote_ip,
+                           &retransmit_view, connection->pending_payload, connection->pending_length);
+    if (status != 0) return status;
+    return net_tcp_connection_note_retransmit(connection);
 }
 
 int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -132,12 +132,22 @@ int ne2k_tcp_ack(ne2k_device_t* device, const ne2k_io_t* io,
                  const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
                  const uint8_t local_ip[4], const uint8_t remote_ip[4],
                  const net_tcp_connection_t* connection);
+/* Construit et émet le FIN+ACK caller-owned de fermeture. */
+int ne2k_tcp_fin(ne2k_device_t* device, const ne2k_io_t* io,
+                 const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
+                 const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                 net_tcp_connection_t* connection);
 /* Construit et émet un segment TCP ACK+payload caller-owned. */
 int ne2k_tcp_data(ne2k_device_t* device, const ne2k_io_t* io,
                   const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
                   const uint8_t local_ip[4], const uint8_t remote_ip[4],
                   const net_tcp_connection_t* connection, const uint8_t* payload,
                   uint16_t payload_length);
+/* Retransmet le dernier payload caller-owned sans avancer le sequence. */
+int ne2k_tcp_retransmit(ne2k_device_t* device, const ne2k_io_t* io,
+                        const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
+                        const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                        net_tcp_connection_t* connection);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -27,6 +27,12 @@ int net_tcp_build_ack(uint8_t* segment, uint32_t capacity, uint16_t source_port,
     return build_control(segment, capacity, source_port, destination_port, sequence, acknowledgment, NET_TCP_FLAG_ACK);
 }
 
+int net_tcp_build_fin_ack(uint8_t* segment, uint32_t capacity, uint16_t source_port,
+                          uint16_t destination_port, uint32_t sequence, uint32_t acknowledgment) {
+    return build_control(segment, capacity, source_port, destination_port, sequence, acknowledgment,
+                         NET_TCP_FLAG_FIN | NET_TCP_FLAG_ACK);
+}
+
 int net_tcp_build_data(uint8_t* segment, uint32_t capacity, uint16_t source_port,
                        uint16_t destination_port, uint32_t sequence, uint32_t acknowledgment,
                        const uint8_t* payload, uint16_t payload_length) {
@@ -90,7 +96,9 @@ int net_tcp_connection_accept_syn_ack(net_tcp_connection_t* connection,const net
 }
 
 int net_tcp_connection_build_ack(const net_tcp_connection_t* connection,uint8_t* segment,uint32_t capacity) {
-    if (!connection || connection->state!=NET_TCP_STATE_ESTABLISHED) return -1;
+    if (!connection || (connection->state != NET_TCP_STATE_ESTABLISHED &&
+                        connection->state != NET_TCP_STATE_FIN_WAIT_2 &&
+                        connection->state != NET_TCP_STATE_CLOSE_WAIT)) return -1;
     return net_tcp_build_ack(segment,capacity,connection->local_port,connection->remote_port,
                              connection->local_sequence,connection->remote_sequence);
 }
@@ -126,6 +134,39 @@ int net_tcp_connection_retransmit_allowed(const net_tcp_connection_t* connection
 int net_tcp_connection_note_retransmit(net_tcp_connection_t* connection) {
     if (!net_tcp_connection_retransmit_allowed(connection)) return -1;
     connection->retransmit_count++; return 0;
+}
+
+int net_tcp_connection_begin_close(net_tcp_connection_t* connection,uint8_t* segment,uint32_t capacity) {
+    int length;
+    if (!connection || connection->state != NET_TCP_STATE_ESTABLISHED) return -1;
+    length = net_tcp_build_fin_ack(segment, capacity, connection->local_port, connection->remote_port,
+                                   connection->local_sequence, connection->remote_sequence);
+    if (length < 0) return -2;
+    connection->local_sequence++; connection->state = NET_TCP_STATE_FIN_WAIT_1;
+    return length;
+}
+
+int net_tcp_connection_accept_ack(net_tcp_connection_t* connection,const net_tcp_view_t* view) {
+    if (!connection || !view || (connection->state != NET_TCP_STATE_ESTABLISHED && connection->state != NET_TCP_STATE_FIN_WAIT_1)) return -1;
+    if (view->source_port != connection->remote_port || view->destination_port != connection->local_port ||
+        (view->flags & NET_TCP_FLAG_ACK) == 0U || view->acknowledgment > connection->local_sequence) return -2;
+    if (connection->pending_length != 0U && view->acknowledgment < connection->local_sequence) return -3;
+    if (connection->pending_length != 0U) {
+        connection->pending_payload = 0; connection->pending_length = 0U;
+        connection->retransmit_count = 0U; connection->retransmit_limit = 0U;
+    }
+    if (connection->state == NET_TCP_STATE_FIN_WAIT_1 && view->acknowledgment == connection->local_sequence)
+        connection->state = NET_TCP_STATE_FIN_WAIT_2;
+    return 0;
+}
+
+int net_tcp_connection_accept_fin(net_tcp_connection_t* connection,const net_tcp_view_t* view) {
+    if (!connection || !view || (connection->state != NET_TCP_STATE_ESTABLISHED && connection->state != NET_TCP_STATE_FIN_WAIT_2)) return -1;
+    if (view->source_port != connection->remote_port || view->destination_port != connection->local_port ||
+        (view->flags & NET_TCP_FLAG_FIN) == 0U || view->sequence != connection->remote_sequence) return -2;
+    connection->remote_sequence++;
+    connection->state = (connection->state == NET_TCP_STATE_FIN_WAIT_2) ? NET_TCP_STATE_CLOSED : NET_TCP_STATE_CLOSE_WAIT;
+    return 0;
 }
 
 int net_tcp_parse(const uint8_t* segment,uint32_t length,net_tcp_view_t* out) {

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -13,6 +13,10 @@
 #define NET_TCP_STATE_CLOSED 0U
 #define NET_TCP_STATE_SYN_SENT 1U
 #define NET_TCP_STATE_ESTABLISHED 2U
+#define NET_TCP_STATE_FIN_WAIT_1 3U
+#define NET_TCP_STATE_FIN_WAIT_2 4U
+#define NET_TCP_STATE_CLOSE_WAIT 5U
+#define NET_TCP_STATE_LAST_ACK 6U
 
 typedef struct {
     uint16_t source_port;
@@ -74,5 +78,14 @@ int net_tcp_connection_track_send(net_tcp_connection_t* connection,
                                   uint8_t retransmit_limit);
 int net_tcp_connection_retransmit_allowed(const net_tcp_connection_t* connection);
 int net_tcp_connection_note_retransmit(net_tcp_connection_t* connection);
+int net_tcp_connection_accept_ack(net_tcp_connection_t* connection,
+                                  const net_tcp_view_t* view);
+int net_tcp_build_fin_ack(uint8_t* segment, uint32_t capacity,
+                          uint16_t source_port, uint16_t destination_port,
+                          uint32_t sequence, uint32_t acknowledgment);
+int net_tcp_connection_begin_close(net_tcp_connection_t* connection,
+                                   uint8_t* segment, uint32_t capacity);
+int net_tcp_connection_accept_fin(net_tcp_connection_t* connection,
+                                  const net_tcp_view_t* view);
 
 #endif

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -123,6 +123,21 @@ void test_tcp_ack_is_emitted_from_connection_state(void) {
       TEST_ASSERT_EQUAL(0, ne2k_tcp_data(&device, &io, &cache, frame, sizeof(frame), local_ip, remote_ip, &connection, payload, sizeof(payload)));
       TEST_ASSERT_EQUAL(44, ((uint16_t)frame[16] << 8) | frame[17]);
       TEST_ASSERT_EQUAL('P', frame[54]); TEST_ASSERT_EQUAL('G', frame[57]); }
+    { uint8_t payload[4] = {'P','I','N','G'}; uint32_t first_sequence;
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_track_send(&connection, payload, sizeof(payload), 1U));
+      TEST_ASSERT_EQUAL(0, ne2k_tcp_data(&device, &io, &cache, frame, sizeof(frame), local_ip, remote_ip, &connection, payload, sizeof(payload)));
+      first_sequence = ((uint32_t)frame[38] << 24) | ((uint32_t)frame[39] << 16) | ((uint32_t)frame[40] << 8) | frame[41];
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_commit_send(&connection, sizeof(payload)));
+      TEST_ASSERT_EQUAL(0, ne2k_tcp_retransmit(&device, &io, &cache, frame, sizeof(frame), local_ip, remote_ip, &connection));
+      TEST_ASSERT_EQUAL(first_sequence, ((uint32_t)frame[38] << 24) | ((uint32_t)frame[39] << 16) | ((uint32_t)frame[40] << 8) | frame[41]);
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_retransmit_allowed(&connection));
+      TEST_ASSERT_NOT_EQUAL(0, ne2k_tcp_retransmit(&device, &io, &cache, frame, sizeof(frame), local_ip, remote_ip, &connection)); }
+    { net_tcp_view_t syn_ack = {443, 49152, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &syn_ack));
+      TEST_ASSERT_EQUAL(0, ne2k_tcp_fin(&device, &io, &cache, frame, sizeof(frame), local_ip, remote_ip, &connection));
+      TEST_ASSERT_EQUAL(NET_TCP_STATE_FIN_WAIT_1, connection.state);
+      TEST_ASSERT_EQUAL((NET_TCP_FLAG_FIN | NET_TCP_FLAG_ACK), frame[47]); }
 }
 
 void test_rx_extract_publishes_bounded_frame(void) {

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -70,6 +70,43 @@ void test_connection_advances_sequences_and_accepts_data(void) {
     TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_commit_send(&connection, 0U));
 }
 
+void test_ack_confirms_pending_payload(void) {
+    net_tcp_connection_t connection; uint8_t payload[2] = {'O','K'}; net_tcp_view_t view;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    view = (net_tcp_view_t){443, 49152, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &view));
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_track_send(&connection, payload, sizeof(payload), 2U));
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_commit_send(&connection, sizeof(payload)));
+    view = (net_tcp_view_t){443, 49152, 701U, 103U, NET_TCP_FLAG_ACK, 0, 0};
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_ack(&connection, &view));
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_retransmit_allowed(&connection));
+    view.acknowledgment = 104U; TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_accept_ack(&connection, &view));
+}
+
+void test_fin_close_transitions(void) {
+    net_tcp_connection_t connection; net_tcp_view_t view; uint8_t segment[20] = {0};
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    view = (net_tcp_view_t){443, 49152, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &view));
+    TEST_ASSERT_EQUAL(20, net_tcp_connection_begin_close(&connection, segment, sizeof(segment)));
+    TEST_ASSERT_EQUAL((NET_TCP_FLAG_FIN | NET_TCP_FLAG_ACK), segment[13]);
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_FIN_WAIT_1, connection.state); TEST_ASSERT_EQUAL(102U, connection.local_sequence);
+    view.flags = NET_TCP_FLAG_ACK; view.acknowledgment = 102U; view.sequence = 700U;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_ack(&connection, &view));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_FIN_WAIT_2, connection.state);
+    view.flags = NET_TCP_FLAG_FIN | NET_TCP_FLAG_ACK; view.sequence = 701U;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_fin(&connection, &view));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_CLOSED, connection.state);
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    view.flags = NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK; view.sequence = 700U; view.acknowledgment = 101U;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &view));
+    view.flags = NET_TCP_FLAG_FIN | NET_TCP_FLAG_ACK; view.sequence = 701U; view.acknowledgment = 101U;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_fin(&connection, &view));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_CLOSE_WAIT, connection.state); TEST_ASSERT_EQUAL(702U, connection.remote_sequence);
+    TEST_ASSERT_EQUAL(20, net_tcp_connection_build_ack(&connection, segment, sizeof(segment)));
+    view.sequence = 704U; TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_accept_fin(&connection, &view));
+}
+
 void test_bounded_retransmission_metadata(void) {
     net_tcp_connection_t connection; uint8_t payload[2] = {'O','K'};
     TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
@@ -84,6 +121,6 @@ void test_bounded_retransmission_metadata(void) {
 }
 
 int main(void) {
-    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); RUN_TEST(test_connection_advances_sequences_and_accepts_data); RUN_TEST(test_bounded_retransmission_metadata); unity_print_results(); unity_cleanup();
+    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); RUN_TEST(test_connection_advances_sequences_and_accepts_data); RUN_TEST(test_ack_confirms_pending_payload); RUN_TEST(test_fin_close_transitions); RUN_TEST(test_bounded_retransmission_metadata); unity_print_results(); unity_cleanup();
     return (unity_stats.tests_failed == 0) ? 0 : 1;
 }


### PR DESCRIPTION
## Résumé

- AOS-155 : retransmission TCP NE2000 bornée et caller-owned;
- AOS-156 : validation ACK et purge du payload pending;
- AOS-157/AOS-158 : FIN+ACK, émission NE2000 et transitions de fermeture;
- documentation française mise à jour.

## Validation locale

- `make test-all`: 301/301 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: réussi;
- `make qemu-ne2k-status`: réussi.

Timers RTO, congestion, TLS, HTTP et appels LLM en ligne restent non fonctionnels de bout en bout.