### PR TITLE
Lot 171: composition TLS sur TCP caller-owned

### DIFF
--- a/docs/aos171_tls_over_tcp_caller_owned.md
+++ b/docs/aos171_tls_over_tcp_caller_owned.md
@@ -1,0 +1,16 @@
+# AOS-171 — Composition TLS sur TCP caller-owned
+
+AOS-171 ajoute `net_tcp_connection_build_tls_record`. La primitive construit d’abord un record TLS dans un buffer fourni par l’appelant, puis l’encapsule comme payload d’un segment TCP caller-owned. Le payload pending référence le record fourni ; aucune allocation, copie cachée ou génération de clé n’est effectuée.
+
+Le sequence TCP reste inchangé avant `net_tcp_connection_commit_send`. Après commit, la longueur consommée est celle du record TLS complet, en-tête TLS de cinq octets compris. Le même buffer peut ainsi être présenté au mécanisme de retransmission bornée déjà existant.
+
+Cette composition ne constitue pas un handshake TLS complet. Le ClientHello est seulement encadré et transportable ; SNI/ALPN, dérivation de clés, chiffrement, validation X.509, retransmission avec RTO adaptatif, HTTP et appels LLM en ligne restent à implémenter.
+
+| Élément | Statut |
+|---|---|
+| Construction record TLS dans buffer appelant | Implémentée. |
+| Encapsulation comme payload TCP | Implémentée. |
+| Pending/retransmission sans allocation | Réutilise l’état TCP existant. |
+| Sequence avancé après commit uniquement | Validé. |
+| Handshake cryptographique TLS | Non implémenté. |
+| HTTP et appels LLM en ligne | Non fonctionnels de bout en bout. |

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -135,3 +135,9 @@ Validation AOS-168/AOS-169 : **305/305 tests verts**, build i386 réussi, smoke 
 Le codec TLS record construit maintenant un ClientHello minimal caller-owned avec random fourni, sans génération cryptographique ni négociation complète. SNI/ALPN, dérivation de clés, chiffrement, X.509, HTTP et appels LLM en ligne restent hors périmètre fonctionnel.
 
 Validation AOS-170 : **306/306 tests verts**, build i386 réussi, smoke `qemu-ai-provider` réussi et smoke `qemu-ne2k-status` réussi.
+
+### AOS-171 — composition TLS sur TCP
+
+`net_tcp_connection_build_tls_record` construit un record TLS dans un buffer caller-owned puis l’encapsule dans un segment TCP pending, réutilisable pour commit et retransmission. Le raccordement ne fournit encore ni cryptographie TLS, ni certificat, ni HTTP ou appel LLM en ligne.
+
+Validation AOS-171 : **307/307 tests verts**, après ajout de `net_tls_record.c` aux chemins de linkage TCP/NE2000 du harness ; build i386 réussi, smoke `qemu-ai-provider` réussi et smoke `qemu-ne2k-status` réussi.

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -116,6 +116,16 @@ int net_tcp_connection_build_data(net_tcp_connection_t* connection,uint8_t* segm
     return length;
 }
 
