### PR TITLE
feat(rtc): source UTC i386 bornée pour politique TLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 # Liste des fichiers objets - MISE À JOUR avec tous les nouveaux fichiers
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
-          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
+          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/rtc.o build/fat16.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
           build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/vga_console.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o build/net_ipv4_udp.o build/net_dns.o build/net_tcp.o build/sha256.o build/aes_gcm.o build/x509_der.o build/bigint.o build/x25519.o build/rsa_verify.o build/net_tls_record.o build/net_http_tls.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
@@ -234,6 +234,10 @@ build/overlay.o: fs/overlay.c fs/overlay.h fs/initrd.h kernel/ata.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 build/ata.o: kernel/ata.c kernel/ata.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+build/rtc.o: kernel/rtc.c kernel/rtc.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/docs/aos401_408_rtc_utc.md
+++ b/docs/aos401_408_rtc_utc.md
@@ -1,0 +1,17 @@
+# AOS-401 à AOS-408 — source UTC RTC i386
+
+Le module `rtc` lit l’horloge CMOS i386 par les ports `0x70` et `0x71`, au moyen d’une interface de ports injectée pour les tests et d’un adaptateur matériel réel disponible uniquement dans le noyau i386. `rtc_read_utc` écrit dans un buffer caller-owned de 16 octets la chaîne canonique `YYYYMMDDHHMMSSZ`, directement acceptable par la politique de dates X.509 existante.
+
+| Contrôle | Comportement |
+|---|---|
+| Mise à jour CMOS | Au plus trois photographies sont tentées ; le bit UIP ou une seconde modifiée invalide la photographie. |
+| Encodage | Les registres BCD et binaires sont acceptés. |
+| Heure | Les modes 12 h avec PM et 24 h sont convertis en UTC 24 h. |
+| Calendrier | Le mois, le jour, les heures, minutes, secondes et les années bissextiles sont vérifiés. |
+| Mémoire | Aucun état global, allocation dynamique ni buffer caché. |
+
+Pour la validation TLS, l’appelant alloue `char utc[RTC_UTC_BUFFER_LENGTH]`, appelle `rtc_read_utc`, puis transmet cette chaîne à `ne2k_tls_client_poll` ou à `x509_certificate_tls_identity_validate`. Un échec RTC doit faire échouer la politique de temps ; il ne doit pas être remplacé par une date arbitraire.
+
+> Le module suppose que le RTC fournit UTC et fixe le siècle à `2000 + année CMOS`. Il ne vérifie pas la batterie RTC, le fuseau configuré par firmware, le siècle CMOS, la dérive d’horloge, NTP ou une attestation temporelle réseau.
+
+Les tests injectent des registres CMOS et couvrent une date BCD en 12 h, une date binaire en 24 h pendant une année bissextile, un BCD invalide, une capacité insuffisante et un bit UIP persistant.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -407,3 +407,9 @@ Le test NE2000 vérifie la requête OpenAI chiffrée, JSON exact, Bearer, séque
 `net_llm_http_status_classify` distingue succès, authentification, erreurs retryables, erreurs permanentes et réponses hors protocole. `net_llm_http_retry_consume` augmente uniquement le compteur caller-owned lorsqu’un nouveau POST est autorisé dans la limite explicite. Il n’attend pas et ne réémet pas automatiquement un POST LLM.
 
 Les vecteurs couvrent `401`, `403`, `408`, `429`, `503`, classes 2xx/3xx/4xx et l’épuisement du budget. Référence : [aos393_400_llm_http_errors.md](aos393_400_llm_http_errors.md). `Retry-After`, temporisation, circuit-breaker, SSE, Unicode, tools, multi-tours, DNS/SYN automatisés et test externe restent hors périmètre.
+
+### AOS-401 à AOS-408 — RTC UTC i386
+
+Le module `rtc` produit `YYYYMMDDHHMMSSZ` depuis les registres CMOS i386 via une photographie stable bornée, BCD/binaire et 12/24 h. Le buffer UTC reste caller-owned et peut être transmis à la politique de dates X.509/TLS. Les données instables, invalides ou insuffisantes sont refusées.
+
+Les tests RTC couvrent BCD 12 h, binaire 24 h, date bissextile, capacité, BCD invalide et bit UIP persistant. Référence : [aos401_408_rtc_utc.md](aos401_408_rtc_utc.md). Batterie RTC, fuseau firmware, siècle matériel, dérive et synchronisation NTP restent hors périmètre.

