### PR TITLE
AOS-1065..1080: suivre les baux DHCP live

### DIFF
--- a/docs/aos1065_1080_dhcp_live_lease.md
+++ b/docs/aos1065_1080_dhcp_live_lease.md
@@ -1,0 +1,23 @@
+# AOS-1065 à AOS-1080 — bail DHCP live borné
+
+Le client DHCP extrait désormais l’option 51 (`IP address lease time`) lors de la validation d’un ACK. La durée est conservée dans `net_dhcp_lease_t` avec le tick d’acquisition caller-owned.
+
+`net_dhcp_lease_mark_acquired` marque un bail valide sans consulter d’horloge globale. `net_dhcp_lease_is_valid_at` vérifie l’expiration par soustraction non signée, ce qui conserve le comportement attendu lors du wraparound d’un compteur 32 bits. `net_dhcp_lease_renewal_due` signale le seuil de renouvellement à mi-bail, sans bloquer ni émettre directement un paquet.
+
+Le parseur reste transactionnel : il construit un bail temporaire et ne publie l’état que si le message DHCP est un ACK cohérent. Une option 51 mal formée est rejetée avec restauration du bail précédent. Les champs existants de routeur, DNS, masque et next-hop restent inchangés.
+
+> Le bail DHCP fournit une politique d’échéance ; la boucle réseau décide quand lancer le renouvellement.
+
+| Élément | Garantie |
+|---|---|
+| Option DHCP | 51, durée en secondes |
+| Horloge | Tick fourni par l’appelant |
+| Expiration | Contrôle non bloquant, wraparound sûr |
+| Renouvellement | Signalé à 50 % du bail |
+| Erreur de parsing | Bail précédent préservé |
+| Mémoire | Aucun buffer dynamique |
+
+Validation locale : **414/414 tests verts**, incluant la durée, le seuil de renouvellement et l’expiration.
+
+Auteur : **Manus AI**
+

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -771,3 +771,6 @@ Le wrapper `net_https_open_application_record_if_ready` complète le garde d’�
 
 ### AOS-1049 à AOS-1064 — RTO TCP caller-owned borné
 `net_tcp_rto_timer_t` fournit une échéance non bloquante et un backoff borné pour les retransmissions TCP. La consommation réutilise `pending_payload` et `retransmit_limit`, restaure timer/connexion sur erreur et ne déplace aucune logique dans IRQ0. Validation locale : **414/414 tests verts**.
+
+### AOS-1065 à AOS-1080 — bail DHCP live borné
+Le parseur ACK extrait l’option 51 et le bail caller-owned expose sa durée, son tick d’acquisition, sa validité et son seuil de renouvellement. Les contrôles sont non bloquants, sûrs au wraparound et transactionnels en cas d’option mal formée. Aucun `kmalloc`. Validation locale : **414/414 tests verts**.

--- a/kernel/net_dhcp.c
+++ b/kernel/net_dhcp.c
@@ -105,6 +105,7 @@ int net_dhcp_parse_ack(const uint8_t* packet, uint32_t length,
         if (code == NET_DHCP_OPTION_SUBNET_MASK) { if (size != 4U) return -4; copy_bytes(next.subnet_mask, packet + pos, 4U); next.subnet_valid = 1U; }
         if (code == NET_DHCP_OPTION_ROUTER) { if (size < 4U || (size & 3U) != 0U) return -4; copy_bytes(next.router_ipv4, packet + pos, 4U); next.router_valid = 1U; }
         if (code == NET_DHCP_OPTION_DNS) { if (size < 4U || (size & 3U) != 0U) return -4; copy_bytes(next.dns_ipv4, packet + pos, 4U); next.dns_valid = 1U; }
+        if (code == NET_DHCP_OPTION_LEASE_TIME) { if (size != 4U) return -4; next.lease_seconds = get_be32(packet + pos); }
         pos += size;
     }
     if (type != NET_DHCP_ACK || !server_seen) return -3;
