### PR TITLE
Lots 159-162: réception TCP, fenêtre et checksums

### DIFF
--- a/docs/aos159_162_tcp_receive_window.md
+++ b/docs/aos159_162_tcp_receive_window.md
@@ -1,0 +1,21 @@
+# AOS-159 à AOS-162 — Envoi suivi d’ACK, réception et fenêtre TCP
+
+AOS-159 ajoute `net_tcp_connection_build_data`, qui construit un segment à partir du sequence courant et enregistre le payload fourni par l’appelant comme pending. Le sequence local n’avance qu’après `net_tcp_connection_commit_send`, ce qui sépare explicitement la construction, la transmission et la confirmation locale du TX.
+
+AOS-160 ajoute `ne2k_tcp_receive`. La primitive vérifie la trame Ethernet IPv4, la version et la longueur IPv4, le protocole TCP, les checksums IPv4 et TCP, puis délègue la validation des ports, du flag ACK et de la séquence à la connexion caller-owned. Le payload est copié uniquement dans le buffer fourni par l’appelant et sa capacité est contrôlée avant toute copie.
+
+AOS-161 ajoute une fenêtre de réception caller-owned. Elle est initialisée à une valeur maximale prudente, peut être configurée explicitement et diminue après chaque payload accepté. Un segment supérieur à la fenêtre restante est rejeté.
+
+AOS-162 durcit les contrôles cryptographiques de transport local avec validation du checksum IPv4 et du checksum TCP pseudo-en-tête IPv4 sur les trames reçues. Cette validation ne fournit pas TLS : elle protège uniquement l’intégrité de la trame TCP reçue au niveau IPv4/TCP.
+
+| Fonctionnalité | Statut réel |
+|---|---|
+| Construction data avec pending caller-owned | Implémentée. |
+| Commit du sequence après TX | Implémenté. |
+| Réception TCP NE2000 bornée | Implémentée. |
+| Checksum IPv4 en réception | Validé. |
+| Checksum TCP pseudo-en-tête en réception | Validé. |
+| Fenêtre de réception explicite | Implémentée. |
+| TLS, HTTP, congestion et LLM en ligne | Non fonctionnels de bout en bout. |
+
+Les tests ciblés TCP et NE2000 passent. La suite globale, le build i386 et les smokes QEMU restent à exécuter avant publication.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -107,3 +107,7 @@ AOS-153 fait progresser explicitement `local_sequence` après envoi confirmé et
 ### AOS-155 à AOS-158 — retransmission, ACK final et fermeture TCP
 
 Les lots ajoutent la retransmission NE2000 caller-owned, la confirmation et purge du payload pending, le codec et l’émission FIN+ACK, puis les transitions FIN_WAIT_1, FIN_WAIT_2, CLOSE_WAIT et CLOSED. La validation complète atteint 301 tests verts, avec build i386, smoke IA et smoke NE2000 réussis. Les timers RTO, la congestion, TLS, HTTP et l’appel LLM en ligne restent hors périmètre fonctionnel.
+
+### AOS-159 à AOS-162 — envoi suivi d’ACK, réception, fenêtre et checksums
+
+AOS-159 ajoute la construction data suivie d’un pending caller-owned avant commit TX. AOS-160 ajoute la réception TCP NE2000 bornée avec copie vers le buffer appelant. AOS-161 ajoute la fenêtre de réception explicite. AOS-162 valide les checksums IPv4 et TCP en réception. Validation : 304 tests verts, build i386 réussi, smoke IA réussi et smoke NE2000 réussi.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -268,6 +268,29 @@ int ne2k_tcp_retransmit(ne2k_device_t* device, const ne2k_io_t* io,
     return net_tcp_connection_note_retransmit(connection);
 }
 
