### PR TITLE
AOS-1009..1016: conditionner la réception HTTPS au handshake complet

### DIFF
--- a/docs/aos1009_1016_https_reception_guard.md
+++ b/docs/aos1009_1016_https_reception_guard.md
@@ -1,0 +1,9 @@
+# AOS-1009 à AOS-1016 — réception HTTPS conditionnée par la session TLS complète
+
+`net_https_open_application_record_if_ready` protège l’ouverture des records applicatifs entrants. Il réutilise `net_https_application_ready`, puis délègue à `net_tls_aes_gcm_session_open` lorsque le handshake est terminé et que les clés et IV de lecture et d’écriture sont présents.
+
+Le wrapper refuse une session partielle sans modifier la séquence de lecture. Les buffers de record, plaintext et vue sont fournis par l’appelant ; aucun secret ou payload n’est copié par cette couche et aucune attente bloquante n’est introduite.
+
+Le chemin HTTPS possède ainsi une barrière symétrique pour émission et réception après le postflight ECDHE_ECDSA. Aucun `kmalloc` n’est utilisé.
+
+Auteur : **Manus AI**

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -759,3 +759,6 @@ Le chemin applicatif expose désormais `net_https_application_ready`, qui exige 
 
 ### AOS-1001 à AOS-1008 — émission HTTPS conditionnée par la session TLS complète
 Le wrapper `net_https_build_application_record_if_ready` raccorde le prédicat de readiness à la construction AES-GCM. Il refuse toute émission avant `SERVER_FINISHED_RECEIVED` ou avec une session partiellement initialisée, puis délègue sans copie au builder TLS existant. Validation locale : **413/413 tests verts**.
+
+### AOS-1009 à AOS-1016 — réception HTTPS conditionnée par la session TLS complète
+Le wrapper `net_https_open_application_record_if_ready` complète le garde d’émission : aucun record entrant n’est déchiffré avant `SERVER_FINISHED_RECEIVED` et l’initialisation complète des clés/IV AES-GCM. La séquence de lecture est déléguée au décodeur TLS existant. Validation locale : **413/413 tests verts**.

--- a/kernel/net_http_tls.c
+++ b/kernel/net_http_tls.c
@@ -275,3 +275,5 @@ int net_llm_model_policy_validate(const net_llm_model_policy_t* policy){uint8_t 
 int net_https_application_ready(const net_tls_handshake_t* handshake,const net_tls_aes_gcm_session_t* session){if(!handshake||!session||!net_tls_handshake_is_complete(handshake))return 0;if(!session->write_key||!session->write_fixed_iv||!session->read_key||!session->read_fixed_iv)return 0;return 1;}
 
 int net_https_build_application_record_if_ready(const net_tls_handshake_t* handshake,net_tls_aes_gcm_session_t* session,uint8_t* record,uint32_t capacity,uint8_t content_type,const uint8_t* plaintext,uint16_t plaintext_length){if(!net_https_application_ready(handshake,session))return -1;return net_tls_aes_gcm_session_build(session,record,capacity,content_type,plaintext,plaintext_length);}
+
+int net_https_open_application_record_if_ready(const net_tls_handshake_t* handshake,net_tls_aes_gcm_session_t* session,const uint8_t* record,uint32_t length,uint8_t* plaintext,uint16_t plaintext_capacity,net_tls_record_view_t* out){if(!net_https_application_ready(handshake,session))return -1;return net_tls_aes_gcm_session_open(session,record,length,plaintext,plaintext_capacity,out);}

--- a/kernel/net_http_tls.h
+++ b/kernel/net_http_tls.h
@@ -149,4 +149,5 @@ typedef struct { uint8_t provider; const char* model; uint8_t model_length; uint
 int net_llm_model_policy_validate(const net_llm_model_policy_t* policy);
 int net_https_application_ready(const net_tls_handshake_t* handshake,const net_tls_aes_gcm_session_t* session);
 int net_https_build_application_record_if_ready(const net_tls_handshake_t* handshake,net_tls_aes_gcm_session_t* session,uint8_t* record,uint32_t capacity,uint8_t content_type,const uint8_t* plaintext,uint16_t plaintext_length);
+int net_https_open_application_record_if_ready(const net_tls_handshake_t* handshake,net_tls_aes_gcm_session_t* session,const uint8_t* record,uint32_t length,uint8_t* plaintext,uint16_t plaintext_capacity,net_tls_record_view_t* out);
 #endif


### PR DESCRIPTION
## Résumé
- ajoute le wrapper de réception HTTPS conditionné ;
- refuse le déchiffrement avant `SERVER_FINISHED_RECEIVED` ;
- conserve la séquence AES-GCM et les buffers caller-owned ;
- ajoute documentation française.

## Validation locale
- `make test-all` : 413/413 tests verts ;
- `git diff --check` : propre.