--- a/kernel/rtc.c
+++ b/kernel/rtc.c
@@ -1,0 +1,36 @@
+#include "rtc.h"
+
+#define RTC_REGISTER_SECONDS 0x00U
+#define RTC_REGISTER_MINUTES 0x02U
+#define RTC_REGISTER_HOURS 0x04U
+#define RTC_REGISTER_DAY 0x07U
+#define RTC_REGISTER_MONTH 0x08U
+#define RTC_REGISTER_YEAR 0x09U
+#define RTC_REGISTER_STATUS_A 0x0aU
+#define RTC_REGISTER_STATUS_B 0x0bU
+#define RTC_STATUS_A_UPDATE_IN_PROGRESS 0x80U
+#define RTC_STATUS_B_24_HOUR 0x02U
+#define RTC_STATUS_B_BINARY 0x04U
+
+static uint8_t rtc_read_register(const rtc_io_t* io,uint8_t reg){io->outb(io->context,RTC_CMOS_INDEX_PORT,(uint8_t)(reg&0x7fU));return io->inb(io->context,RTC_CMOS_DATA_PORT);}
+static int rtc_bcd(uint8_t value,uint8_t* output){if(!output||(value&0x0fU)>9U||((value>>4)&0x0fU)>9U)return -1;*output=(uint8_t)(((value>>4)*10U)+(value&0x0fU));return 0;}
+static uint8_t rtc_leap(uint16_t year){return (uint8_t)((year%4U==0U&&(year%100U!=0U||year%400U==0U))?1U:0U);}
+static uint8_t rtc_days_in_month(uint16_t year,uint8_t month){static const uint8_t days[12]={31U,28U,31U,30U,31U,30U,31U,31U,30U,31U,30U,31U};if(month<1U||month>12U)return 0U;return (uint8_t)(month==2U?days[1]+rtc_leap(year):days[month-1U]);}
+static void rtc_two_digits(char* output,uint16_t offset,uint8_t value){output[offset]=(char)('0'+value/10U);output[offset+1U]=(char)('0'+value%10U);}
+
+#ifdef __i386__
+static uint8_t rtc_i386_inb(void* context,uint16_t port){uint8_t value;(void)context;__asm__ volatile("inb %1,%0":"=a"(value):"Nd"(port));return value;}
+static void rtc_i386_outb(void* context,uint16_t port,uint8_t value){(void)context;__asm__ volatile("outb %0,%1"::"a"(value),"Nd"(port));}
+#endif
+
+int rtc_i386_io(rtc_io_t* io){
+    if(!io)return -1;
+    io->context=(void*)0;
+#ifdef __i386__
+    io->inb=rtc_i386_inb;io->outb=rtc_i386_outb;return 0;
+#else
+    io->inb=(rtc_inb_fn)0;io->outb=(rtc_outb_fn)0;return -1;
+#endif
+}
+
+int rtc_read_utc(const rtc_io_t* io,char* output,uint16_t output_capacity){uint8_t attempt,second_a,second_b,minute,hour,day,month,year,status_b,pm;uint16_t full_year;if(!io||!io->inb||!io->outb||!output||output_capacity<RTC_UTC_BUFFER_LENGTH)return -1;for(attempt=0U;attempt<3U;attempt++){if(rtc_read_register(io,RTC_REGISTER_STATUS_A)&RTC_STATUS_A_UPDATE_IN_PROGRESS)continue;second_a=rtc_read_register(io,RTC_REGISTER_SECONDS);minute=rtc_read_register(io,RTC_REGISTER_MINUTES);hour=rtc_read_register(io,RTC_REGISTER_HOURS);day=rtc_read_register(io,RTC_REGISTER_DAY);month=rtc_read_register(io,RTC_REGISTER_MONTH);year=rtc_read_register(io,RTC_REGISTER_YEAR);status_b=rtc_read_register(io,RTC_REGISTER_STATUS_B);second_b=rtc_read_register(io,RTC_REGISTER_SECONDS);if((rtc_read_register(io,RTC_REGISTER_STATUS_A)&RTC_STATUS_A_UPDATE_IN_PROGRESS)||second_a!=second_b)continue;pm=(uint8_t)(hour&0x80U);hour=(uint8_t)(hour&0x7fU);if((status_b&RTC_STATUS_B_BINARY)==0U){if(rtc_bcd(second_a,&second_a)!=0||rtc_bcd(minute,&minute)!=0||rtc_bcd(hour,&hour)!=0||rtc_bcd(day,&day)!=0||rtc_bcd(month,&month)!=0||rtc_bcd(year,&year)!=0)return -2;}if((status_b&RTC_STATUS_B_24_HOUR)==0U){if(hour<1U||hour>12U)return -3;if(pm){if(hour!=12U)hour=(uint8_t)(hour+12U);}else if(hour==12U)hour=0U;}full_year=(uint16_t)(2000U+year);if(second_a>59U||minute>59U||hour>23U||month<1U||month>12U||day<1U||day>rtc_days_in_month(full_year,month))return -4;output[0]=(char)('0'+(full_year/1000U)%10U);output[1]=(char)('0'+(full_year/100U)%10U);output[2]=(char)('0'+(full_year/10U)%10U);output[3]=(char)('0'+full_year%10U);rtc_two_digits(output,4U,month);rtc_two_digits(output,6U,day);rtc_two_digits(output,8U,hour);rtc_two_digits(output,10U,minute);rtc_two_digits(output,12U,second_a);output[14]='Z';output[15]='\0';return 0;}return -5;}

