### PR TITLE
AOS-1081..1096: ajouter le contrat writer FAT16

### DIFF
--- a/docs/aos1081_1096_fat16_writer_contract.md
+++ b/docs/aos1081_1096_fat16_writer_contract.md
@@ -1,0 +1,23 @@
+# AOS-1081 à AOS-1096 — contrat writer sectoriel FAT16
+
+Le volume FAT16 accepte désormais un callback `fat16_write_sector_fn` caller-owned via `fat16_attach_writer`. Le montage conserve un mode lecture seule par défaut : aucun writer n’est installé implicitement et les volumes existants restent compatibles.
+
+`fat16_write_sector` vérifie le montage, la présence explicite du writer, le buffer caller-owned et la plage LBA du volume avant de déléguer une écriture d’un secteur de 512 octets. Les erreurs du backend sont converties en erreur FAT16 et aucun état global n’est modifié.
+
+Ce sous-lot établit la primitive de stockage nécessaire aux prochaines écritures de FAT, d’entrées de répertoire et de données. Il ne prétend pas encore implémenter l’allocation de clusters, les noms longs LFN, FAT32 ou la création atomique de fichiers ; ces fonctions restent à livrer au-dessus de ce contrat borné.
+
+> L’écriture disque est explicitement injectée par le caller ; le FAT16 historique reste lecture seule tant qu’elle n’est pas attachée.
+
+| Élément | Garantie |
+|---|---|
+| Mode par défaut | Lecture seule |
+| Writer | Callback explicite caller-owned |
+| Granularité | Un secteur de 512 octets |
+| Bornage | LBA contrôlé contre le volume monté |
+| Erreur backend | Retour FAT16, pas d’état partiel |
+| Allocation | Aucune |
+
+Validation locale : **415/415 tests verts**, dont le test d’attachement, d’écriture et de rejet hors volume.
+
+Auteur : **Manus AI**
+

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -774,3 +774,6 @@ Le wrapper `net_https_open_application_record_if_ready` complète le garde d’�
 
 ### AOS-1065 à AOS-1080 — bail DHCP live borné
 Le parseur ACK extrait l’option 51 et le bail caller-owned expose sa durée, son tick d’acquisition, sa validité et son seuil de renouvellement. Les contrôles sont non bloquants, sûrs au wraparound et transactionnels en cas d’option mal formée. Aucun `kmalloc`. Validation locale : **414/414 tests verts**.
+
+### AOS-1081 à AOS-1096 — contrat writer sectoriel FAT16
+Le volume FAT16 accepte un writer sectoriel explicite caller-owned, désactivé par défaut, avec contrôle du montage et de la plage LBA. Cette primitive prépare les futures écritures FAT/entrées de répertoire sans introduire LFN, FAT32 ou allocation de clusters prématurément. Validation locale : **415/415 tests verts**.