@@ -115,3 +116,6 @@ int net_dhcp_parse_ack(const uint8_t* packet, uint32_t length,
 
 int net_dhcp_lease_next_hop(const net_dhcp_lease_t* lease,const uint8_t destination[4],uint8_t next_hop[4]){uint8_t next[4],index,local=1U;if(!lease||!destination||!next_hop||!lease->valid||!lease->subnet_valid)return -1;for(index=0U;index<4U;index++)if((uint8_t)(lease->ipv4[index]&lease->subnet_mask[index])!=(uint8_t)(destination[index]&lease->subnet_mask[index]))local=0U;if(local)copy_bytes(next,destination,4U);else{if(!lease->router_valid)return -2;copy_bytes(next,lease->router_ipv4,4U);}copy_bytes(next_hop,next,4U);return 0;
 }
+int net_dhcp_lease_mark_acquired(net_dhcp_lease_t* lease,uint32_t now){if(!lease||!lease->valid||lease->lease_seconds==0U)return -1;lease->acquired_tick=now;return 0;}
+int net_dhcp_lease_is_valid_at(const net_dhcp_lease_t* lease,uint32_t now){uint32_t elapsed;if(!lease||!lease->valid||lease->lease_seconds==0U)return 0;elapsed=now-lease->acquired_tick;return elapsed<lease->lease_seconds?1:0;}
+int net_dhcp_lease_renewal_due(const net_dhcp_lease_t* lease,uint32_t now){uint32_t elapsed,renew_after;if(!lease||!lease->valid||lease->lease_seconds==0U)return 0;elapsed=now-lease->acquired_tick;renew_after=lease->lease_seconds-(lease->lease_seconds/2U);return elapsed>=renew_after?1:0;}

--- a/kernel/net_dhcp.h
+++ b/kernel/net_dhcp.h
@@ -13,6 +13,7 @@
 #define NET_DHCP_OPTION_SERVER_ID 54U
 #define NET_DHCP_OPTION_PARAMETER_REQUEST_LIST 55U
 #define NET_DHCP_OPTION_END 255U
+#define NET_DHCP_OPTION_LEASE_TIME 51U
 #define NET_DHCP_DISCOVER 1U
 #define NET_DHCP_OFFER 2U
 #define NET_DHCP_REQUEST 3U
@@ -35,6 +36,8 @@ typedef struct {
     uint8_t router_ipv4[4];
     uint8_t dns_ipv4[4];
     uint32_t xid;
+    uint32_t lease_seconds;
+    uint32_t acquired_tick;
 } net_dhcp_lease_t;
 
 int net_dhcp_build_discover(uint8_t* packet, uint32_t capacity,
@@ -51,5 +54,9 @@ int net_dhcp_parse_ack(const uint8_t* packet, uint32_t length,
 /* Copie la destination si elle est locale, sinon le routeur DHCP ; ne modifie pas next_hop sur erreur. */
 int net_dhcp_lease_next_hop(const net_dhcp_lease_t* lease,
                             const uint8_t destination[4], uint8_t next_hop[4]);
+/* Marque l’acquisition et vérifie un bail live sans attendre ni allouer. */
+int net_dhcp_lease_mark_acquired(net_dhcp_lease_t* lease,uint32_t now);
+int net_dhcp_lease_is_valid_at(const net_dhcp_lease_t* lease,uint32_t now);
+int net_dhcp_lease_renewal_due(const net_dhcp_lease_t* lease,uint32_t now);
 
 #endif

--- a/tests/unit/kernel/test_net_dhcp.c
+++ b/tests/unit/kernel/test_net_dhcp.c
@@ -30,7 +30,7 @@ void test_build_and_parse_dhcp_offer(void) {
       TEST_ASSERT_EQUAL(2, lease.server_ipv4[3]);
       net_dhcp_lease_clear(&lease); TEST_ASSERT_EQUAL(0, lease.valid); TEST_ASSERT_EQUAL(0, lease.router_valid); TEST_ASSERT_EQUAL(0, lease.dns_valid); }
     TEST_ASSERT_NOT_EQUAL(0, net_dhcp_parse_offer(packet, 250, 0x87654321U, &offer));
-    { uint8_t request[278] = {0}; uint8_t requested[4] = {10,0,2,15}; uint8_t server[4] = {10,0,2,2}; uint8_t local[4] = {10,0,2,99}; uint8_t remote[4] = {1,1,1,1}; uint8_t hop[4] = {9,9,9,9};
+    { uint8_t request[290] = {0}; uint8_t requested[4] = {10,0,2,15}; uint8_t server[4] = {10,0,2,2}; uint8_t local[4] = {10,0,2,99}; uint8_t remote[4] = {1,1,1,1}; uint8_t hop[4] = {9,9,9,9};
       net_dhcp_lease_t ack = {0}, preserved;
       TEST_ASSERT_EQUAL(255, net_dhcp_build_request(request, sizeof(request), 0x12345678U, mac, requested, server));
       TEST_ASSERT_EQUAL(NET_DHCP_REQUEST, request[242]);
@@ -38,14 +38,14 @@ void test_build_and_parse_dhcp_offer(void) {
       request[242] = NET_DHCP_ACK;
       request[255] = NET_DHCP_OPTION_SUBNET_MASK; request[256] = 4; request[257] = 255; request[258] = 255; request[259] = 255; request[260] = 0;
       request[261] = NET_DHCP_OPTION_ROUTER; request[262] = 4; request[263] = 10; request[264] = 0; request[265] = 2; request[266] = 2;
-      request[267] = NET_DHCP_OPTION_DNS; request[268] = 8; request[269] = 1; request[270] = 1; request[271] = 1; request[272] = 1; request[273] = 8; request[274] = 8; request[275] = 8; request[276] = 8; request[277] = NET_DHCP_OPTION_END;
-      TEST_ASSERT_EQUAL(0, net_dhcp_parse_ack(request, sizeof(request), 0x12345678U, &ack));
-      TEST_ASSERT_EQUAL(1, ack.valid); TEST_ASSERT_EQUAL(10, ack.ipv4[0]); TEST_ASSERT_EQUAL(1, ack.subnet_valid); TEST_ASSERT_EQUAL(255, ack.subnet_mask[0]); TEST_ASSERT_EQUAL(1, ack.router_valid); TEST_ASSERT_EQUAL(10, ack.router_ipv4[0]); TEST_ASSERT_EQUAL(2, ack.router_ipv4[3]); TEST_ASSERT_EQUAL(1, ack.dns_valid); TEST_ASSERT_EQUAL(1, ack.dns_ipv4[0]);
+      request[267] = NET_DHCP_OPTION_DNS; request[268] = 8; request[269] = 1; request[270] = 1; request[271] = 1; request[272] = 1; request[273] = 8; request[274] = 8; request[275] = 8; request[276] = 8; request[277] = NET_DHCP_OPTION_LEASE_TIME; request[278] = 4; request[279] = 0; request[280] = 0; request[281] = 0; request[282] = 100; request[283] = NET_DHCP_OPTION_END;
+      TEST_ASSERT_EQUAL(0, net_dhcp_parse_ack(request, 284, 0x12345678U, &ack));
+      TEST_ASSERT_EQUAL(1, ack.valid); TEST_ASSERT_EQUAL(100U, ack.lease_seconds); TEST_ASSERT_EQUAL(10, ack.ipv4[0]); TEST_ASSERT_EQUAL(1, ack.subnet_valid); TEST_ASSERT_EQUAL(0, net_dhcp_lease_mark_acquired(&ack,1000U)); TEST_ASSERT_EQUAL(1, net_dhcp_lease_is_valid_at(&ack,1049U)); TEST_ASSERT_EQUAL(1, net_dhcp_lease_renewal_due(&ack,1050U)); TEST_ASSERT_EQUAL(1, net_dhcp_lease_is_valid_at(&ack,1099U)); TEST_ASSERT_EQUAL(0, net_dhcp_lease_is_valid_at(&ack,1100U)); TEST_ASSERT_EQUAL(255, ack.subnet_mask[0]); TEST_ASSERT_EQUAL(1, ack.router_valid); TEST_ASSERT_EQUAL(10, ack.router_ipv4[0]); TEST_ASSERT_EQUAL(2, ack.router_ipv4[3]); TEST_ASSERT_EQUAL(1, ack.dns_valid); TEST_ASSERT_EQUAL(1, ack.dns_ipv4[0]);
       TEST_ASSERT_EQUAL(0, net_dhcp_lease_next_hop(&ack, local, hop)); TEST_ASSERT_EQUAL(10, hop[0]); TEST_ASSERT_EQUAL(99, hop[3]);
       TEST_ASSERT_EQUAL(0, net_dhcp_lease_next_hop(&ack, remote, hop)); TEST_ASSERT_EQUAL(10, hop[0]); TEST_ASSERT_EQUAL(2, hop[3]);
       ack.subnet_valid = 0; hop[0] = 9; TEST_ASSERT_NOT_EQUAL(0, net_dhcp_lease_next_hop(&ack, remote, hop)); TEST_ASSERT_EQUAL(9, hop[0]); ack.subnet_valid = 1;
       preserved = ack; request[262] = 3;
-      TEST_ASSERT_NOT_EQUAL(0, net_dhcp_parse_ack(request, sizeof(request), 0x12345678U, &ack));
+      TEST_ASSERT_NOT_EQUAL(0, net_dhcp_parse_ack(request, 284, 0x12345678U, &ack));
       TEST_ASSERT_EQUAL(preserved.valid, ack.valid); TEST_ASSERT_EQUAL(preserved.subnet_valid, ack.subnet_valid); TEST_ASSERT_EQUAL(preserved.router_valid, ack.router_valid); TEST_ASSERT_EQUAL(preserved.dns_valid, ack.dns_valid); TEST_ASSERT_EQUAL(preserved.dns_ipv4[0], ack.dns_ipv4[0]); }
 }
 


### PR DESCRIPTION
## Résumé
- parse l’option DHCP 51 ;
- expose acquisition, validité et renouvellement caller-owned ;
- conserve le parsing transactionnel et le next-hop existant ;
- ajoute tests et documentation française.

## Validation locale
- `make test-all` : 414/414 tests verts ;
- `make -j2` : build i386 propre ;
- `git diff --check` : propre.