### PR TITLE
feat(tls): orchestrateur handshake depuis NE2000

### DIFF
--- a/docs/aos305_312_ne2k_tls_orchestrator.md
+++ b/docs/aos305_312_ne2k_tls_orchestrator.md
@@ -1,0 +1,30 @@
+# AOS-305 à AOS-312 — orchestrateur TLS depuis NE2000
+
+## Périmètre livré
+
+Le pilote NE2000 expose désormais un contexte `ne2k_tls_client_t` entièrement caller-owned et deux opérations de haut niveau : `ne2k_tls_client_start` pour émettre le ClientHello sur une connexion TCP établie, puis `ne2k_tls_client_poll` pour traiter les segments TLS reçus par NE2000.
+
+| Étape | Opération fournie |
+|---|---|
+| Initialisation | `ne2k_tls_client_init` initialise le réassembleur TCP/TLS, le transcript, le contexte X25519, les secrets et la session AEAD avec des buffers fournis par l’appelant. |
+| ClientHello | `ne2k_tls_client_start` construit le record TLS, note l’état/transcript, suit le payload TCP, l’émet par NE2000 puis avance la séquence seulement après soumission réussie. |
+| Messages serveur | `ne2k_tls_client_poll` utilise le réassembleur authentifié TCP/TLS existant ; les fragments incomplets sont conservés et renvoient `1`. |
+| Identité serveur | Après `Certificate`, la feuille doit valider la chaîne RSA à une ancre fournie et correspondre au hostname demandé avant le flight. |
+| Flight client | Après `ServerHelloDone`, le wrapper construit le flight X25519 (ClientKeyExchange, CCS, Finished), l’émet sur NE2000 et confirme la séquence TCP. |
+| Post-flight | Le même polling accepte CCS puis Finished serveur AES-GCM ; le contexte indique `complete` lorsque le handshake est achevé. |
+
+## Transactionnalité et mémoire
+
+Les structures TCP et TLS sont sauvegardées avant toute réception qui peut échouer. Une erreur de framing, de signature, de chaîne, de hostname, de flight ou de post-flight restaure connexion, automate, transcript, contextes X25519/AEAD et longueurs publiées. Le TX ClientHello maintient également une copie de travail : l’état ne progresse qu’après soumission NE2000 et commit TCP.
+
+Aucun buffer n’est alloué : l’appelant fournit les buffers records, handshake, transcript, trames RX/TX, segment TCP, flight, plaintext ainsi que les workspaces RSA, X25519 et PRF.
+
+## Validation
+
+Le test NE2000 initialise une connexion TCP établie et son cache ARP, initialise l’orchestrateur, émet un ClientHello, contrôle le record TLS à l’emplacement TCP attendu, l’avancement de `local_sequence`, le transcript et l’état `CLIENT_HELLO_SENT`. Il couvre également un polling NE2000 vide : aucun octet, flight ou état TLS n’est publié/modifié. Les tests TCP/TLS existants couvrent séparément le réassemblage authentifié, la construction transactionnelle du flight X25519, le rollback d’authentification et le post-flight AES-GCM.
+
+> Le nouveau wrapper coordonne les primitives disponibles ; il ne transforme pas encore le système en client HTTPS de production autonome.
+
+## Limites explicites
+
+Le polling accepte encore un message TLS serveur par record au niveau du réassembleur existant. Les certificats clients sont refusés car le flight X25519 actuel ne les construit pas. La chaîne reste limitée à une ancre RSA directe, sans intermédiaires, dates, usages, révocation ni ECDSA. L’exemple d’intégration ne couvre pas un échange réseau réel complet dans QEMU contre un serveur TLS externe, la résolution/connexion end-to-end, HTTP LLM, l’authentification API, les retries et la fragmentation des grandes requêtes. X25519/bigint reste non constante-temps.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -321,3 +321,12 @@ Référence : [aos289_296_tls_hostname.md](aos289_296_tls_hostname.md). Les IP, 
 Le test utilise une racine RSA 1024 bits et une feuille RSA/SHA-256 signée, intégrées comme vecteur DER hors ligne ; il couvre le succès, un émetteur d’ancre altéré et une signature tronquée. Référence : [aos297_304_x509_trust_chain.md](aos297_304_x509_trust_chain.md).
 
 Les intermédiaires, dates, contraintes et usages de clé, révocation, ECDSA/EdDSA, algorithmes SHA-384+, configuration des ancres et invocation automatique depuis NE2000 restent absents. Le hostname demeure une validation séparée et X25519/bigint reste non constante-temps.