+int ne2k_tcp_receive(const uint8_t* frame, uint16_t frame_length,
+                     net_tcp_connection_t* connection, uint8_t* payload,
+                     uint16_t payload_capacity, uint16_t* payload_length) {
+    uint16_t ip_offset = NET_ETHERNET_HEADER_SIZE, tcp_offset, ip_length, tcp_length, accepted, i;
+    net_tcp_view_t view;
+    if (!frame || !connection || !payload_length || frame_length < NET_ETHERNET_HEADER_SIZE + 40U) return -1;
+    if (frame[12] != 0x08U || frame[13] != 0x00U || (frame[ip_offset] >> 4) != 4U) return -2;
+    if ((frame[ip_offset + 9U]) != NET_TCP_PROTOCOL) return -3;
+    if (net_ipv4_checksum(frame + ip_offset, NET_IPV4_HEADER_SIZE) != 0U) return -4;
+    ip_length = (uint16_t)(((uint16_t)frame[ip_offset + 2U] << 8) | frame[ip_offset + 3U]);
+    if (ip_length < 40U || (uint32_t)NET_ETHERNET_HEADER_SIZE + ip_length > frame_length) return -5;
+    tcp_offset = (uint16_t)(ip_offset + ((frame[ip_offset] & 0x0fU) * 4U));
+    if (tcp_offset + NET_TCP_HEADER_SIZE > frame_length) return -6;
+    tcp_length = (uint16_t)(ip_length - (tcp_offset - ip_offset));
+    if (net_tcp_checksum_ipv4(frame + ip_offset + 12U, frame + ip_offset + 16U,
+                              frame + tcp_offset, tcp_length) != 0U) return -7;
+    if (net_tcp_parse(frame + tcp_offset, tcp_length, &view) != 0) return -8;
+    if (view.payload_length > payload_capacity || (!payload && view.payload_length != 0U)) return -8;
+    if (net_tcp_connection_accept_data(connection, &view, &accepted) != 0) return -9;
+    for (i = 0; i < accepted; ++i) payload[i] = view.payload[i];
+    *payload_length = accepted; return 0;
+}
+
 int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,
                     uint8_t* frame, uint16_t frame_capacity, uint16_t attempts,
                     uint16_t expected_id, net_dns_a_result_t* result) {

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -148,6 +148,10 @@ int ne2k_tcp_retransmit(ne2k_device_t* device, const ne2k_io_t* io,
                         const net_arp_cache_t* cache, uint8_t* frame, uint16_t frame_capacity,
                         const uint8_t local_ip[4], const uint8_t remote_ip[4],
                         net_tcp_connection_t* connection);
+/* Extrait un segment TCP reçu vers un payload caller-owned borné. */
+int ne2k_tcp_receive(const uint8_t* frame, uint16_t frame_length,
+                     net_tcp_connection_t* connection, uint8_t* payload,
+                     uint16_t payload_capacity, uint16_t* payload_length);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -84,7 +84,8 @@ int net_tcp_connection_open(net_tcp_connection_t* connection,uint16_t local_port
     connection->local_port=local_port; connection->remote_port=remote_port;
     connection->local_sequence=local_sequence+1U; connection->remote_sequence=0U;
     connection->pending_payload=0; connection->pending_length=0U; connection->retransmit_count=0U;
-    connection->retransmit_limit=0U; connection->state=NET_TCP_STATE_SYN_SENT; return 0;
+    connection->retransmit_limit=0U; connection->receive_window=0xffffU;
+    connection->state=NET_TCP_STATE_SYN_SENT; return 0;
 }
 
 int net_tcp_connection_accept_syn_ack(net_tcp_connection_t* connection,const net_tcp_view_t* view) {
@@ -103,6 +104,18 @@ int net_tcp_connection_build_ack(const net_tcp_connection_t* connection,uint8_t*
                              connection->local_sequence,connection->remote_sequence);
 }
 
+int net_tcp_connection_build_data(net_tcp_connection_t* connection,uint8_t* segment,uint32_t capacity,
+                                  const uint8_t* payload,uint16_t payload_length,uint8_t retransmit_limit) {
+    int length;
+    if (!connection || !segment || !payload || payload_length == 0U || connection->state != NET_TCP_STATE_ESTABLISHED) return -1;
+    length = net_tcp_build_data(segment, capacity, connection->local_port, connection->remote_port,
+                                connection->local_sequence, connection->remote_sequence,
+                                payload, payload_length);
+    if (length < 0) return -2;
+    if (net_tcp_connection_track_send(connection, payload, payload_length, retransmit_limit) != 0) return -3;
+    return length;
+}
+
 int net_tcp_connection_commit_send(net_tcp_connection_t* connection,uint16_t payload_length) {
     if (!connection || connection->state!=NET_TCP_STATE_ESTABLISHED || payload_length == 0U) return -1;
     connection->local_sequence += payload_length; return 0;
@@ -113,10 +126,16 @@ int net_tcp_connection_accept_data(net_tcp_connection_t* connection,const net_tc
     if (!connection || !view || !accepted_length || connection->state != NET_TCP_STATE_ESTABLISHED) return -1;
     if (view->source_port != connection->remote_port || view->destination_port != connection->local_port ||
         (view->flags & NET_TCP_FLAG_ACK) == 0U || view->sequence != connection->remote_sequence ||
-        view->acknowledgment > connection->local_sequence) return -2;
+        view->acknowledgment > connection->local_sequence || view->payload_length > connection->receive_window) return -2;
     *accepted_length = view->payload_length;
     connection->remote_sequence += view->payload_length;
+    connection->receive_window = (uint16_t)(connection->receive_window - view->payload_length);
     return 0;
+}
+
+int net_tcp_connection_set_receive_window(net_tcp_connection_t* connection,uint16_t receive_window) {
+    if (!connection) return -1;
+    connection->receive_window = receive_window; return 0;
 }
 
 int net_tcp_connection_track_send(net_tcp_connection_t* connection,const uint8_t* payload,

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -37,6 +37,7 @@ typedef struct {
     uint16_t pending_length;
     uint8_t retransmit_count;
     uint8_t retransmit_limit;
+    uint16_t receive_window;
     uint8_t state;
 } net_tcp_connection_t;
 
@@ -69,10 +70,16 @@ int net_tcp_connection_accept_syn_ack(net_tcp_connection_t* connection,
                                       const net_tcp_view_t* view);
 int net_tcp_connection_build_ack(const net_tcp_connection_t* connection,
                                  uint8_t* segment, uint32_t capacity);
+int net_tcp_connection_build_data(net_tcp_connection_t* connection,
+                                  uint8_t* segment, uint32_t capacity,
+                                  const uint8_t* payload, uint16_t payload_length,
+                                  uint8_t retransmit_limit);
 int net_tcp_connection_commit_send(net_tcp_connection_t* connection, uint16_t payload_length);
 int net_tcp_connection_accept_data(net_tcp_connection_t* connection,
                                    const net_tcp_view_t* view,
                                    uint16_t* accepted_length);
+int net_tcp_connection_set_receive_window(net_tcp_connection_t* connection,
+                                           uint16_t receive_window);
 int net_tcp_connection_track_send(net_tcp_connection_t* connection,
                                   const uint8_t* payload, uint16_t payload_length,
                                   uint8_t retransmit_limit);

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -140,6 +140,25 @@ void test_tcp_ack_is_emitted_from_connection_state(void) {
       TEST_ASSERT_EQUAL((NET_TCP_FLAG_FIN | NET_TCP_FLAG_ACK), frame[47]); }
 }
 
+void test_tcp_receive_copies_bounded_payload(void) {
+    uint8_t frame[128] = {0}, payload[4] = {0}; net_tcp_connection_t connection; uint16_t length = 0U, i;
+    uint8_t tcp_payload[4] = {'P','O','N','G'}; uint8_t remote_ip[4] = {10,0,2,2}; uint8_t local_ip[4] = {10,0,2,15}; uint16_t checksum;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    { net_tcp_view_t syn_ack = {443, 49152, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &syn_ack)); }
+    for (i = 0; i < 6U; ++i) { frame[i] = 0x52U; frame[6U+i] = 0x02U; }
+    frame[12] = 0x08U; frame[13] = 0x00U; frame[14] = 0x45U; frame[16] = 0U; frame[17] = 44U; frame[22] = 64U; frame[23] = NET_TCP_PROTOCOL;
+    for (i = 0; i < 4U; ++i) { frame[26U+i] = remote_ip[i]; frame[30U+i] = local_ip[i]; }
+    { uint16_t ip_checksum = net_ipv4_checksum(frame + 14U, 20U); frame[24] = (uint8_t)(ip_checksum >> 8); frame[25] = (uint8_t)ip_checksum; }
+    TEST_ASSERT_EQUAL(24, net_tcp_build_data(frame + 34U, sizeof(frame) - 34U, 443, 49152, 701U, 101U, tcp_payload, sizeof(tcp_payload)));
+    checksum = net_tcp_checksum_ipv4(remote_ip, local_ip, frame + 34U, 24U); frame[50] = (uint8_t)(checksum >> 8); frame[51] = (uint8_t)checksum;
+    TEST_ASSERT_EQUAL(0, ne2k_tcp_receive(frame, 58U, &connection, payload, sizeof(payload), &length));
+    TEST_ASSERT_EQUAL(4U, length); TEST_ASSERT_EQUAL('P', payload[0]); TEST_ASSERT_EQUAL('G', payload[3]);
+    frame[50] ^= 0xffU; TEST_ASSERT_NOT_EQUAL(0, ne2k_tcp_receive(frame, 58U, &connection, payload, sizeof(payload), &length));
+    frame[50] ^= 0xffU; frame[24] ^= 0xffU; TEST_ASSERT_NOT_EQUAL(0, ne2k_tcp_receive(frame, 58U, &connection, payload, sizeof(payload), &length));
+    TEST_ASSERT_NOT_EQUAL(0, ne2k_tcp_receive(frame, 58U, &connection, payload, 3U, &length));
+}
+
 void test_rx_extract_publishes_bounded_frame(void) {
     uint8_t storage[NET_NIC_QUEUE_CAPACITY * 64U] = {0};
     uint8_t dma[9] = {NE2K_RX_STATUS_OK, 0, 9, 0, 1, 2, 3, 4, 5};
@@ -162,6 +181,7 @@ void test_probe_rejects_missing_reset_ack(void) {
 int main(void) {
     unity_init();
     RUN_TEST(test_probe_and_prepare_use_injected_io);
+    RUN_TEST(test_tcp_receive_copies_bounded_payload);
     RUN_TEST(test_tcp_ack_is_emitted_from_connection_state);
     RUN_TEST(test_rx_extract_publishes_bounded_frame);
     RUN_TEST(test_probe_rejects_missing_reset_ack);

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -70,6 +70,30 @@ void test_connection_advances_sequences_and_accepts_data(void) {
     TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_commit_send(&connection, 0U));
 }
 
+void test_receive_window_is_bounded(void) {
+    net_tcp_connection_t connection; net_tcp_view_t view; uint16_t accepted = 0U;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    view = (net_tcp_view_t){443, 49152, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &view));
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_set_receive_window(&connection, 3U));
+    view.flags = NET_TCP_FLAG_ACK; view.sequence = 701U; view.acknowledgment = 101U; view.payload_length = 2U;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_data(&connection, &view, &accepted));
+    TEST_ASSERT_EQUAL(1U, connection.receive_window);
+    view.sequence = 703U; view.payload_length = 2U;
+    TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_accept_data(&connection, &view, &accepted));
+}
+
+void test_build_data_tracks_until_commit(void) {
+    net_tcp_connection_t connection; uint8_t segment[24]; uint8_t payload[4] = {'P','I','N','G'};
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    { net_tcp_view_t syn_ack = {443, 49152, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &syn_ack)); }
+    TEST_ASSERT_EQUAL(24, net_tcp_connection_build_data(&connection, segment, sizeof(segment), payload, sizeof(payload), 3U));
+    TEST_ASSERT_EQUAL(101U, connection.local_sequence); TEST_ASSERT_EQUAL(payload, connection.pending_payload);
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_commit_send(&connection, sizeof(payload)));
+    TEST_ASSERT_EQUAL(105U, connection.local_sequence); TEST_ASSERT_EQUAL(1, net_tcp_connection_retransmit_allowed(&connection));
+}
+
 void test_ack_confirms_pending_payload(void) {
     net_tcp_connection_t connection; uint8_t payload[2] = {'O','K'}; net_tcp_view_t view;
     TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
@@ -121,6 +145,6 @@ void test_bounded_retransmission_metadata(void) {
 }
 
 int main(void) {
-    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); RUN_TEST(test_connection_advances_sequences_and_accepts_data); RUN_TEST(test_ack_confirms_pending_payload); RUN_TEST(test_fin_close_transitions); RUN_TEST(test_bounded_retransmission_metadata); unity_print_results(); unity_cleanup();
+    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); RUN_TEST(test_connection_advances_sequences_and_accepts_data); RUN_TEST(test_receive_window_is_bounded); RUN_TEST(test_build_data_tracks_until_commit); RUN_TEST(test_ack_confirms_pending_payload); RUN_TEST(test_fin_close_transitions); RUN_TEST(test_bounded_retransmission_metadata); unity_print_results(); unity_cleanup();
     return (unity_stats.tests_failed == 0) ? 0 : 1;
 }


### PR DESCRIPTION
## Résumé

- AOS-159 : construction de données avec pending caller-owned avant commit TX;
- AOS-160 : réception TCP NE2000 bornée et copie vers buffer appelant;
- AOS-161 : fenêtre de réception explicitement contrôlée;
- AOS-162 : validation checksums IPv4 et TCP en réception;
- documentation française mise à jour.

## Validation locale

- `make test-all`: 304/304 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: réussi;
- `make qemu-ne2k-status`: réussi.

TLS, HTTP, congestion et appels LLM en ligne restent non fonctionnels de bout en bout.