### PR TITLE
feat(net): client HTTPS JSON LLM sur NE2000

### DIFF
--- a/docs/aos313_320_https_llm_client.md
+++ b/docs/aos313_320_https_llm_client.md
@@ -1,0 +1,24 @@
+# AOS-313 à AOS-320 — client HTTPS LLM sur NE2000
+
+## Périmètre livré
+
+Le pilote NE2000 fournit deux points d’entrée HTTP sécurisé destinés à un client LLM caller-owned. `ne2k_https_llm_post_json` construit un POST JSON HTTP/1.1, le chiffre dans un record TLS AES-128-GCM de la session du contexte NE2000, l’encapsule dans TCP et l’émet. `ne2k_https_llm_poll_response` reçoit un segment TCP depuis NE2000, ouvre son record TLS, puis transmet le plaintext à l’accumulateur HTTP `Content-Length` existant.
+
+| Opération | Précondition | Résultat |
+|---|---|---|
+| `ne2k_https_llm_post_json` | Handshake TLS `complete`, session AES-GCM prête, cache ARP et connexion TCP établie. | POST `application/json` avec `Content-Length`, record applicatif AES-GCM et commit TCP après TX réussi. |
+| `ne2k_https_llm_poll_response` | Même session TLS complète, accumulateur HTTP caller-owned. | Retourne `1` tant que la réponse est incomplète ; publie la vue body seulement à la taille Content-Length exacte. |
+
+Les deux appels ne réalisent aucune allocation dynamique. Ils reçoivent les trames, le request buffer, le record TLS, le plaintext HTTP, l’accumulateur de réponse et les états TCP/TLS par l’appelant.
+
+## Sécurité et transactionnalité
+
+L’émission refuse toute requête tant que le Finished serveur n’a pas été vérifié par l’orchestrateur. Avant un POST, la séquence TCP et le compteur AEAD d’écriture sont sauvegardés ; une erreur de construction, d’ARP, de TX ou de commit les restaure. La réception applique le rollback déjà assuré par l’ouverture TLS/HTTP et restaure également le contexte NE2000 et TCP si l’ACK ne peut pas être émis.
+
+Le test HTTP/TLS existant couvre le framing exact du POST JSON, les bornes et son round-trip AES-GCM ; le test NE2000 couvre le transport ClientHello préalable et le polling vide. Le Makefile et le runner lient explicitement HTTP/TLS au test NE2000 pour vérifier l’intégration de compilation.
+
+> Ces wrappers sont une couche de transport applicative. Ils n’intègrent ni clé API ni choix automatique de fournisseur, et ne doivent pas être présentés comme un accès OpenAI ou Ollama opérationnel de bout en bout.
+
+## Limites explicites
+
+La résolution DNS, SYN/SYN-ACK, DHCP/ARP de connexion, l’alimentation d’une ancre de production, le test QEMU contre un serveur TLS externe, les clés `Authorization`, la sérialisation OpenAI/Ollama spécifique, le streaming SSE, chunked, HTTP/2, retries, pagination, compression, gros bodies fragmentés et le parsing JSON restent hors périmètre. La chaîne X.509 reste RSA à une ancre directe ; dates, intermédiaires, révocation et ECDSA manquent. X25519/bigint reste non constante-temps.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -330,3 +330,12 @@ Les intermédiaires, dates, contraintes et usages de clé, révocation, ECDSA/Ed
 Le contexte et tous les buffers/workspaces sont caller-owned. Les tests NE2000 couvrent l’initialisation, l’émission ClientHello, les séquences/transcript et le polling vide sans mutation ; les tests TCP/TLS existants couvrent le flux cryptographique sous-jacent. Référence : [aos305_312_ne2k_tls_orchestrator.md](aos305_312_ne2k_tls_orchestrator.md).
 
 Le flux ne constitue pas encore un HTTPS de production : un message serveur par record, pas de certificats clients, chaîne RSA directe sans intermédiaires/dates/usages/révocation/ECDSA, pas de test QEMU contre un serveur externe, ni résolution/connexion complète, HTTP LLM, auth API, retries ou fragmentation de grosses requêtes. X25519/bigint reste non constante-temps.
+
+
+### AOS-313 à AOS-320 — client HTTPS LLM sur NE2000
+
+`ne2k_https_llm_post_json` construit et chiffre un POST JSON HTTP/1.1 uniquement après le Finished TLS complet, puis l’émet via TCP/NE2000 avec rollback de la séquence TCP et du compteur AEAD en cas d’échec. `ne2k_https_llm_poll_response` ouvre les records AES-GCM reçus puis alimente l’accumulateur HTTP Content-Length caller-owned et ACK seulement après traitement réussi.
+
+Le module HTTP/TLS est désormais lié au test NE2000 ; les tests HTTP/TLS couvrent le framing POST et le round-trip AES-GCM, tandis que le test NE2000 couvre la préparation TLS et le polling vide. Référence : [aos313_320_https_llm_client.md](aos313_320_https_llm_client.md).
+
+Aucune clé API, auth Authorization, intégration spécifique OpenAI/Ollama, DNS/SYN de connexion, test QEMU contre serveur externe, streaming SSE, chunked, HTTP/2, retries, pagination, compression, grandes requêtes ni parsing JSON n’est encore livré. La PKI reste une ancre RSA directe et X25519/bigint reste non constante-temps.