+
+
+### AOS-305 à AOS-312 — orchestrateur handshake TLS depuis NE2000
+
+`ne2k_tls_client_t` relie désormais le polling TCP NE2000 au réassembleur TLS authentifié, à la validation de chaîne RSA à une ancre et hostname, au flight X25519 et au post-flight AES-GCM. `ne2k_tls_client_start` émet ClientHello transactionnellement ; `ne2k_tls_client_poll` accumule les fragments, contrôle l’identité, émet le flight une fois `ServerHelloDone` reçu et marque le handshake complet après Finished serveur.
+
+Le contexte et tous les buffers/workspaces sont caller-owned. Les tests NE2000 couvrent l’initialisation, l’émission ClientHello, les séquences/transcript et le polling vide sans mutation ; les tests TCP/TLS existants couvrent le flux cryptographique sous-jacent. Référence : [aos305_312_ne2k_tls_orchestrator.md](aos305_312_ne2k_tls_orchestrator.md).
+
+Le flux ne constitue pas encore un HTTPS de production : un message serveur par record, pas de certificats clients, chaîne RSA directe sans intermédiaires/dates/usages/révocation/ECDSA, pas de test QEMU contre un serveur externe, ni résolution/connexion complète, HTTP LLM, auth API, retries ou fragmentation de grosses requêtes. X25519/bigint reste non constante-temps.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -679,3 +679,81 @@ int ne2k_prepare(ne2k_device_t* device, const ne2k_io_t* io) {
     device->initialized = 1U;
     return 0;
 }