+int net_tcp_connection_build_tls_record(net_tcp_connection_t* connection,uint8_t* segment,uint32_t capacity,
+                                        uint8_t* record,uint32_t record_capacity,uint8_t content_type,
+                                        const uint8_t* payload,uint16_t payload_length,uint8_t retransmit_limit) {
+    int record_length;
+    if (!record) return -1;
+    record_length = net_tls_record_build(record, record_capacity, content_type, payload, payload_length);
+    if (record_length < 0 || record_length > 0xffff) return -2;
+    return net_tcp_connection_build_data(connection, segment, capacity, record, (uint16_t)record_length, retransmit_limit);
+}
+
 int net_tcp_connection_commit_send(net_tcp_connection_t* connection,uint16_t payload_length) {
     if (!connection || connection->state!=NET_TCP_STATE_ESTABLISHED || payload_length == 0U) return -1;
     connection->local_sequence += payload_length; return 0;

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -2,6 +2,7 @@
 #define AIOS_NET_TCP_H
 
 #include <stdint.h>
+#include "net_tls_record.h"
 
 #define NET_TCP_HEADER_SIZE 20U
 #define NET_TCP_PROTOCOL 6U
@@ -74,6 +75,11 @@ int net_tcp_connection_build_data(net_tcp_connection_t* connection,
                                   uint8_t* segment, uint32_t capacity,
                                   const uint8_t* payload, uint16_t payload_length,
                                   uint8_t retransmit_limit);
+int net_tcp_connection_build_tls_record(net_tcp_connection_t* connection,
+                                        uint8_t* segment, uint32_t capacity,
+                                        uint8_t* record, uint32_t record_capacity,
+                                        uint8_t content_type, const uint8_t* payload,
+                                        uint16_t payload_length, uint8_t retransmit_limit);
 int net_tcp_connection_commit_send(net_tcp_connection_t* connection, uint16_t payload_length);
 int net_tcp_connection_accept_data(net_tcp_connection_t* connection,
                                    const net_tcp_view_t* view,

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -125,9 +125,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_sha256: $(UNIT_DIR)/kernel/test_sha256.c ..
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_tcp: $(UNIT_DIR)/kernel/test_net_tcp.c ../kernel/net_tcp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_tcp: $(UNIT_DIR)/kernel/test_net_tcp.c ../kernel/net_tcp.c ../kernel/net_tls_record.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_tcp.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_tcp.c ../kernel/net_tls_record.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
@@ -149,9 +149,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dhcp: $(UNIT_DIR)/kernel/test_net_dhcp.
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c ../kernel/net_tls_record.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c ../kernel/net_tls_record.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -131,6 +131,7 @@ run_test() {
     fi
     if [ "$(basename "$test_file")" = "test_net_tcp.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/net_tcp.c"
+        extra_src="$extra_src $BASE_DIR/kernel/net_tls_record.c"
     fi
     if [ "$(basename "$test_file")" = "test_net_dns.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/net_dns.c"
@@ -149,6 +150,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/net_dhcp.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_dns.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_tcp.c"
+        extra_src="$extra_src $BASE_DIR/kernel/net_tls_record.c"
     fi
     if [ "$(basename "$test_file")" = "test_pci.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/pci.c"

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -70,6 +70,16 @@ void test_connection_advances_sequences_and_accepts_data(void) {
     TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_commit_send(&connection, 0U));
 }
 
+void test_tls_record_is_composed_into_tcp(void) {
+    net_tcp_connection_t connection; uint8_t segment[64], record[32]; uint8_t hello[3] = {'H','I','!'}; net_tls_record_view_t view;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
+    { net_tcp_view_t syn_ack = {443, 49152, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+      TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn_ack(&connection, &syn_ack)); }
+    TEST_ASSERT_EQUAL(28, net_tcp_connection_build_tls_record(&connection, segment, sizeof(segment), record, sizeof(record), NET_TLS_CONTENT_HANDSHAKE, hello, sizeof(hello), 2U));
+    TEST_ASSERT_EQUAL(8, connection.pending_length); TEST_ASSERT_EQUAL(record, connection.pending_payload);
+    TEST_ASSERT_EQUAL(0, net_tls_record_parse(record, 8, &view)); TEST_ASSERT_EQUAL(3U, view.payload_length);
+}
+
 void test_receive_window_is_bounded(void) {
     net_tcp_connection_t connection; net_tcp_view_t view; uint16_t accepted = 0U;
     TEST_ASSERT_EQUAL(0, net_tcp_connection_open(&connection, 49152, 443, 100U));
@@ -145,6 +155,6 @@ void test_bounded_retransmission_metadata(void) {
 }
 
 int main(void) {
-    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); RUN_TEST(test_connection_advances_sequences_and_accepts_data); RUN_TEST(test_receive_window_is_bounded); RUN_TEST(test_build_data_tracks_until_commit); RUN_TEST(test_ack_confirms_pending_payload); RUN_TEST(test_fin_close_transitions); RUN_TEST(test_bounded_retransmission_metadata); unity_print_results(); unity_cleanup();
+    unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); RUN_TEST(test_connection_advances_sequences_and_accepts_data); RUN_TEST(test_tls_record_is_composed_into_tcp); RUN_TEST(test_receive_window_is_bounded); RUN_TEST(test_build_data_tracks_until_commit); RUN_TEST(test_ack_confirms_pending_payload); RUN_TEST(test_fin_close_transitions); RUN_TEST(test_bounded_retransmission_metadata); unity_print_results(); unity_cleanup();
     return (unity_stats.tests_failed == 0) ? 0 : 1;
 }


### PR DESCRIPTION
## Résumé

- AOS-171 : composition d’un record TLS dans un payload TCP caller-owned;
- pending et retransmission réutilisent le buffer fourni, sans allocation;
- sequence avancé uniquement après commit TX;
- Makefile et script de tests corrigés pour lier net_tls_record.c aux tests TCP/NE2000;
- documentation française mise à jour.

## Validation locale

- `make test-all`: 307/307 tests verts;
- `make all`: build i386 réussi;
- `make qemu-ai-provider`: réussi;
- `make qemu-ne2k-status`: réussi.

Le framing TLS est transportable mais le handshake cryptographique, SNI/ALPN, X.509, HTTP et les appels LLM en ligne restent non fonctionnels de bout en bout.