### PR TITLE
Lots 168-169: FIN TCP et ACK de contrôle

### DIFF
--- a/docs/aos168_169_tcp_fin_control.md
+++ b/docs/aos168_169_tcp_fin_control.md
@@ -1,0 +1,16 @@
+# AOS-168/AOS-169 — Contrôle FIN et ACK de fermeture
+
+AOS-168 ajoute `ne2k_tcp_poll_fin_ack`. Cette primitive lit une trame TCP depuis la RAM NE2000, vérifie Ethernet/IPv4/TCP et les deux checksums, exige le flag FIN, puis délègue la transition de fermeture à l’état TCP caller-owned avant d’émettre l’ACK de fermeture.
+
+AOS-169 sépare le traitement des FIN des ACK purs. Un ACK sans payload ne déclenche pas automatiquement un nouvel ACK, ce qui évite une boucle de contrôle. Le chemin FIN→ACK reste explicitement piloté par l’appelant et réutilise les buffers RX/TX ainsi que le cache ARP fournis.
+
+Le codec TLS record existant (`kernel/net_tls_record.c`) reste limité au framing TLS 1.2 caller-owned. Il ne réalise encore ni négociation cryptographique, ni validation de certificats, ni chiffrement ; son raccordement au transport TCP constitue un prochain lot distinct.
+
+| Fonction | Statut |
+|---|---|
+| FIN reçu et validé | Implémenté dans le polling dédié. |
+| ACK FIN transmis via NE2000 | Implémenté après transition d’état. |
+| ACK pur sans réponse automatique | Protégé contre les boucles. |
+| Framing TLS record | Existant et testé séparément. |
+| Handshake TLS cryptographique | Non implémenté. |
+| HTTP et appels LLM en ligne | Non fonctionnels de bout en bout. |

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -123,3 +123,9 @@ Validation AOS-163/AOS-165 : **305/305 tests verts**, build i386 réussi, `qemu-
 `ne2k_tcp_poll_ack` reçoit et valide un payload TCP, le publie dans le buffer appelant puis émet son ACK via le cache ARP caller-owned. RX vide retourne `1` sans émission ; une erreur ARP/TX est propagée après acceptation afin que l’appelant puisse décider d’une nouvelle tentative. Documentation : `docs/aos166_167_tcp_poll_ack.md`.
 
 Validation AOS-166/AOS-167 : **305/305 tests verts**, build i386 réussi, smoke `qemu-ai-provider` réussi et smoke `qemu-ne2k-status` réussi.
+
+### AOS-168/AOS-169 — FIN→ACK et contrôle TCP
+
+Le polling FIN caller-owned valide la trame, effectue la transition de fermeture et émet l’ACK via NE2000. Les ACK purs ne déclenchent pas de réponse automatique afin d’éviter les boucles. Le framing TLS 1.2 existe séparément, mais son handshake cryptographique et son raccordement TCP restent à implémenter.
+
+Validation AOS-168/AOS-169 : **305/305 tests verts**, build i386 réussi, smoke `qemu-ai-provider` réussi et smoke `qemu-ne2k-status` réussi.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -321,6 +321,30 @@ int ne2k_tcp_poll_ack(ne2k_device_t* device, const ne2k_io_t* io,
     return 0;
 }
 
+int ne2k_tcp_poll_fin_ack(ne2k_device_t* device, const ne2k_io_t* io,
+                          const net_arp_cache_t* cache, uint8_t* rx_frame,
+                          uint16_t rx_capacity, uint8_t* tx_frame, uint16_t tx_capacity,
+                          const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                          net_tcp_connection_t* connection) {
+    uint16_t frame_length = 0U, ip_header_size, tcp_offset, ip_length, tcp_length; net_tcp_view_t view; int status;
+    if (!cache || !rx_frame || !tx_frame || !local_ip || !remote_ip || !connection) return -1;
+    status = ne2k_rx_poll(device, io, rx_frame, rx_capacity, &frame_length);
+    if (status != 0) return status;
+    if (frame_length == 0U) return 1;
+    if (frame_length < NET_ETHERNET_HEADER_SIZE + 40U || rx_frame[12] != 0x08U || rx_frame[13] != 0x00U ||
+        (rx_frame[14] >> 4) != 4U || rx_frame[23] != NET_TCP_PROTOCOL) return -2;
+    if (net_ipv4_checksum(rx_frame + 14U, 20U) != 0U) return -3;
+    ip_length = (uint16_t)(((uint16_t)rx_frame[16] << 8) | rx_frame[17]);
+    ip_header_size = (uint16_t)((rx_frame[14] & 0x0fU) * 4U);
+    if (ip_header_size < 20U || ip_length < ip_header_size + NET_TCP_HEADER_SIZE ||
+        (uint32_t)NET_ETHERNET_HEADER_SIZE + ip_length > frame_length) return -4;
+    tcp_offset = (uint16_t)(14U + ip_header_size); tcp_length = (uint16_t)(ip_length - ip_header_size);
+    if (net_tcp_checksum_ipv4(rx_frame + 26U, rx_frame + 30U, rx_frame + tcp_offset, tcp_length) != 0U ||
+        net_tcp_parse(rx_frame + tcp_offset, tcp_length, &view) != 0) return -5;
+    if ((view.flags & NET_TCP_FLAG_FIN) == 0U || net_tcp_connection_accept_fin(connection, &view) != 0) return -6;
+    return ne2k_tcp_ack(device, io, cache, tx_frame, tx_capacity, local_ip, remote_ip, connection);
+}
+
 int ne2k_dns_poll_a(ne2k_device_t* device, const ne2k_io_t* io,
                     uint8_t* frame, uint16_t frame_capacity, uint16_t attempts,
                     uint16_t expected_id, net_dns_a_result_t* result) {

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -164,6 +164,12 @@ int ne2k_tcp_poll_ack(ne2k_device_t* device, const ne2k_io_t* io,
                       const uint8_t local_ip[4], const uint8_t remote_ip[4],
                       net_tcp_connection_t* connection, uint8_t* payload,
                       uint16_t payload_capacity, uint16_t* payload_length);
+/* Reçoit un FIN, passe l’état en CLOSE_WAIT/CLOSED et émet son ACK. */
+int ne2k_tcp_poll_fin_ack(ne2k_device_t* device, const ne2k_io_t* io,
+                          const net_arp_cache_t* cache, uint8_t* rx_frame,
+                          uint16_t rx_capacity, uint8_t* tx_frame, uint16_t tx_capacity,
+                          const uint8_t local_ip[4], const uint8_t remote_ip[4],
+                          net_tcp_connection_t* connection);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -169,7 +169,9 @@ void test_tcp_poll_is_bounded_when_rx_empty(void) {
     { net_arp_cache_t cache; uint8_t tx[64] = {0}; uint8_t local_ip[4] = {10,0,2,15}; uint8_t remote_ip[4] = {10,0,2,2};
       TEST_ASSERT_EQUAL(0, net_arp_cache_init(&cache));
       fake.tx_count = 0U; TEST_ASSERT_EQUAL(1, ne2k_tcp_poll_ack(&device, &io, &cache, frame, sizeof(frame), tx, sizeof(tx), local_ip, remote_ip, &connection, payload, sizeof(payload), &length));
-      TEST_ASSERT_EQUAL(0U, length); TEST_ASSERT_EQUAL(0U, fake.tx_count); }
+      TEST_ASSERT_EQUAL(0U, length); TEST_ASSERT_EQUAL(0U, fake.tx_count);
+      fake.tx_count = 0U; TEST_ASSERT_EQUAL(1, ne2k_tcp_poll_fin_ack(&device, &io, &cache, frame, sizeof(frame), tx, sizeof(tx), local_ip, remote_ip, &connection));
+      TEST_ASSERT_EQUAL(0U, fake.tx_count); }
 }
 
 void test_rx_extract_publishes_bounded_frame(void) {


### PR DESCRIPTION
## Résumé

- AOS-168 : polling FIN caller-owned, validation et ACK de fermeture;
- AOS-169 : séparation des ACK purs pour éviter les boucles;
- documentation française mise à jour.

## Validation locale

- `make test-all`: 305/305 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: réussi;
- `make qemu-ne2k-status`: réussi.

Le framing TLS 1.2 reste limité au codec record caller-owned; handshake cryptographique, HTTP et appels LLM en ligne restent non fonctionnels de bout en bout.