### PR TITLE
AOS-217: document RSA verification interface status

### DIFF
--- a/docs/aos217_rsa_interface_status.md
+++ b/docs/aos217_rsa_interface_status.md
@@ -1,0 +1,22 @@
+# AOS-217 — Interface RSA caller-owned : rapport d’état
+
+Cette PR introduit uniquement le contrat public `rsa_pkcs1_v15_sha256_verify`. Il fixe dès maintenant les entrées de la future vérification RSA PKCS#1 v1.5 SHA-256 et impose un workspace fourni par l’appelant. Aucune allocation dynamique n’est autorisée.
+
+| Composant | État |
+|---|---|
+| Interface C caller-owned | Intégrée |
+| Contrôle des arguments | Non implémenté |
+| Arithmétique bigint | Non implémentée |
+| Exponentiation modulaire RSA | Non implémentée |
+| Décodage PKCS#1 v1.5 | Non implémenté |
+| Vérification SHA-256 | Non implémentée |
+| Tests RSA / vecteurs | Non implémentés |
+| Intégration ServerKeyExchange | Non implémentée |
+
+La fonction ne doit pas être appelée par le handshake avant l’ajout de son implémentation et de vecteurs de référence. La suite de tests actuelle valide la base déjà fusionnée, mais ne fournit aucune assurance sur RSA.
+
+> Cette PR est un point de cadrage API et non une livraison de cryptographie RSA. Elle ne rend pas les certificats ni `ServerKeyExchange` authentifiés.
+
+## Validation de la base
+
+Le build i386 et la suite Unity existante sont verts : **332/332 tests**, zéro échec et zéro test ignoré. Ces résultats ne constituent pas des tests RSA.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -228,3 +228,8 @@ Validation AOS-201/AOS-208 : **330/330 tests verts**, build i386 réussi, smokes
 Un lecteur DER borné et un parseur X.509 minimal publient maintenant sans copie le TBSCertificate, le serial, issuer, subject, dates de validité et la clé publique RSA du certificat serveur. Le handshake peut déclencher explicitement cette analyse après réception de Certificate. Les longueurs tronquées, indéfinies ou incohérentes sont rejetées.
 
 Validation AOS-209/AOS-216 : **332/332 tests verts**, build i386 réussi. La chaîne de confiance, les dates, l’hôte, les usages, les signatures de certificats, ECDHE réel, la signature ServerKeyExchange et l’orchestration TLS de production restent à implémenter. Référence : [aos209_216_x509_der.md](aos209_216_x509_der.md).
+
+
+### AOS-217 — Interface RSA PKCS#1 v1.5 SHA-256 : état
+
+L’interface caller-owned `rsa_pkcs1_v15_sha256_verify` est réservée pour la future vérification de signature. Elle ne contient encore ni bigint, ni exponentiation modulaire, ni décodage PKCS#1, ni tests RSA, ni intégration `ServerKeyExchange` ; elle ne fournit donc aucune authentification. Référence : [aos217_rsa_interface_status.md](aos217_rsa_interface_status.md).

--- a/kernel/rsa_verify.h
+++ b/kernel/rsa_verify.h
@@ -1,0 +1,10 @@
+#ifndef AIOS_RSA_VERIFY_H
+#define AIOS_RSA_VERIFY_H
+#include <stdint.h>
+/* Vérifie une signature PKCS#1 v1.5 SHA-256 avec espaces de travail fournis par l'appelant. */
+int rsa_pkcs1_v15_sha256_verify(const uint8_t* modulus, uint16_t modulus_length,
+                                const uint8_t* exponent, uint16_t exponent_length,
+                                const uint8_t digest[32], const uint8_t* signature,
+                                uint16_t signature_length, uint8_t* workspace,
+                                uint16_t workspace_length);
+#endif


### PR DESCRIPTION
## Portée exacte\n\nCette PR intègre uniquement le contrat caller-owned `rsa_pkcs1_v15_sha256_verify` et son rapport d’état.\n\n## Non livré\n\nAucune arithmétique bigint, exponentiation RSA, vérification PKCS#1 v1.5 SHA-256, vecteur RSA ou intégration ServerKeyExchange n’est présente. Cette PR ne rend aucune signature TLS vérifiée.\n\n## Validation\n\nLa base existante compile et `make test-all` est vert avec 332/332 tests. Ces tests ne couvrent pas RSA.