--- a/kernel/fs/fat16.c
+++ b/kernel/fs/fat16.c
@@ -112,6 +112,7 @@ int fat16_mount(fat16_volume_t* v, fat16_read_sector_fn read_sector, uint32_t ba
     if (!v || !read_sector) return OS_FAT16_CORRUPT;
     v->mounted = 0U;
     v->read_sector = read_sector;
+    v->write_sector = 0;
     v->base_lba = base_lba;
     if (read_sector(base_lba, sector) != 0) {
         status_text = "FAT16: secteur boot illisible";
@@ -168,6 +169,8 @@ int fat16_mount(fat16_volume_t* v, fat16_read_sector_fn read_sector, uint32_t ba
 int fat16_is_mounted(const fat16_volume_t* v) {
     return v && v->mounted != 0U;
 }
+int fat16_attach_writer(fat16_volume_t* v, fat16_write_sector_fn write_sector){if(!v||!fat16_is_mounted(v)||!write_sector)return OS_FAT16_CORRUPT;v->write_sector=write_sector;return 0;}
+int fat16_write_sector(const fat16_volume_t* v,uint32_t lba,const uint8_t* buffer){if(!v||!buffer||!fat16_is_mounted(v)||!v->write_sector)return OS_FAT16_NOT_MOUNTED;if(lba<v->base_lba||lba-v->base_lba>=v->total_sectors)return OS_FAT16_CORRUPT;return v->write_sector(lba,buffer)==0?0:OS_FAT16_CORRUPT;}
 
 int fat16_list_root(const fat16_volume_t* v, os_fat16_dirent_t* out, uint32_t capacity) {
     uint32_t i;

--- a/kernel/fs/fat16.h
+++ b/kernel/fs/fat16.h
@@ -5,9 +5,11 @@
 #include "../../include/os_syscalls.h"
 
 typedef int (*fat16_read_sector_fn)(uint32_t lba, void* buffer);
+typedef int (*fat16_write_sector_fn)(uint32_t lba, const void* buffer);
 
 typedef struct {
     fat16_read_sector_fn read_sector;
+    fat16_write_sector_fn write_sector;
     uint32_t base_lba;
     uint32_t total_sectors;
     uint32_t fat_lba;
@@ -37,6 +39,9 @@ fat16_volume_t* fat16_root(void);
 int fat16_mount(fat16_volume_t* volume, fat16_read_sector_fn read_sector,
                 uint32_t base_lba);
 int fat16_is_mounted(const fat16_volume_t* volume);
+/* Attache explicitement un writer caller-owned ; aucun writer implicite n’est créé au montage. */
+int fat16_attach_writer(fat16_volume_t* volume, fat16_write_sector_fn write_sector);
+int fat16_write_sector(const fat16_volume_t* volume, uint32_t lba, const uint8_t* buffer);
 int fat16_list_root(const fat16_volume_t* volume, os_fat16_dirent_t* out,
                     uint32_t capacity);
 int fat16_read_file(const fat16_volume_t* volume, const char* name,

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -26,6 +26,12 @@ static int read_sector(uint32_t lba, void* out) {
     for (i = 0U; i < 512U; i++) ((uint8_t*)out)[i] = disk[lba * 512U + i];
     return 0;
 }
+static int write_sector(uint32_t lba, const void* in) {
+    uint32_t i;
+    if (!in || lba >= TEST_SECTORS) return -1;
+    for (i = 0U; i < 512U; i++) disk[lba * 512U + i] = ((const uint8_t*)in)[i];
+    return 0;
+}
 
 static void make_volume(void) {
     uint32_t fat;
@@ -562,6 +568,7 @@ static void test_rejects_bad_bpb(void) {
     TEST_ASSERT_FALSE(fat16_is_mounted(&volume));
 }
 
+static void test_writes_only_with_explicit_writer(void){fat16_volume_t volume;uint8_t buffer[512]={0};make_volume();TEST_ASSERT_EQUAL(0,fat16_mount(&volume,read_sector,0U));TEST_ASSERT_EQUAL(OS_FAT16_NOT_MOUNTED,fat16_write_sector(&volume,2U,buffer));TEST_ASSERT_EQUAL(0,fat16_attach_writer(&volume,write_sector));buffer[0]=0xa5U;TEST_ASSERT_EQUAL(0,fat16_write_sector(&volume,2U,buffer));TEST_ASSERT_EQUAL(0xa5U,disk[2U*512U]);TEST_ASSERT_EQUAL(OS_FAT16_CORRUPT,fat16_write_sector(&volume,TEST_SECTORS,buffer));}
 static void test_rejects_bad_name_and_small_buffer(void) {
     fat16_volume_t volume;
     char content[4];
@@ -579,6 +586,7 @@ int main(void) {
     RUN_TEST(test_cursor_reads_successive_windows);
     RUN_TEST(test_rejects_bad_bpb);
     RUN_TEST(test_rejects_bad_name_and_small_buffer);
+    RUN_TEST(test_writes_only_with_explicit_writer);
     unity_print_results();
     unity_cleanup();
     return 0;


### PR DESCRIPTION
## Résumé
- ajoute un callback writer sectoriel caller-owned ;
- conserve le montage lecture seule par défaut ;
- contrôle montage et plage LBA ;
- ajoute test et documentation française ;
- prépare les prochaines écritures FAT sans prétendre encore livrer LFN/FAT32.

## Validation locale
- `make test-all` : 415/415 tests verts ;
- `make -j2` : build i386 propre ;
- `git diff --check` : propre.