--- a/kernel/rtc.h
+++ b/kernel/rtc.h
@@ -1,0 +1,20 @@
+#ifndef AIOS_RTC_H
+#define AIOS_RTC_H
+
+#include <stdint.h>
+
+#define RTC_CMOS_INDEX_PORT 0x70U
+#define RTC_CMOS_DATA_PORT 0x71U
+#define RTC_UTC_TEXT_LENGTH 15U
+#define RTC_UTC_BUFFER_LENGTH 16U
+
+typedef uint8_t (*rtc_inb_fn)(void* context,uint16_t port);
+typedef void (*rtc_outb_fn)(void* context,uint16_t port,uint8_t value);
+typedef struct { void* context; rtc_inb_fn inb; rtc_outb_fn outb; } rtc_io_t;
+
+/* Prépare les accès ports CMOS réels sur i386 ; indisponible dans les tests hôte. */
+int rtc_i386_io(rtc_io_t* io);
+/* Lit une photographie CMOS UTC stable et écrit YYYYMMDDHHMMSSZ + NUL dans un buffer caller-owned. */
+int rtc_read_utc(const rtc_io_t* io,char* output,uint16_t output_capacity);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -222,6 +222,11 @@ $(BUILD_DIR)/$(ROBUSTNESS_DIR)/test_gpt2_gguf_bounds: $(ROBUSTNESS_DIR)/test_gpt
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_gguf.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled robustness test: $(notdir $@)"
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_rtc: $(UNIT_DIR)/kernel/test_rtc.c ../kernel/rtc.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/rtc.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_%: $(UNIT_DIR)/kernel/test_%.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -154,6 +154,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_sha256.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/sha256.c"
     fi