+
+int ne2k_tls_client_init(ne2k_tls_client_t* client,uint8_t* record_buffer,uint16_t record_capacity,
+                         uint8_t* handshake_buffer,uint16_t handshake_capacity,
+                         uint8_t* transcript_buffer,uint16_t transcript_capacity){
+    uint8_t index;
+    if(!client)return -1;
+    if(net_tcp_tls_stream_init(&client->stream,record_buffer,record_capacity,handshake_buffer,handshake_capacity)!=0)return -2;
+    if(net_tls_handshake_init(&client->handshake)!=0)return -3;
+    if(net_tls_transcript_init(&client->transcript,transcript_buffer,transcript_capacity)!=0)return -4;
+    for(index=0U;index<48U;index++)client->master_secret[index]=0U;
+    for(index=0U;index<NET_TLS_AES_128_GCM_KEY_BLOCK_LENGTH;index++)client->key_block[index]=0U;
+    for(index=0U;index<NET_TLS_X25519_KEY_LENGTH;index++){client->x25519.client_public[index]=0U;client->x25519.shared_secret[index]=0U;}
+    client->x25519.ready=0U;client->session.write_key=0;client->session.read_key=0;client->session.write_fixed_iv=0;client->session.read_fixed_iv=0;client->session.write_sequence=0U;client->session.read_sequence=0U;client->peer_identity_validated=0U;client->complete=0U;
+    return 0;
+}
+
+int ne2k_tls_client_start(ne2k_device_t* device,const ne2k_io_t* io,const net_arp_cache_t* cache,
+                          uint8_t* tx_frame,uint16_t tx_capacity,const uint8_t local_ip[4],const uint8_t remote_ip[4],
+                          net_tcp_connection_t* connection,ne2k_tls_client_t* client,
+                          const uint8_t client_random[32],uint8_t* client_hello_record,uint32_t client_hello_capacity,
+                          uint8_t retransmit_limit){
+    ne2k_tls_client_t next_client;net_tcp_connection_t next_connection;net_tls_record_view_t record;int length,status;
+    if(!device||!io||!cache||!tx_frame||!local_ip||!remote_ip||!connection||!client||!client_random||!client_hello_record)return -1;
+    if(connection->state!=NET_TCP_STATE_ESTABLISHED||client->handshake.state!=NET_TLS_HANDSHAKE_IDLE)return -2;
+    next_client=*client;next_connection=*connection;
+    length=net_tls_client_hello_build(client_hello_record,client_hello_capacity,client_random);
+    if(length<0||net_tls_record_parse(client_hello_record,(uint32_t)length,&record)!=0)return -3;
+    if(net_tls_handshake_note_client_hello(&next_client.handshake)!=0||net_tls_transcript_append(&next_client.transcript,record.payload,record.payload_length)!=0)return -4;
+    if(net_tcp_connection_track_send(&next_connection,client_hello_record,(uint16_t)length,retransmit_limit)!=0)return -5;
+    status=ne2k_tcp_data(device,io,cache,tx_frame,tx_capacity,local_ip,remote_ip,&next_connection,client_hello_record,(uint16_t)length);
+    if(status!=0)return -6;
+    if(net_tcp_connection_commit_send(&next_connection,(uint16_t)length)!=0)return -7;
+    *connection=next_connection;*client=next_client;return length;
+}
+
+int ne2k_tls_client_poll(ne2k_device_t* device,const ne2k_io_t* io,const net_arp_cache_t* cache,
+                         uint8_t* rx_frame,uint16_t rx_capacity,uint8_t* tx_frame,uint16_t tx_capacity,
+                         const uint8_t local_ip[4],const uint8_t remote_ip[4],net_tcp_connection_t* connection,
+                         ne2k_tls_client_t* client,const uint8_t client_random[32],const uint8_t client_private[NET_TLS_X25519_KEY_LENGTH],
+                         const x509_certificate_view_t* trust_anchor,const char* hostname,
+                         uint32_t* rsa_workspace,uint16_t rsa_workspace_length,
+                         uint32_t* x25519_workspace,uint16_t x25519_workspace_length,
+                         uint8_t* prf_workspace,uint32_t prf_workspace_capacity,
+                         uint8_t* tcp_segment,uint32_t tcp_segment_capacity,
+                         uint8_t* flight_records,uint32_t flight_records_capacity,uint32_t* flight_records_length,
+                         uint8_t* plaintext,uint16_t plaintext_capacity,uint8_t retransmit_limit,uint16_t* consumed){
+    ne2k_tls_client_t previous_client;net_tcp_connection_t previous_connection;net_tcp_view_t view;uint16_t frame_length=0U;uint32_t local_flight_length=0U;int status;
+    if(!device||!io||!cache||!rx_frame||!tx_frame||!local_ip||!remote_ip||!connection||!client||!client_random||!client_private||!trust_anchor||!hostname||!rsa_workspace||!x25519_workspace||!prf_workspace||!tcp_segment||!flight_records||!flight_records_length||!plaintext||!consumed)return -1;
+    *consumed=0U;*flight_records_length=0U;
+    status=ne2k_rx_poll_tcp(device,io,rx_frame,rx_capacity,&frame_length,&view);
+    if(status!=0)return status;
+    previous_client=*client;previous_connection=*connection;
+    if(client->handshake.state==NET_TLS_HANDSHAKE_FINISHED_SENT||client->handshake.state==NET_TLS_HANDSHAKE_SERVER_CHANGE_CIPHER_SPEC_RECEIVED){
+        status=net_tcp_connection_accept_tls_x25519_postflight(connection,&client->handshake,&client->transcript,client->master_secret,&client->session,&view,plaintext,plaintext_capacity,prf_workspace,prf_workspace_capacity,consumed);
+        if(status!=0)goto rollback;
+        if(ne2k_tcp_ack(device,io,cache,tx_frame,tx_capacity,local_ip,remote_ip,connection)!=0)goto rollback;
+        if(net_tls_handshake_is_complete(&client->handshake))client->complete=1U;
+        return 0;
+    }
+    status=net_tcp_connection_accept_tls_authenticated_fragment(connection,&view,&client->stream,&client->handshake,client_random,&client->transcript,rsa_workspace,rsa_workspace_length,consumed);
+    if(status<0)goto rollback;
+    if(ne2k_tcp_ack(device,io,cache,tx_frame,tx_capacity,local_ip,remote_ip,connection)!=0)goto rollback;
+    if(status==1)return 1;
+    if(client->handshake.state==NET_TLS_HANDSHAKE_CERTIFICATE_RECEIVED){
+        if(x509_certificate_chain_validate_one(&client->handshake.server_x509,trust_anchor,rsa_workspace,rsa_workspace_length)!=0||x509_certificate_hostname_validate(&client->handshake.server_x509,hostname)!=0)goto rollback;
+        client->peer_identity_validated=1U;
+    }
+    if(client->handshake.state!=NET_TLS_HANDSHAKE_SERVER_HELLO_DONE_RECEIVED)return 0;
+    if(!client->peer_identity_validated||client->handshake.certificate_requested)return 0;
+    status=net_tcp_connection_build_tls_x25519_flight(connection,&client->handshake,&client->x25519,client_private,client_random,&client->transcript,client->master_secret,client->key_block,&client->session,tcp_segment,tcp_segment_capacity,flight_records,flight_records_capacity,&local_flight_length,x25519_workspace,x25519_workspace_length,prf_workspace,prf_workspace_capacity,retransmit_limit);
+    if(status<0)goto rollback;
+    if(ne2k_tcp_data(device,io,cache,tx_frame,tx_capacity,local_ip,remote_ip,connection,flight_records,(uint16_t)local_flight_length)!=0)goto rollback;
+    if(net_tcp_connection_commit_send(connection,(uint16_t)local_flight_length)!=0)goto rollback;
+    *flight_records_length=local_flight_length;
+    return 0;
+rollback:
+    *client=previous_client;*connection=previous_connection;*consumed=0U;*flight_records_length=0U;return -2;
+}

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -63,6 +63,18 @@ typedef struct {
     uint8_t mac_valid;
 } ne2k_device_t;
 
