### PR TITLE
Lots 166-167: polling TCP avec ACK automatique

### DIFF
--- a/docs/aos166_167_tcp_poll_ack.md
+++ b/docs/aos166_167_tcp_poll_ack.md
@@ -1,0 +1,17 @@
+# AOS-166/AOS-167 — Polling TCP suivi d’ACK automatique
+
+AOS-166 ajoute `ne2k_tcp_poll_ack`. La primitive appelle le polling TCP caller-owned, valide la trame et la fenêtre, copie le payload accepté, puis construit et transmet l’ACK avec les adresses IPv4 et le cache ARP fournis par l’appelant.
+
+AOS-167 formalise les codes de retour. Une absence de trame retourne `1`, publie une longueur nulle et n’émet rien. Une trame valide avec payload retourne `0` uniquement après transmission réussie de l’ACK. Une erreur de cache ARP ou de transmission est propagée après l’acceptation du payload ; l’appelant dispose alors de la longueur et peut décider d’une nouvelle tentative ou d’une retransmission selon sa politique.
+
+L’orchestration n’introduit aucun buffer statique caché, aucune allocation et aucun timer. Le buffer RX, le buffer TX, le payload, l’état TCP, le cache ARP et les adresses IP sont tous caller-owned.
+
+| Cas | Résultat |
+|---|---|
+| RX vide | Retour `1`, longueur `0`, aucune émission. |
+| Trame invalide | Erreur négative, payload non publié. |
+| Payload accepté et ACK transmis | Retour `0`, longueur publiée. |
+| Payload accepté mais ARP/TX échoue | Erreur négative, longueur conservée pour décision appelante. |
+| TLS, HTTP, RTO et LLM en ligne | Non fonctionnels de bout en bout. |
+
+Les tests NE2000 couvrent au minimum le cas RX vide, l’absence d’émission ACK et la conservation de la longueur nulle.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -117,3 +117,9 @@ AOS-159 ajoute la construction data suivie d’un pending caller-owned avant com
 AOS-163 ajoute `ne2k_tcp_poll`, AOS-164 formalise le retour non bloquant RX vide avec longueur nulle, et AOS-165 regroupe les contrôles de bornes, checksums, séquence et fenêtre dans le chemin de réception caller-owned. Le prochain incrément reste la génération d’un ACK automatique après payload accepté.
 
 Validation AOS-163/AOS-165 : **305/305 tests verts**, build i386 réussi, `qemu-ai-provider` réussi et `qemu-ne2k-status` réussi.
+
+### AOS-166/AOS-167 — polling TCP suivi d’ACK
+
+`ne2k_tcp_poll_ack` reçoit et valide un payload TCP, le publie dans le buffer appelant puis émet son ACK via le cache ARP caller-owned. RX vide retourne `1` sans émission ; une erreur ARP/TX est propagée après acceptation afin que l’appelant puisse décider d’une nouvelle tentative. Documentation : `docs/aos166_167_tcp_poll_ack.md`.
+
+Validation AOS-166/AOS-167 : **305/305 tests verts**, build i386 réussi, smoke `qemu-ai-provider` réussi et smoke `qemu-ne2k-status` réussi.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -304,6 +304,23 @@ int ne2k_tcp_poll(ne2k_device_t* device, const ne2k_io_t* io,
     return ne2k_tcp_receive(frame, frame_length, connection, payload, payload_capacity, payload_length);
 }
 
+int ne2k_tcp_poll_ack(ne2k_device_t* device, const ne2k_io_t* io,
+                      const net_arp_cache_t* cache, uint8_t* rx_frame,
+                      uint16_t rx_capacity, uint8_t* tx_frame, uint16_t tx_capacity,
+                      const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                      net_tcp_connection_t* connection, uint8_t* payload,
+                      uint16_t payload_capacity, uint16_t* payload_length) {
+    int status;
+    if (!cache || !tx_frame || !local_ip || !remote_ip || !connection || !payload_length) return -1;
+    *payload_length = 0U;
+    status = ne2k_tcp_poll(device, io, rx_frame, rx_capacity, connection, payload,
+                           payload_capacity, payload_length);
+    if (status != 0 || *payload_length == 0U) return status;
+    status = ne2k_tcp_ack(device, io, cache, tx_frame, tx_capacity, local_ip, remote_ip, connection);
+    if (status != 0) return status;
+    return 0;
+}
+
 int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,
                     uint8_t* frame, uint16_t frame_capacity, uint16_t attempts,
                     uint16_t expected_id, net_dns_a_result_t* result) {

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -157,6 +157,13 @@ int ne2k_tcp_poll(ne2k_device_t* device, const ne2k_io_t* io,
                   uint8_t* frame, uint16_t frame_capacity,
                   net_tcp_connection_t* connection, uint8_t* payload,
                   uint16_t payload_capacity, uint16_t* payload_length);
+/* Reçoit un payload TCP puis émet son ACK avec les adresses IP et le cache ARP fournis. */
+int ne2k_tcp_poll_ack(ne2k_device_t* device, const ne2k_io_t* io,
+                      const net_arp_cache_t* cache, uint8_t* rx_frame,
+                      uint16_t rx_capacity, uint8_t* tx_frame, uint16_t tx_capacity,
+                      const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                      net_tcp_connection_t* connection, uint8_t* payload,
+                      uint16_t payload_capacity, uint16_t* payload_length);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -166,6 +166,10 @@ void test_tcp_poll_is_bounded_when_rx_empty(void) {
     TEST_ASSERT_EQUAL(0, ne2k_prepare(&device, &io)); TEST_ASSERT_EQUAL(0, ne2k_configure_rings(&device, &io));
     TEST_ASSERT_EQUAL(1, ne2k_tcp_poll(&device, &io, frame, sizeof(frame), &connection, payload, sizeof(payload), &length));
     TEST_ASSERT_EQUAL(0U, length);
+    { net_arp_cache_t cache; uint8_t tx[64] = {0}; uint8_t local_ip[4] = {10,0,2,15}; uint8_t remote_ip[4] = {10,0,2,2};
+      TEST_ASSERT_EQUAL(0, net_arp_cache_init(&cache));
+      fake.tx_count = 0U; TEST_ASSERT_EQUAL(1, ne2k_tcp_poll_ack(&device, &io, &cache, frame, sizeof(frame), tx, sizeof(tx), local_ip, remote_ip, &connection, payload, sizeof(payload), &length));
+      TEST_ASSERT_EQUAL(0U, length); TEST_ASSERT_EQUAL(0U, fake.tx_count); }
 }
 
 void test_rx_extract_publishes_bounded_frame(void) {


### PR DESCRIPTION
## Résumé

- AOS-166 : polling TCP RX suivi d’un ACK automatique caller-owned;
- AOS-167 : contrats RX vide, erreurs ARP/TX et longueur publiée;
- documentation française mise à jour.

## Validation locale

- `make test-all`: 305/305 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: réussi;
- `make qemu-ne2k-status`: réussi.

TLS, HTTP, congestion et appels LLM en ligne restent non fonctionnels de bout en bout.