--- a/kernel/ne2k.c
+++ b/kernel/ne2k.c
@@ -757,3 +757,44 @@ int ne2k_tls_client_poll(ne2k_device_t* device,const ne2k_io_t* io,const net_arp
 rollback:
     *client=previous_client;*connection=previous_connection;*consumed=0U;*flight_records_length=0U;return -2;
 }
+
+int ne2k_https_llm_post_json(ne2k_device_t* device,const ne2k_io_t* io,const net_arp_cache_t* cache,
+                             uint8_t* tx_frame,uint16_t tx_capacity,const uint8_t local_ip[4],const uint8_t remote_ip[4],
+                             net_tcp_connection_t* connection,ne2k_tls_client_t* client,
+                             uint8_t* request,uint16_t request_capacity,const char* host,const char* path,
+                             const uint8_t* json,uint16_t json_length,uint8_t* tls_record,uint32_t tls_capacity,
+                             uint8_t retransmit_limit){
+    net_tcp_connection_t previous_connection;uint64_t previous_sequence;int request_length,record_length,status;
+    if(!device||!io||!cache||!tx_frame||!local_ip||!remote_ip||!connection||!client||!request||!host||!path||(!json&&json_length)||!tls_record)return -1;
+    if(!client->complete||!net_tls_handshake_is_complete(&client->handshake))return -2;
+    previous_connection=*connection;previous_sequence=client->session.write_sequence;
+    request_length=net_http_build_post_json(request,request_capacity,host,path,json,json_length);
+    if(request_length<0)return -3;
+    record_length=net_tls_aes_gcm_session_build(&client->session,tls_record,tls_capacity,NET_TLS_CONTENT_APPLICATION_DATA,request,(uint16_t)request_length);
+    if(record_length<0)goto rollback;
+    if(net_tcp_connection_track_send(connection,tls_record,(uint16_t)record_length,retransmit_limit)!=0)goto rollback;
+    status=ne2k_tcp_data(device,io,cache,tx_frame,tx_capacity,local_ip,remote_ip,connection,tls_record,(uint16_t)record_length);
+    if(status!=0)goto rollback;
+    if(net_tcp_connection_commit_send(connection,(uint16_t)record_length)!=0)goto rollback;
+    return record_length;
+rollback:
+    *connection=previous_connection;client->session.write_sequence=previous_sequence;return -4;
+}
+
+int ne2k_https_llm_poll_response(ne2k_device_t* device,const ne2k_io_t* io,const net_arp_cache_t* cache,
+                                  uint8_t* rx_frame,uint16_t rx_capacity,uint8_t* tx_frame,uint16_t tx_capacity,
+                                  const uint8_t local_ip[4],const uint8_t remote_ip[4],net_tcp_connection_t* connection,
+                                  ne2k_tls_client_t* client,uint8_t* plaintext,uint16_t plaintext_capacity,
+                                  net_http_response_accumulator_t* accumulator,net_http_response_view_t* response,uint16_t* consumed){
+    ne2k_tls_client_t previous_client;net_tcp_connection_t previous_connection;net_tcp_view_t view;uint16_t frame_length=0U;int status;
+    if(!device||!io||!cache||!rx_frame||!tx_frame||!local_ip||!remote_ip||!connection||!client||!plaintext||!accumulator||!response||!consumed)return -1;
+    if(!client->complete||!net_tls_handshake_is_complete(&client->handshake))return -2;
+    *consumed=0U;status=ne2k_rx_poll_tcp(device,io,rx_frame,rx_capacity,&frame_length,&view);if(status!=0)return status;
+    previous_client=*client;previous_connection=*connection;
+    status=net_http_tls_open_response_stream(connection,&client->session,&view,plaintext,plaintext_capacity,accumulator,response,consumed);
+    if(status<0)goto rollback;
+    if(ne2k_tcp_ack(device,io,cache,tx_frame,tx_capacity,local_ip,remote_ip,connection)!=0)goto rollback;
+    return status;
+rollback:
+    *client=previous_client;*connection=previous_connection;*consumed=0U;return -3;
+}

--- a/kernel/ne2k.h
+++ b/kernel/ne2k.h
@@ -8,6 +8,7 @@
 #include "net_dhcp.h"
 #include "net_dns.h"
 #include "net_tcp.h"
+#include "net_http_tls.h"
 
 #define NE2K_REG_COMMAND 0x00U
 #define NE2K_REG_RESET   0x1fU
