### PR TITLE
Lot 170: ClientHello TLS caller-owned

### DIFF
--- a/docs/aos170_tls_client_hello_framing.md
+++ b/docs/aos170_tls_client_hello_framing.md
@@ -1,0 +1,16 @@
+# AOS-170 — ClientHello TLS 1.2 minimal caller-owned
+
+AOS-170 ajoute `net_tls_client_hello_build`. Cette primitive construit un record TLS Handshake contenant un ClientHello TLS 1.2 minimal : version annoncée, random de 32 octets fourni par l’appelant, session vide, une suite cryptographique explicitement annoncée et compression nulle.
+
+La primitive est volontairement limitée au framing. Elle ne génère pas de random cryptographique, ne négocie pas les extensions SNI/ALPN, ne dérive aucune clé, ne chiffre aucun record et ne valide aucun certificat. Le raccordement au transport TCP doit donc être traité comme une étape ultérieure, avec une politique de vérification indépendante.
+
+| Élément | Statut |
+|---|---|
+| Construction ClientHello caller-owned | Implémentée. |
+| Version TLS 1.2 annoncée | Implémentée. |
+| Random cryptographique | Fourni par l’appelant ; aucune génération interne. |
+| SNI/ALPN, dérivation de clés, chiffrement | Non implémentés. |
+| Validation X.509 et handshake complet | Non implémentés. |
+| HTTP et appels LLM en ligne | Non fonctionnels de bout en bout. |
+
+Le test TLS record couvre désormais la construction/parsing du record générique et le ClientHello minimal, y compris le rejet d’une capacité insuffisante.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -129,3 +129,9 @@ Validation AOS-166/AOS-167 : **305/305 tests verts**, build i386 réussi, smoke 
 Le polling FIN caller-owned valide la trame, effectue la transition de fermeture et émet l’ACK via NE2000. Les ACK purs ne déclenchent pas de réponse automatique afin d’éviter les boucles. Le framing TLS 1.2 existe séparément, mais son handshake cryptographique et son raccordement TCP restent à implémenter.
 
 Validation AOS-168/AOS-169 : **305/305 tests verts**, build i386 réussi, smoke `qemu-ai-provider` réussi et smoke `qemu-ne2k-status` réussi.
+
+### AOS-170 — ClientHello TLS 1.2 minimal
+
+Le codec TLS record construit maintenant un ClientHello minimal caller-owned avec random fourni, sans génération cryptographique ni négociation complète. SNI/ALPN, dérivation de clés, chiffrement, X.509, HTTP et appels LLM en ligne restent hors périmètre fonctionnel.
+
+Validation AOS-170 : **306/306 tests verts**, build i386 réussi, smoke `qemu-ai-provider` réussi et smoke `qemu-ne2k-status` réussi.

