### PR TITLE
AOS-977..984: rattacher l identité X509 au handshake TLS

### DIFF
--- a/docs/aos977_984_tls_identity_handshake.md
+++ b/docs/aos977_984_tls_identity_handshake.md
@@ -1,0 +1,9 @@
+# AOS-977 à AOS-984 — rattachement de l’identité X.509 au handshake TLS
+
+`net_tls_handshake_validate_server_identity` raccorde explicitement l’état TLS à la validation d’identité X.509 déjà disponible. Le caller fournit le trust anchor, le hostname, l’instant UTC et le workspace fixe. La fonction refuse un handshake nul, un trust anchor absent, des paramètres temporels absents ou un certificat serveur non parsé.
+
+La validation réutilise le contrôle de chaîne, de nom DNS et de période de validité. Elle ne copie ni certificat, ni hostname, ni secret. La vérification cryptographique ECDSA du message `ServerKeyExchange` demeure dans le chemin authentifié existant et n’est pas contournée par ce wrapper.
+
+Ce lot fournit le point d’intégration nécessaire au fournisseur HTTPS sans introduire d’allocation dynamique. Les vecteurs X.509 et ECDSA déjà présents restent la source de non-régression.
+
+Auteur : **Manus AI**

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -747,3 +747,6 @@ Un enregistrement fixe, versionné et caller-owned conserve uniquement le fourni
 
 ### AOS-969 à AOS-976 — politique explicite fournisseur/modèle
 `net_llm_model_policy_t` valide un fournisseur connu, un nom de modèle caller-owned imprimable et une autorisation de rotation binaire. La politique ne copie pas le modèle et ne déclenche aucune bascule implicite ; elle fournit un garde avant sérialisation de requête. Validation locale : **413/413 tests verts**.
+
+### AOS-977 à AOS-984 — rattachement de l’identité X.509 au handshake TLS
+Le handshake expose désormais une validation d’identité serveur qui réutilise la chaîne X.509, le trust anchor, le hostname et le temps fournis par l’appelant. Elle exige un certificat serveur déjà parsé et validé, ne copie aucun certificat et ne réalise aucune allocation. La vérification ECDSA de `ServerKeyExchange` existante reste inchangée.

--- a/kernel/net_tls_record.c
+++ b/kernel/net_tls_record.c
@@ -438,3 +438,5 @@ int net_tls_client_hello_build(uint8_t* record,uint32_t capacity,const uint8_t r
     hello[57]=0U;hello[58]=13U;hello[59]=0U;hello[60]=4U;hello[61]=0U;hello[62]=2U;hello[63]=4U;hello[64]=1U;
     length=net_tls_record_build(record,capacity,NET_TLS_CONTENT_HANDSHAKE,hello,sizeof(hello));return length;
 }
+
+int net_tls_handshake_validate_server_identity(const net_tls_handshake_t* handshake,const x509_certificate_view_t* trust_anchor,const char* hostname,const char* utc_time,uint32_t* workspace,uint16_t workspace_length){if(!handshake||!trust_anchor||!hostname||!utc_time||!workspace)return -1;if(!handshake->server_x509_valid)return -2;return x509_certificate_tls_identity_validate(&handshake->server_x509,trust_anchor,hostname,utc_time,workspace,workspace_length);}

--- a/kernel/net_tls_record.h
+++ b/kernel/net_tls_record.h
@@ -185,4 +185,5 @@ int net_tls_handshake_is_complete(const net_tls_handshake_t* handshake);
 /* Construit un ClientHello TLS 1.2 minimal dans un record caller-owned. */
 int net_tls_client_hello_build(uint8_t* record, uint32_t capacity,
                                const uint8_t random[32]);
+int net_tls_handshake_validate_server_identity(const net_tls_handshake_t* handshake,const x509_certificate_view_t* trust_anchor,const char* hostname,const char* utc_time,uint32_t* workspace,uint16_t workspace_length);
 #endif


### PR DESCRIPTION
## Résumé
- ajoute un point d’entrée strict de validation d’identité serveur ;
- réutilise chaîne X.509, trust anchor, hostname et temps caller-owned ;
- ne copie aucun certificat ni secret ;
- conserve la vérification ECDSA ServerKeyExchange existante ;
- ajoute la documentation française.

## Validation locale
- `make test-all` : 413/413 tests verts ;
- `git diff --check` : propre.