### PR TITLE
feat(http): POST JSON borné sur TLS

### DIFF
--- a/docs/aos281_288_http_post_json.md
+++ b/docs/aos281_288_http_post_json.md
@@ -1,0 +1,28 @@
+# AOS-281 à AOS-288 — HTTP POST JSON borné sur TLS
+
+## Périmètre livré
+
+Ce macro-lot apporte l’émission d’une requête HTTP/1.1 `POST` contenant un body JSON fourni par l’appelant. Le constructeur écrit tous les octets dans un buffer de requête caller-owned, calcule sa longueur au format décimal et fixe les en-têtes nécessaires à un échange HTTP/1.1 minimal.
+
+| Élément | Garantie livrée |
+|---|---|
+| Méthode et cible | `POST <path> HTTP/1.1`, avec chemin obligatoire commençant par `/`. |
+| En-têtes | `Host`, `Content-Type: application/json`, `Content-Length` et `Connection: close`. |
+| Longueur du body | Valeur décimale de `0` à `65 535`, calculée à partir de `json_length`. |
+| Corps | Suite d’octets caller-owned, copiée sans terminaison implicite ni allocation. |
+| Transport | `net_http_tls_build_post_json` chiffre le plaintext HTTP dans un record applicatif TLS AES-GCM puis l’encapsule dans TCP. |
+| Erreurs | Les pointeurs requis, les chemins invalides et les insuffisances de capacité sont rejetés avant l’envoi. |
+
+## Validation appliquée
+
+Les tests unitaires vérifient la requête complète destinée à une API de complétions, y compris `Content-Length: 30` pour le JSON de test. Ils couvrent également un buffer trop petit, un chemin sans `/` initial, un body non nul absent et le round-trip réel : POST construit, chiffré AES-GCM, encapsulé TCP, parsé et déchiffré côté serveur simulé. Le plaintext déchiffré est comparé octet pour octet à la requête attendue.
+
+> Le module construit un framing HTTP sûr et borné ; il ne valide pas la syntaxe ou la sémantique du document JSON. Celle-ci reste sous la responsabilité de l’appelant qui fournit le body et sa taille.
+
+## Contrat mémoire
+
+Les buffers de requête HTTP, record TLS, segment TCP et plaintext de vérification appartiennent tous à l’appelant. Les fonctions n’allouent pas de mémoire dynamique et n’utilisent pas `kmalloc`.
+
+## Limites explicites
+
+Le POST est livré comme un record applicatif TLS unique ; il ne fragmente pas encore une très grande requête HTTP sur plusieurs records TLS ou segments TCP. `Transfer-Encoding: chunked`, les réponses sans `Content-Length`, HTTP/2, les en-têtes d’autorisation, Bearer/API keys, OAuth, les certificats clients, la compression, les retries applicatifs et le streaming de génération ne sont pas fournis. Le handshake de production déclenché depuis le pilote, la validation du nom d’hôte, la chaîne de confiance X.509, les dates et le backend X25519 constante-temps restent hors périmètre.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -298,3 +298,10 @@ Le module HTTP/TLS expose désormais `net_http_response_accumulator_t` et `net_h
 Le test couvre une réponse `200` dont le body de cinq octets arrive en deux records TLS successifs. Référence : [aos273_280_http_content_length_stream.md](aos273_280_http_content_length_stream.md).
 
 `Transfer-Encoding: chunked`, les réponses terminées par fermeture, trailers, compression, HTTP/2, POST, authentification applicative, pagination, streaming LLM, handshake de production, chaîne X.509, dates, nom d’hôte et backend X25519 constante-temps restent non implémentés.
+
+
+### AOS-281 à AOS-288 — HTTP POST JSON borné sur TLS
+
+La couche HTTP/TLS fournit `net_http_build_post_json` et `net_http_tls_build_post_json`. La première construit un POST HTTP/1.1 caller-owned avec `Host`, `Content-Type: application/json`, `Content-Length` décimal et `Connection: close`; la seconde chiffre ce plaintext dans un record TLS AES-GCM encapsulé dans TCP. Les tests contrôlent le framing exact, les refus de paramètres ou capacités invalides et le déchiffrement octet pour octet côté serveur simulé.
+
+Référence : [aos281_288_http_post_json.md](aos281_288_http_post_json.md). L’implémentation n’assure pas encore la fragmentation de très grandes requêtes, chunked, HTTP/2, authentification HTTP/API, retries, streaming LLM, handshake de production, hostname, chaîne X.509, dates ni X25519 constante-temps.

--- a/kernel/net_http_tls.c
+++ b/kernel/net_http_tls.c
@@ -16,6 +16,24 @@ static int net_http_append_text(uint8_t* output,uint16_t capacity,uint16_t* leng
     return 0;
 }
 
+static int net_http_append_bytes(uint8_t* output,uint16_t capacity,uint16_t* length,const uint8_t* input,uint16_t input_length){
+    uint16_t index;
+    if(!output||!length||(!input&&input_length)||(uint32_t)*length+input_length>capacity)return -1;
+    for(index=0U;index<input_length;index++)output[*length+index]=input[index];
+    *length=(uint16_t)(*length+input_length);
+    return 0;
+}
+
+static int net_http_append_uint16(uint8_t* output,uint16_t capacity,uint16_t* length,uint16_t value){
+    uint16_t divisor=10000U;uint8_t emitted=0U;
+    while(divisor>0U){
+        uint8_t digit=(uint8_t)(value/divisor);
+        if(digit||emitted||divisor==1U){if(net_http_append_char(output,capacity,length,(uint8_t)('0'+digit))!=0)return -1;emitted=1U;}
+        value=(uint16_t)(value%divisor);divisor=(uint16_t)(divisor/10U);
+    }
+    return 0;
+}
+
 static int net_http_prefix(const uint8_t* input,uint16_t length,uint16_t offset,const char* text){
     uint16_t index=0U;
     while(text[index]){if((uint16_t)(offset+index)>=length||input[offset+index]!=(uint8_t)text[index])return 0;index++;}
@@ -52,6 +70,19 @@ int net_http_build_get(uint8_t* request,uint16_t capacity,const char* host,const
 
 int net_http_tls_build_get(net_tcp_connection_t* connection,net_tls_aes_gcm_session_t* session,uint8_t* tcp_segment,uint32_t tcp_capacity,uint8_t* tls_record,uint32_t tls_capacity,uint8_t* request,uint16_t request_capacity,const char* host,const char* path,uint8_t retransmit_limit){
     int request_length=net_http_build_get(request,request_capacity,host,path);
+    if(request_length<0)return -1;
+    return net_tcp_connection_build_tls_aes_gcm(connection,session,tcp_segment,tcp_capacity,tls_record,tls_capacity,NET_TLS_CONTENT_APPLICATION_DATA,request,(uint16_t)request_length,retransmit_limit);
+}
+
+int net_http_build_post_json(uint8_t* request,uint16_t capacity,const char* host,const char* path,const uint8_t* json,uint16_t json_length){
+    uint16_t length=0U;
+    if(!request||!host||!path||path[0]!='/'||(!json&&json_length))return -1;
+    if(net_http_append_text(request,capacity,&length,"POST")!=0||net_http_append_char(request,capacity,&length,' ')!=0||net_http_append_text(request,capacity,&length,path)!=0||net_http_append_char(request,capacity,&length,' ')!=0||net_http_append_text(request,capacity,&length,"HTTP/1.1")!=0||net_http_append_char(request,capacity,&length,'\r')!=0||net_http_append_char(request,capacity,&length,'\n')!=0||net_http_append_text(request,capacity,&length,"Host:")!=0||net_http_append_char(request,capacity,&length,' ')!=0||net_http_append_text(request,capacity,&length,host)!=0||net_http_append_char(request,capacity,&length,'\r')!=0||net_http_append_char(request,capacity,&length,'\n')!=0||net_http_append_text(request,capacity,&length,"Content-Type:")!=0||net_http_append_char(request,capacity,&length,' ')!=0||net_http_append_text(request,capacity,&length,"application/json")!=0||net_http_append_char(request,capacity,&length,'\r')!=0||net_http_append_char(request,capacity,&length,'\n')!=0||net_http_append_text(request,capacity,&length,"Content-Length:")!=0||net_http_append_char(request,capacity,&length,' ')!=0||net_http_append_uint16(request,capacity,&length,json_length)!=0||net_http_append_char(request,capacity,&length,'\r')!=0||net_http_append_char(request,capacity,&length,'\n')!=0||net_http_append_text(request,capacity,&length,"Connection:")!=0||net_http_append_char(request,capacity,&length,' ')!=0||net_http_append_text(request,capacity,&length,"close")!=0||net_http_append_char(request,capacity,&length,'\r')!=0||net_http_append_char(request,capacity,&length,'\n')!=0||net_http_append_char(request,capacity,&length,'\r')!=0||net_http_append_char(request,capacity,&length,'\n')!=0||net_http_append_bytes(request,capacity,&length,json,json_length)!=0)return -2;
+    return (int)length;
+}
+
+int net_http_tls_build_post_json(net_tcp_connection_t* connection,net_tls_aes_gcm_session_t* session,uint8_t* tcp_segment,uint32_t tcp_capacity,uint8_t* tls_record,uint32_t tls_capacity,uint8_t* request,uint16_t request_capacity,const char* host,const char* path,const uint8_t* json,uint16_t json_length,uint8_t retransmit_limit){
+    int request_length=net_http_build_post_json(request,request_capacity,host,path,json,json_length);
     if(request_length<0)return -1;
     return net_tcp_connection_build_tls_aes_gcm(connection,session,tcp_segment,tcp_capacity,tls_record,tls_capacity,NET_TLS_CONTENT_APPLICATION_DATA,request,(uint16_t)request_length,retransmit_limit);
 }

--- a/kernel/net_http_tls.h
+++ b/kernel/net_http_tls.h
@@ -29,6 +29,15 @@ int net_http_tls_build_get(net_tcp_connection_t* connection,net_tls_aes_gcm_sess
                            uint8_t* request,uint16_t request_capacity,const char* host,const char* path,
                            uint8_t retransmit_limit);
 
+/* Construit un POST HTTP/1.1 JSON, avec Content-Type, Content-Length et Connection: close. */
+int net_http_build_post_json(uint8_t* request,uint16_t capacity,const char* host,const char* path,
+                             const uint8_t* json,uint16_t json_length);
+/* Chiffre un POST JSON dans un record TLS applicatif et l’encapsule dans un segment TCP. */
+int net_http_tls_build_post_json(net_tcp_connection_t* connection,net_tls_aes_gcm_session_t* session,
+                                 uint8_t* tcp_segment,uint32_t tcp_capacity,uint8_t* tls_record,uint32_t tls_capacity,
+                                 uint8_t* request,uint16_t request_capacity,const char* host,const char* path,
+                                 const uint8_t* json,uint16_t json_length,uint8_t retransmit_limit);
+
 /* Parse une réponse HTTP/1.1 complète déjà déchiffrée. Le body reste une vue sur plaintext. */
 int net_http_response_parse(const uint8_t* plaintext,uint16_t plaintext_length,net_http_response_view_t* out);
 /* Accumule une réponse HTTP/1.1 Content-Length à travers plusieurs plaintexts TLS.

--- a/tests/unit/kernel/test_net_http_tls.c
+++ b/tests/unit/kernel/test_net_http_tls.c
@@ -34,6 +34,30 @@ void test_http_tls_get_and_response(void){
     TEST_ASSERT_EQUAL(200,response.status_code);TEST_ASSERT_EQUAL(2,response.body_length);TEST_ASSERT_EQUAL('o',response.body[0]);TEST_ASSERT_EQUAL('k',response.body[1]);
 }
 
+void test_http_post_json_build_and_bounds(void){
+    static const uint8_t json[]={ '{','"','m','o','d','e','l','"',':','"','g','p','t','2','"',',','"','p','r','o','m','p','t','"',':','"','h','i','"','}' };
+    static const uint8_t expected[]="POST /v1/completions HTTP/1.1\r\nHost: api.example.test\r\nContent-Type: application/json\r\nContent-Length: 30\r\nConnection: close\r\n\r\n{\"model\":\"gpt2\",\"prompt\":\"hi\"}";
+    uint8_t request[192]={0};
+    TEST_ASSERT_EQUAL((int)(sizeof(expected)-1U),net_http_build_post_json(request,sizeof(request),"api.example.test","/v1/completions",json,sizeof(json)));
+    TEST_ASSERT_EQUAL_MEMORY(expected,request,sizeof(expected)-1U);
+    TEST_ASSERT_NOT_EQUAL(0,net_http_build_post_json(request,12U,"api.example.test","/v1/completions",json,sizeof(json)));
+    TEST_ASSERT_NOT_EQUAL(0,net_http_build_post_json(request,sizeof(request),"api.example.test","v1/completions",json,sizeof(json)));
+    TEST_ASSERT_NOT_EQUAL(0,net_http_build_post_json(request,sizeof(request),"api.example.test","/v1/completions",0,1U));
+}
+
+void test_http_tls_post_json_encrypted(void){
+    net_tcp_connection_t client,server;net_tls_aes_gcm_session_t client_session,server_session;net_tcp_view_t view;net_tls_record_view_t record;
+    static const uint8_t json[]={ '{','"','m','o','d','e','l','"',':','"','g','p','t','2','"',',','"','p','r','o','m','p','t','"',':','"','h','i','"','}' };
+    static const uint8_t expected[]="POST /v1/completions HTTP/1.1\r\nHost: api.example.test\r\nContent-Type: application/json\r\nContent-Length: 30\r\nConnection: close\r\n\r\n{\"model\":\"gpt2\",\"prompt\":\"hi\"}";
+    uint8_t key_material[40]={0},tcp_segment[256]={0},tls_record[224]={0},request[192]={0},plaintext[192]={0};uint16_t consumed=0U;int length;
+    open_pair(&client,&server,&client_session,&server_session,key_material);
+    length=net_http_tls_build_post_json(&client,&client_session,tcp_segment,sizeof(tcp_segment),tls_record,sizeof(tls_record),request,sizeof(request),"api.example.test","/v1/completions",json,sizeof(json),1U);
+    TEST_ASSERT_EQUAL((int)(20U+5U+8U+sizeof(expected)-1U+16U),length);TEST_ASSERT_EQUAL(1,client_session.write_sequence);
+    TEST_ASSERT_EQUAL(0,net_tcp_parse(tcp_segment,(uint16_t)length,&view));
+    TEST_ASSERT_EQUAL(0,net_tcp_connection_accept_tls_aes_gcm(&server,&server_session,&view,plaintext,sizeof(plaintext),&record,&consumed));
+    TEST_ASSERT_EQUAL(sizeof(expected)-1U,record.payload_length);TEST_ASSERT_EQUAL_MEMORY(expected,plaintext,sizeof(expected)-1U);TEST_ASSERT_EQUAL(1,server_session.read_sequence);
+}
+
 void test_http_tls_response_stream_content_length(void){net_tcp_connection_t client,server;net_tls_aes_gcm_session_t client_session,server_session;net_tcp_view_t view;net_http_response_accumulator_t accumulator;net_http_response_view_t response;uint8_t key_material[40]={0},first_segment[128]={0},second_segment[96]={0},first_record[96]={0},second_record[64]={0},plaintext[96]={0},response_buffer[96]={0},first_response[]={ 'H','T','T','P','/','1','.','1',' ','2','0','0',' ','O','K','\r','\n','C','o','n','t','e','n','t','-','L','e','n','g','t','h',':',' ','5','\r','\n','\r','\n','h','e'},second_response[]={ 'l','l','o'};uint16_t consumed=0U;int length;open_pair(&client,&server,&client_session,&server_session,key_material);TEST_ASSERT_EQUAL(0,net_http_response_accumulator_init(&accumulator,response_buffer,sizeof(response_buffer)));length=net_tcp_connection_build_tls_aes_gcm(&server,&server_session,first_segment,sizeof(first_segment),first_record,sizeof(first_record),NET_TLS_CONTENT_APPLICATION_DATA,first_response,sizeof(first_response),1U);TEST_ASSERT_EQUAL(89,length);TEST_ASSERT_EQUAL(0,net_tcp_parse(first_segment,(uint16_t)length,&view));TEST_ASSERT_EQUAL(1,net_http_tls_open_response_stream(&client,&client_session,&view,plaintext,sizeof(plaintext),&accumulator,&response,&consumed));TEST_ASSERT_EQUAL(sizeof(first_response),accumulator.length);TEST_ASSERT_EQUAL(1,accumulator.headers_complete);TEST_ASSERT_EQUAL(1,client_session.read_sequence);TEST_ASSERT_EQUAL(0,net_tcp_connection_commit_send(&server,69U));length=net_tcp_connection_build_tls_aes_gcm(&server,&server_session,second_segment,sizeof(second_segment),second_record,sizeof(second_record),NET_TLS_CONTENT_APPLICATION_DATA,second_response,sizeof(second_response),1U);TEST_ASSERT_EQUAL(52,length);TEST_ASSERT_EQUAL(0,net_tcp_parse(second_segment,(uint16_t)length,&view));TEST_ASSERT_EQUAL(0,net_http_tls_open_response_stream(&client,&client_session,&view,plaintext,sizeof(plaintext),&accumulator,&response,&consumed));TEST_ASSERT_EQUAL(200,response.status_code);TEST_ASSERT_EQUAL(5,response.body_length);TEST_ASSERT_EQUAL('h',response.body[0]);TEST_ASSERT_EQUAL('o',response.body[4]);TEST_ASSERT_EQUAL(2,client_session.read_sequence);}
 void test_http_response_parse_rejects_invalid_framing(void){
     net_http_response_view_t response;uint8_t invalid[]={ 'N','O','T',' ','H','T','T','P','\r','\n','\r','\n'};uint8_t incomplete[]={ 'H','T','T','P','/','1','.','1',' ','2','0','0',' ','O','K','\r','\n'};
@@ -41,4 +65,4 @@ void test_http_response_parse_rejects_invalid_framing(void){
     TEST_ASSERT_NOT_EQUAL(0,net_http_response_parse(incomplete,sizeof(incomplete),&response));
 }
 
-int main(void){unity_init();RUN_TEST(test_http_tls_get_and_response);RUN_TEST(test_http_tls_response_stream_content_length);RUN_TEST(test_http_response_parse_rejects_invalid_framing);unity_print_results();unity_cleanup();return unity_stats.tests_failed==0?0:1;}
+int main(void){unity_init();RUN_TEST(test_http_tls_get_and_response);RUN_TEST(test_http_post_json_build_and_bounds);RUN_TEST(test_http_tls_post_json_encrypted);RUN_TEST(test_http_tls_response_stream_content_length);RUN_TEST(test_http_response_parse_rejects_invalid_framing);unity_print_results();unity_cleanup();return unity_stats.tests_failed==0?0:1;}


### PR DESCRIPTION
## Périmètre

- ajoute `net_http_build_post_json` pour construire un POST HTTP/1.1 caller-owned avec Host, `Content-Type: application/json`, Content-Length et Connection: close ;
- ajoute `net_http_tls_build_post_json` pour chiffrer puis encapsuler ce POST dans TLS AES-GCM/TCP ;
- couvre les capacités insuffisantes, les paramètres invalides et un round-trip serveur déchiffré octet pour octet ;
- documente le lot AOS-281 à AOS-288 et ses limites.

## Validation locale

- `make test-all` : 348/348 tests réussis ;
- `make all` : build i386 freestanding réussi ;
- `make qemu-ai-provider` : smoke réussi ;
- `make qemu-ne2k-status` : smoke réussi.

## Limites explicites

La fragmentation des grandes requêtes, chunked, HTTP/2, l’authentification API, les retries, le streaming LLM, le handshake de production, hostname, la chaîne X.509, les dates et X25519 constante-temps restent hors périmètre.