--- a/kernel/net_tls_record.c
+++ b/kernel/net_tls_record.c
@@ -3,3 +3,12 @@ static uint16_t get16(const uint8_t* p){return (uint16_t)(((uint16_t)p[0]<<8)|p[
 static void put16(uint8_t* p,uint16_t v){p[0]=(uint8_t)(v>>8);p[1]=(uint8_t)v;}
 int net_tls_record_build(uint8_t* record,uint32_t capacity,uint8_t content_type,const uint8_t* payload,uint16_t payload_length){uint16_t i;if(!record||(!payload&&payload_length)||capacity<(uint32_t)NET_TLS_RECORD_HEADER+payload_length||content_type==0U)return -1;record[0]=content_type;record[1]=NET_TLS_VERSION_1_2_MAJOR;record[2]=NET_TLS_VERSION_1_2_MINOR;put16(record+3,payload_length);for(i=0;i<payload_length;i++)record[5+i]=payload[i];return (int)(5U+payload_length);}
 int net_tls_record_parse(const uint8_t* record,uint32_t length,net_tls_record_view_t* out){uint16_t payload_length;if(!record||!out||length<NET_TLS_RECORD_HEADER||record[1]!=NET_TLS_VERSION_1_2_MAJOR||record[2]!=NET_TLS_VERSION_1_2_MINOR)return -1;payload_length=get16(record+3);if((uint32_t)payload_length+NET_TLS_RECORD_HEADER>length||record[0]==0U)return -2;out->content_type=record[0];out->major=record[1];out->minor=record[2];out->payload=record+5;out->payload_length=payload_length;return 0;}
+int net_tls_client_hello_build(uint8_t* record,uint32_t capacity,const uint8_t random[32]){
+    uint8_t hello[45]; uint8_t i; int length;
+    if(!record||!random||capacity<NET_TLS_RECORD_HEADER+49U)return -1;
+    hello[0]=1U; hello[1]=0U; hello[2]=0U; hello[3]=44U; hello[4]=NET_TLS_VERSION_1_2_MAJOR; hello[5]=NET_TLS_VERSION_1_2_MINOR;
+    for(i=0;i<32U;i++) hello[6U+i]=random[i];
+    hello[38]=0U; hello[39]=0U; hello[40]=2U; hello[41]=0x00U; hello[42]=0x9cU; hello[43]=1U; hello[44]=0U;
+    length=net_tls_record_build(record,capacity,NET_TLS_CONTENT_HANDSHAKE,hello,sizeof(hello));
+    return length;
+}

--- a/kernel/net_tls_record.h
+++ b/kernel/net_tls_record.h
@@ -7,5 +7,8 @@
 #define NET_TLS_VERSION_1_2_MINOR 3U
 typedef struct { uint8_t content_type; uint8_t major; uint8_t minor; const uint8_t* payload; uint16_t payload_length; } net_tls_record_view_t;
 int net_tls_record_build(uint8_t* record, uint32_t capacity, uint8_t content_type, const uint8_t* payload, uint16_t payload_length);
-int net_tls_record_parse(const uint8_t* record, uint32_t length, net_tls_record_view_t* out);
+int net_tls_record_parse(const uint8_t* record,uint32_t length,net_tls_record_view_t* out);
+/* Construit un ClientHello TLS 1.2 minimal dans un record caller-owned. */
+int net_tls_client_hello_build(uint8_t* record, uint32_t capacity,
+                               const uint8_t random[32]);
 #endif

--- a/tests/unit/kernel/test_net_tls_record.c
+++ b/tests/unit/kernel/test_net_tls_record.c
@@ -1,5 +1,6 @@
 #include "../../framework/unity.h"
 #include "../../../kernel/net_tls_record.h"
 void setUp(void){} void tearDown(void){}
+void test_tls_client_hello_build(void){uint8_t record[64]={0},random[32]={0},i;net_tls_record_view_t view;for(i=0;i<32;i++)random[i]=i;TEST_ASSERT_EQUAL(50,net_tls_client_hello_build(record,sizeof(record),random));TEST_ASSERT_EQUAL(0,net_tls_record_parse(record,50,&view));TEST_ASSERT_EQUAL(NET_TLS_CONTENT_HANDSHAKE,view.content_type);TEST_ASSERT_EQUAL(45,view.payload_length);TEST_ASSERT_EQUAL(1,view.payload[0]);TEST_ASSERT_EQUAL(44,view.payload[3]);TEST_ASSERT_EQUAL(0,view.payload[38]);TEST_ASSERT_EQUAL(0,view.payload[39]);TEST_ASSERT_NOT_EQUAL(0,net_tls_client_hello_build(record,49,random));}
 void test_tls_record_build_parse(void){uint8_t record[32]={0},payload[3]={'C','H','1'};net_tls_record_view_t view;TEST_ASSERT_EQUAL(8,net_tls_record_build(record,sizeof(record),NET_TLS_CONTENT_HANDSHAKE,payload,3));TEST_ASSERT_EQUAL(0,net_tls_record_parse(record,8,&view));TEST_ASSERT_EQUAL(NET_TLS_CONTENT_HANDSHAKE,view.content_type);TEST_ASSERT_EQUAL(3,view.payload_length);TEST_ASSERT_EQUAL('C',view.payload[0]);record[2]=2;TEST_ASSERT_NOT_EQUAL(0,net_tls_record_parse(record,8,&view));}
-int main(void){unity_init();RUN_TEST(test_tls_record_build_parse);unity_print_results();unity_cleanup();return unity_stats.tests_failed==0?0:1;}
+int main(void){unity_init();RUN_TEST(test_tls_client_hello_build);RUN_TEST(test_tls_record_build_parse);unity_print_results();unity_cleanup();return unity_stats.tests_failed==0?0:1;}


### PR DESCRIPTION
## Résumé

- AOS-170 : ClientHello TLS 1.2 minimal caller-owned;
- random fourni par l’appelant, suite cipher et compression nulle;
- bornes de capacité et parsing validés;
- documentation française mise à jour.

## Validation locale

- `make test-all`: 306/306 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: réussi;
- `make qemu-ne2k-status`: réussi.

Le ClientHello est uniquement du framing : SNI/ALPN, dérivation de clés, chiffrement, X.509, HTTP et appels LLM en ligne restent non fonctionnels de bout en bout.