+    if [ "$(basename "$test_file")" = "test_rtc.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/rtc.c"
+    fi
     if [ "$(basename "$test_file")" = "test_net_tcp.c" ] || [ "$(basename "$test_file")" = "test_net_http_tls.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/net_tcp.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_tls_record.c"

--- a/tests/unit/kernel/test_rtc.c
+++ b/tests/unit/kernel/test_rtc.c
@@ -1,0 +1,14 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/rtc.h"
+
+typedef struct { uint8_t registers[128]; uint8_t selected; } fake_rtc_t;
+void setUp(void) {}
+void tearDown(void) {}
+static uint8_t fake_inb(void* context,uint16_t port){fake_rtc_t* fake=(fake_rtc_t*)context;return port==RTC_CMOS_DATA_PORT?fake->registers[fake->selected]:0U;}
+static void fake_outb(void* context,uint16_t port,uint8_t value){fake_rtc_t* fake=(fake_rtc_t*)context;if(port==RTC_CMOS_INDEX_PORT)fake->selected=(uint8_t)(value&0x7fU);}
+
+void test_rtc_reads_bcd_12_hour_utc(void){fake_rtc_t fake={0};rtc_io_t io={&fake,fake_inb,fake_outb};char utc[RTC_UTC_BUFFER_LENGTH]={0};fake.registers[0x00U]=0x56U;fake.registers[0x02U]=0x34U;fake.registers[0x04U]=0x89U;fake.registers[0x07U]=0x18U;fake.registers[0x08U]=0x08U;fake.registers[0x09U]=0x26U;fake.registers[0x0aU]=0U;fake.registers[0x0bU]=0U;TEST_ASSERT_EQUAL(0,rtc_read_utc(&io,utc,sizeof(utc)));TEST_ASSERT_EQUAL_MEMORY("20260818213456Z",utc,RTC_UTC_TEXT_LENGTH);TEST_ASSERT_EQUAL(0,utc[15]);}
+void test_rtc_reads_binary_24_hour_leap_day(void){fake_rtc_t fake={0};rtc_io_t io={&fake,fake_inb,fake_outb};char utc[RTC_UTC_BUFFER_LENGTH]={0};fake.registers[0x00U]=1U;fake.registers[0x02U]=2U;fake.registers[0x04U]=3U;fake.registers[0x07U]=29U;fake.registers[0x08U]=2U;fake.registers[0x09U]=24U;fake.registers[0x0aU]=0U;fake.registers[0x0bU]=0x06U;TEST_ASSERT_EQUAL(0,rtc_read_utc(&io,utc,sizeof(utc)));TEST_ASSERT_EQUAL_MEMORY("20240229030201Z",utc,RTC_UTC_TEXT_LENGTH);}
+void test_rtc_rejects_invalid_or_unstable_source(void){fake_rtc_t fake={0};rtc_io_t io={&fake,fake_inb,fake_outb};char utc[RTC_UTC_BUFFER_LENGTH]={0};fake.registers[0x00U]=0x6aU;fake.registers[0x02U]=0U;fake.registers[0x04U]=0x01U;fake.registers[0x07U]=0x01U;fake.registers[0x08U]=0x01U;fake.registers[0x09U]=0x26U;fake.registers[0x0aU]=0U;fake.registers[0x0bU]=0U;TEST_ASSERT_NOT_EQUAL(0,rtc_read_utc(&io,utc,sizeof(utc)));TEST_ASSERT_NOT_EQUAL(0,rtc_read_utc(&io,utc,RTC_UTC_TEXT_LENGTH));fake.registers[0x0aU]=0x80U;TEST_ASSERT_NOT_EQUAL(0,rtc_read_utc(&io,utc,sizeof(utc)));TEST_ASSERT_NOT_EQUAL(0,rtc_i386_io(0));}
+
+int main(void){unity_init();RUN_TEST(test_rtc_reads_bcd_12_hour_utc);RUN_TEST(test_rtc_reads_binary_24_hour_leap_day);RUN_TEST(test_rtc_rejects_invalid_or_unstable_source);unity_print_results();unity_cleanup();return unity_stats.tests_failed==0?0:1;}


### PR DESCRIPTION
## Périmètre

Implémente AOS-401 à AOS-408 : module RTC CMOS i386 à ports injectables, lecture stable bornée, BCD/binaire, conversion 12/24 h et rendu caller-owned `YYYYMMDDHHMMSSZ` pour la politique de dates X.509/TLS.

Aucune allocation dynamique, aucun état global, aucune attente non bornée. Le format produit est directement transmissible à `ne2k_tls_client_poll` et `x509_certificate_tls_identity_validate`.

## Validation

- `make test-all` : 363/363 verts
- `make all` : build i386 freestanding vert avec `build/rtc.o`
- `make qemu-ai-provider` : smoke vert
- `make qemu-ne2k-status` : smoke vert
- `git diff --check` : vert

## Limites explicites

L’horloge est supposée UTC avec siècle `2000 + année CMOS`. Batterie, fuseau firmware, registre de siècle, dérive, NTP sécurisé et test sur CMOS matériel réel restent hors périmètre.