### PR TITLE
Lots 163-165: polling TCP NE2000 caller-owned

### DIFF
--- a/docs/aos163_165_tcp_poll_orchestration.md
+++ b/docs/aos163_165_tcp_poll_orchestration.md
@@ -1,0 +1,19 @@
+# AOS-163 à AOS-165 — Polling TCP et orchestration RX caller-owned
+
+AOS-163 ajoute `ne2k_tcp_poll`, une primitive d’orchestration qui lit une trame via `ne2k_rx_poll`, puis appelle `ne2k_tcp_receive` pour vérifier IPv4/TCP, checksums, ports, séquence et fenêtre avant copie du payload. Tous les buffers restent fournis par l’appelant.
+
+AOS-164 formalise la sémantique non bloquante du polling : une absence de paquet retourne `1` et publie `payload_length = 0`. Une erreur de périphérique ou de trame conserve également une longueur de payload nulle, ce qui évite de réutiliser une valeur stale de l’appelant.
+
+AOS-165 regroupe les contrôles RX déjà ajoutés — bornes de trame, capacité de payload, checksum IPv4, checksum TCP pseudo-en-tête IPv4 et séquence TCP — dans un chemin utilisable directement par l’orchestrateur NE2000 sans allocation ni buffer global.
+
+| Élément | Statut |
+|---|---|
+| Polling NE2000 puis extraction TCP | Implémenté. |
+| RX vide non bloquant | Implémenté. |
+| Longueur caller-owned réinitialisée | Implémentée. |
+| Checksums IPv4/TCP | Validés avant copie. |
+| Fenêtre et séquence TCP | Validées par la connexion. |
+| Réponse ACK automatique sur RX | Reste un lot suivant ; l’orchestrateur expose d’abord le payload. |
+| TLS, HTTP et LLM en ligne | Non fonctionnels de bout en bout. |
+
+Les tests ciblés NE2000 passent après le nouveau contrat RX vide. La non-régression et les smokes restent obligatoires avant publication.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -111,3 +111,9 @@ Les lots ajoutent la retransmission NE2000 caller-owned, la confirmation et purg
 ### AOS-159 à AOS-162 — envoi suivi d’ACK, réception, fenêtre et checksums
 
 AOS-159 ajoute la construction data suivie d’un pending caller-owned avant commit TX. AOS-160 ajoute la réception TCP NE2000 bornée avec copie vers le buffer appelant. AOS-161 ajoute la fenêtre de réception explicite. AOS-162 valide les checksums IPv4 et TCP en réception. Validation : 304 tests verts, build i386 réussi, smoke IA réussi et smoke NE2000 réussi.
+
+### AOS-163 à AOS-165 — polling TCP et orchestration RX
+
+AOS-163 ajoute `ne2k_tcp_poll`, AOS-164 formalise le retour non bloquant RX vide avec longueur nulle, et AOS-165 regroupe les contrôles de bornes, checksums, séquence et fenêtre dans le chemin de réception caller-owned. Le prochain incrément reste la génération d’un ACK automatique après payload accepté.
+
+Validation AOS-163/AOS-165 : **305/305 tests verts**, build i386 réussi, `qemu-ai-provider` réussi et `qemu-ne2k-status` réussi.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -291,6 +291,19 @@ int ne2k_tcp_receive(const uint8_t* frame, uint16_t frame_length,
     *payload_length = accepted; return 0;
 }
 
+int ne2k_tcp_poll(ne2k_device_t* device, const ne2k_io_t* io,
+                  uint8_t* frame, uint16_t frame_capacity,
+                  net_tcp_connection_t* connection, uint8_t* payload,
+                  uint16_t payload_capacity, uint16_t* payload_length) {
+    uint16_t frame_length = 0U; int status;
+    if (!device || !io || !frame || !connection || !payload_length) return -1;
+    *payload_length = 0U;
+    status = ne2k_rx_poll(device, io, frame, frame_capacity, &frame_length);
+    if (status != 0) return status;
+    if (frame_length == 0U) return 1;
+    return ne2k_tcp_receive(frame, frame_length, connection, payload, payload_capacity, payload_length);
+}
+
 int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,
                     uint8_t* frame, uint16_t frame_capacity, uint16_t attempts,
                     uint16_t expected_id, net_dns_a_result_t* result) {

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -152,6 +152,11 @@ int ne2k_tcp_retransmit(ne2k_device_t* device, const ne2k_io_t* io,
 int ne2k_tcp_receive(const uint8_t* frame, uint16_t frame_length,
                      net_tcp_connection_t* connection, uint8_t* payload,
                      uint16_t payload_capacity, uint16_t* payload_length);
+/* Polling et extraction TCP en une étape, tous les buffers appartenant à l’appelant. */
+int ne2k_tcp_poll(ne2k_device_t* device, const ne2k_io_t* io,
+                  uint8_t* frame, uint16_t frame_capacity,
+                  net_tcp_connection_t* connection, uint8_t* payload,
+                  uint16_t payload_capacity, uint16_t* payload_length);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -159,6 +159,15 @@ void test_tcp_receive_copies_bounded_payload(void) {
     TEST_ASSERT_NOT_EQUAL(0, ne2k_tcp_receive(frame, 58U, &connection, payload, 3U, &length));
 }
 
+void test_tcp_poll_is_bounded_when_rx_empty(void) {
+    fake_ne2k_t fake = {0x12, 0, 0, 0}; ne2k_io_t io = {&fake, fake_inb, fake_outb}; ne2k_device_t device;
+    net_tcp_connection_t connection; uint8_t frame[64] = {0}; uint8_t payload[8] = {0}; uint16_t length = 99U;
+    fake.isr = NE2K_ISR_RESET; TEST_ASSERT_EQUAL(0, ne2k_probe(&device, 0x300, &io));
+    TEST_ASSERT_EQUAL(0, ne2k_prepare(&device, &io)); TEST_ASSERT_EQUAL(0, ne2k_configure_rings(&device, &io));
+    TEST_ASSERT_EQUAL(1, ne2k_tcp_poll(&device, &io, frame, sizeof(frame), &connection, payload, sizeof(payload), &length));
+    TEST_ASSERT_EQUAL(0U, length);
+}
+
 void test_rx_extract_publishes_bounded_frame(void) {
     uint8_t storage[NET_NIC_QUEUE_CAPACITY * 64U] = {0};
     uint8_t dma[9] = {NE2K_RX_STATUS_OK, 0, 9, 0, 1, 2, 3, 4, 5};
@@ -182,6 +191,7 @@ int main(void) {
     unity_init();
     RUN_TEST(test_probe_and_prepare_use_injected_io);
     RUN_TEST(test_tcp_receive_copies_bounded_payload);
+    RUN_TEST(test_tcp_poll_is_bounded_when_rx_empty);
     RUN_TEST(test_tcp_ack_is_emitted_from_connection_state);
     RUN_TEST(test_rx_extract_publishes_bounded_frame);
     RUN_TEST(test_probe_rejects_missing_reset_ack);


### PR DESCRIPTION
## Résumé

- AOS-163 : polling TCP NE2000 et extraction caller-owned;
- AOS-164 : contrat RX vide non bloquant avec longueur nulle;
- AOS-165 : contrôles bornes, checksums, séquence et fenêtre;
- documentation française mise à jour.

## Validation locale

- `make test-all`: 305/305 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: réussi;
- `make qemu-ne2k-status`: réussi.

TLS, HTTP, congestion et appels LLM en ligne restent non fonctionnels de bout en bout.