+typedef struct {
+    net_tcp_tls_stream_t stream;
+    net_tls_handshake_t handshake;
+    net_tls_transcript_t transcript;
+    net_tls_x25519_context_t x25519;
+    net_tls_aes_gcm_session_t session;
+    uint8_t master_secret[48];
+    uint8_t key_block[NET_TLS_AES_128_GCM_KEY_BLOCK_LENGTH];
+    uint8_t peer_identity_validated;
+    uint8_t complete;
+} ne2k_tls_client_t;
+
 /* Sonde le registre reset et prépare le mode arrêt/word pour une init ultérieure. */
 int ne2k_probe(ne2k_device_t* device, uint16_t base_port, const ne2k_io_t* io);
 /* Prépare les callbacks de ports i386 réels; retourne -1 hors noyau i386. */
@@ -170,6 +182,29 @@ int ne2k_tcp_poll_fin_ack(ne2k_device_t* device, const ne2k_io_t* io,
                           uint16_t rx_capacity, uint8_t* tx_frame, uint16_t tx_capacity,
                           const uint8_t local_ip[4], const uint8_t remote_ip[4],
                           net_tcp_connection_t* connection);
+
+/* Initialise l’état TLS intégralement caller-owned : stream, transcript, clés et session. */
+int ne2k_tls_client_init(ne2k_tls_client_t* client,uint8_t* record_buffer,uint16_t record_capacity,
+                         uint8_t* handshake_buffer,uint16_t handshake_capacity,
+                         uint8_t* transcript_buffer,uint16_t transcript_capacity);
+/* Construit, émet et confirme transactionnellement le ClientHello TLS sur TCP établi. */
+int ne2k_tls_client_start(ne2k_device_t* device,const ne2k_io_t* io,const net_arp_cache_t* cache,
+                          uint8_t* tx_frame,uint16_t tx_capacity,const uint8_t local_ip[4],const uint8_t remote_ip[4],
+                          net_tcp_connection_t* connection,ne2k_tls_client_t* client,
+                          const uint8_t client_random[32],uint8_t* client_hello_record,uint32_t client_hello_capacity,
+                          uint8_t retransmit_limit);
+/* Polling NE2000 : authentifie les messages serveur, valide l’ancre/hostname, émet le flight X25519 puis traite le post-flight. */
+int ne2k_tls_client_poll(ne2k_device_t* device,const ne2k_io_t* io,const net_arp_cache_t* cache,
+                         uint8_t* rx_frame,uint16_t rx_capacity,uint8_t* tx_frame,uint16_t tx_capacity,
+                         const uint8_t local_ip[4],const uint8_t remote_ip[4],net_tcp_connection_t* connection,
+                         ne2k_tls_client_t* client,const uint8_t client_random[32],const uint8_t client_private[NET_TLS_X25519_KEY_LENGTH],
+                         const x509_certificate_view_t* trust_anchor,const char* hostname,
+                         uint32_t* rsa_workspace,uint16_t rsa_workspace_length,
+                         uint32_t* x25519_workspace,uint16_t x25519_workspace_length,
+                         uint8_t* prf_workspace,uint32_t prf_workspace_capacity,
+                         uint8_t* tcp_segment,uint32_t tcp_segment_capacity,
+                         uint8_t* flight_records,uint32_t flight_records_capacity,uint32_t* flight_records_length,
+                         uint8_t* plaintext,uint16_t plaintext_capacity,uint8_t retransmit_limit,uint16_t* consumed);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/tests/unit/kernel/test_ne2k.c
+++ b/tests/unit/kernel/test_ne2k.c
@@ -193,6 +193,18 @@ void test_probe_rejects_missing_reset_ack(void) {
     TEST_ASSERT_NOT_EQUAL(0, ne2k_probe(&device, 0x300, &io));
 }
 