@@ -205,6 +206,19 @@ int ne2k_tls_client_poll(ne2k_device_t* device,const ne2k_io_t* io,const net_arp
                          uint8_t* tcp_segment,uint32_t tcp_segment_capacity,
                          uint8_t* flight_records,uint32_t flight_records_capacity,uint32_t* flight_records_length,
                          uint8_t* plaintext,uint16_t plaintext_capacity,uint8_t retransmit_limit,uint16_t* consumed);
+/* Construit, chiffre et émet un POST JSON LLM uniquement après handshake TLS complet. */
+int ne2k_https_llm_post_json(ne2k_device_t* device,const ne2k_io_t* io,const net_arp_cache_t* cache,
+                             uint8_t* tx_frame,uint16_t tx_capacity,const uint8_t local_ip[4],const uint8_t remote_ip[4],
+                             net_tcp_connection_t* connection,ne2k_tls_client_t* client,
+                             uint8_t* request,uint16_t request_capacity,const char* host,const char* path,
+                             const uint8_t* json,uint16_t json_length,uint8_t* tls_record,uint32_t tls_capacity,
+                             uint8_t retransmit_limit);
+/* Polling d’une réponse HTTP Content-Length chiffrée après TLS complet ; retourne 1 tant que le body est incomplet. */
+int ne2k_https_llm_poll_response(ne2k_device_t* device,const ne2k_io_t* io,const net_arp_cache_t* cache,
+                                  uint8_t* rx_frame,uint16_t rx_capacity,uint8_t* tx_frame,uint16_t tx_capacity,
+                                  const uint8_t local_ip[4],const uint8_t remote_ip[4],net_tcp_connection_t* connection,
+                                  ne2k_tls_client_t* client,uint8_t* plaintext,uint16_t plaintext_capacity,
+                                  net_http_response_accumulator_t* accumulator,net_http_response_view_t* response,uint16_t* consumed);
 /* Attache le périphérique à l’IRQ ISA fournie par le matériel, sans allocation. */
 int ne2k_irq_attach(ne2k_device_t* device, const ne2k_io_t* io);
 /* Acquitte l’ISR et compte les événements NE2000 observés par l’IRQ. */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -184,9 +184,9 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_dhcp: $(UNIT_DIR)/kernel/test_net_dhcp.
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c ../kernel/net_tls_record.c ../kernel/sha256.c ../kernel/aes_gcm.c ../kernel/x509_der.c ../kernel/rsa_verify.c ../kernel/bigint.c ../kernel/x25519.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_ne2k: $(UNIT_DIR)/kernel/test_ne2k.c ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c ../kernel/net_tls_record.c ../kernel/net_http_tls.c ../kernel/sha256.c ../kernel/aes_gcm.c ../kernel/x509_der.c ../kernel/rsa_verify.c ../kernel/bigint.c ../kernel/x25519.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c ../kernel/net_tls_record.c ../kernel/sha256.c ../kernel/aes_gcm.c ../kernel/x509_der.c ../kernel/rsa_verify.c ../kernel/bigint.c ../kernel/x25519.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/ne2k.c ../kernel/net_nic.c ../kernel/net_ethernet_arp.c ../kernel/net_ipv4_udp.c ../kernel/net_dhcp.c ../kernel/net_dns.c ../kernel/net_tcp.c ../kernel/net_tls_record.c ../kernel/net_http_tls.c ../kernel/sha256.c ../kernel/aes_gcm.c ../kernel/x509_der.c ../kernel/rsa_verify.c ../kernel/bigint.c ../kernel/x25519.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -182,7 +182,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/net_dhcp.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_dns.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_tcp.c"
-        extra_src="$extra_src $BASE_DIR/kernel/net_tls_record.c"
+        extra_src="$extra_src $BASE_DIR/kernel/net_tls_record.c $BASE_DIR/kernel/net_http_tls.c"
         extra_src="$extra_src $BASE_DIR/kernel/sha256.c"
         extra_src="$extra_src $BASE_DIR/kernel/aes_gcm.c"
         extra_src="$extra_src $BASE_DIR/kernel/x509_der.c"


### PR DESCRIPTION
## Périmètre

- ajoute l’émission POST JSON HTTP/1.1 chiffrée AES-GCM après Finished TLS ;
- ajoute le polling de réponse Content-Length TLS/HTTP ;
- impose le handshake TLS complet avant tout trafic applicatif ;
- restaure séquence TCP et compteur AEAD lors des échecs locaux ;
- lie HTTP/TLS dans les règles de test NE2000 ;
- documente clairement les limites de fournisseur et de production.

## Validation locale

- `make test-all` : 351/351 tests réussis ;
- `make all` : build i386 freestanding réussi ;
- `make qemu-ai-provider` : smoke réussi ;
- `make qemu-ne2k-status` : smoke réussi.

## Limites explicites

Aucune clé API ni header Authorization, aucun choix/format OpenAI ou Ollama spécifique, DNS/SYN automatisé, serveur externe QEMU, streaming SSE/chunked/HTTP2, retries, grandes requêtes ou parsing JSON n’est fourni. La chaîne X.509 est encore RSA à une ancre directe, et X25519/bigint reste non constante-temps.