+void test_ne2k_tls_client_start_and_empty_poll(void) {
+    fake_ne2k_t fake = {0x12, NE2K_ISR_RESET | NE2K_ISR_RDC, 0, 0};ne2k_io_t io = {&fake, fake_inb, fake_outb};ne2k_device_t device;net_arp_cache_t cache;net_tcp_connection_t connection;ne2k_tls_client_t client;x509_certificate_view_t anchor={0};
+    uint8_t local_mac[6]={0x02,0,0,0,0,1},remote_mac[6]={0x52,0x54,0,0,0,2},local_ip[4]={10,0,2,15},remote_ip[4]={10,0,2,2},client_random[32]={0},client_private[32]={0};
+    uint8_t record_buffer[256]={0},handshake_buffer[256]={0},transcript_buffer[512]={0},hello_record[256]={0},rx_frame[256]={0},tx_frame[512]={0},tcp_segment[256]={0},flight_records[128]={0},plaintext[128]={0};uint32_t rsa_workspace[224]={0},x25519_workspace[136]={0},flight_length=99U;uint8_t prf_workspace[256]={0};uint16_t consumed=99U;int length;
+    TEST_ASSERT_EQUAL(0,ne2k_probe(&device,0x300,&io));TEST_ASSERT_EQUAL(0,ne2k_prepare(&device,&io));TEST_ASSERT_EQUAL(0,ne2k_configure_rings(&device,&io));TEST_ASSERT_EQUAL(0,ne2k_set_mac(&device,local_mac));TEST_ASSERT_EQUAL(0,net_arp_cache_init(&cache));TEST_ASSERT_EQUAL(0,net_arp_cache_put(&cache,remote_ip,remote_mac));TEST_ASSERT_EQUAL(0,net_tcp_connection_open(&connection,49152U,443U,100U));
+    {net_tcp_view_t syn_ack={443U,49152U,700U,101U,NET_TCP_FLAG_SYN|NET_TCP_FLAG_ACK,0,0};TEST_ASSERT_EQUAL(0,net_tcp_connection_accept_syn_ack(&connection,&syn_ack));}
+    TEST_ASSERT_EQUAL(0,ne2k_tls_client_init(&client,record_buffer,sizeof(record_buffer),handshake_buffer,sizeof(handshake_buffer),transcript_buffer,sizeof(transcript_buffer)));
+    length=ne2k_tls_client_start(&device,&io,&cache,tx_frame,sizeof(tx_frame),local_ip,remote_ip,&connection,&client,client_random,hello_record,sizeof(hello_record),1U);
+    TEST_ASSERT_GREATER_THAN(0,length);TEST_ASSERT_EQUAL(NET_TLS_HANDSHAKE_CLIENT_HELLO_SENT,client.handshake.state);TEST_ASSERT_EQUAL((uint16_t)(length-5),client.transcript.length);TEST_ASSERT_EQUAL((uint32_t)(101U+length),connection.local_sequence);TEST_ASSERT_EQUAL(NET_TLS_CONTENT_HANDSHAKE,tx_frame[54]);
+    fake.isr=NE2K_ISR_RESET;TEST_ASSERT_EQUAL(1,ne2k_tls_client_poll(&device,&io,&cache,rx_frame,sizeof(rx_frame),tx_frame,sizeof(tx_frame),local_ip,remote_ip,&connection,&client,client_random,client_private,&anchor,"api.example.test",rsa_workspace,224U,x25519_workspace,136U,prf_workspace,sizeof(prf_workspace),tcp_segment,sizeof(tcp_segment),flight_records,sizeof(flight_records),&flight_length,plaintext,sizeof(plaintext),1U,&consumed));TEST_ASSERT_EQUAL(0U,consumed);TEST_ASSERT_EQUAL(0U,flight_length);TEST_ASSERT_EQUAL(NET_TLS_HANDSHAKE_CLIENT_HELLO_SENT,client.handshake.state);
+}
+
 int main(void) {
     unity_init();
     RUN_TEST(test_probe_and_prepare_use_injected_io);
@@ -201,6 +213,7 @@ int main(void) {
     RUN_TEST(test_tcp_ack_is_emitted_from_connection_state);
     RUN_TEST(test_rx_extract_publishes_bounded_frame);
     RUN_TEST(test_probe_rejects_missing_reset_ack);
+    RUN_TEST(test_ne2k_tls_client_start_and_empty_poll);
     unity_print_results();
     unity_cleanup();
     return (unity_stats.tests_failed == 0) ? 0 : 1;


### PR DESCRIPTION
## Périmètre

- ajoute un contexte TLS NE2000 entièrement caller-owned ;
- émet ClientHello avec suivi TCP/transcript transactionnel ;
- raccorde le polling NE2000 au réassembleur TLS authentifié ;
- impose chaîne RSA à ancre et hostname avant le flight X25519 ;
- émet le flight et traite le post-flight AES-GCM ;
- ajoute un test NE2000 ClientHello, séquences/transcript et polling RX vide.

## Validation locale

- `make test-all` : 351/351 tests réussis ;
- `make all` : build i386 freestanding réussi ;
- `make qemu-ai-provider` : smoke réussi ;
- `make qemu-ne2k-status` : smoke réussi.

## Limites explicites

Le reassembleur traite encore un message serveur par record. Certificats clients, intermédiaires, dates/usages/révocation/ECDSA, test QEMU contre serveur externe, résolution/connexion end-to-end, HTTP LLM, auth API, retries et fragmentation des grandes requêtes restent hors périmètre. X25519/bigint reste non constante-temps.