### PR TITLE
AOS-1097..1112: provisionner OpenAI au niveau noyau

### DIFF
--- a/docs/aos1097_1112_openai_bearer_syscall.md
+++ b/docs/aos1097_1112_openai_bearer_syscall.md
@@ -1,0 +1,26 @@
+# AOS-1097 à AOS-1112 — provisionnement OpenAI sécurisé
+
+Le noyau AI-OS expose désormais `SYS_LLM_OPENAI_CREDENTIAL` pour provisionner un bearer OpenAI dans un buffer fixe du noyau. La requête POD est bornée à `OS_LLM_BEARER_MAX` octets et le token est validé comme chaîne ASCII terminée ; il n’est jamais renvoyé dans un résultat syscall ni imprimé par le shell.
+
+Le bearer précédent est effacé avant tout remplacement. Le provisionnement est accepté uniquement lorsque la session LLM est inactive, ce qui empêche de modifier les identifiants pendant une connexion TLS ou une requête en cours. Les requêtes Ollama continuent d’utiliser un chemin sans bearer ; les requêtes OpenAI refusent proprement l’envoi si aucun credential n’a été provisionné.
+
+La fermeture de session efface le buffer credential avec la même primitive de nettoyage que les clés TLS et les buffers HTTP. Le code reste freestanding, sans `kmalloc`, sans copie vers un buffer dynamique et sans modification du protocole TLS.
+
+> Le credential est un secret de session noyau : il doit être injecté avant l’acquisition réseau et disparaît à la fermeture de la session.
+
+| Élément | Garantie |
+|---|---|
+| API | `SYS_LLM_OPENAI_CREDENTIAL` |
+| Taille | `OS_LLM_BEARER_MAX` octets maximum |
+| Validation | ASCII, terminaison obligatoire |
+| Moment d’écriture | Session LLM inactive uniquement |
+| Utilisation | OpenAI seulement, jamais Ollama |
+| Effacement | Remplacement et `ai-close` |
+| Allocation | Aucune |
+
+Validation locale : **415/415 tests verts**, build i386 propre et contrôle de diff propre.
+
+Ce lot rend le chemin OpenAI provisionnable au niveau noyau. L’interface graphique ou le shell doit fournir le secret par un canal de saisie protégé ; le noyau ne propose volontairement aucune commande qui l’affiche ou le persiste en clair.
+
+Auteur : **Manus AI**
+

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -777,3 +777,6 @@ Le parseur ACK extrait l’option 51 et le bail caller-owned expose sa durée, s
 
 ### AOS-1081 à AOS-1096 — contrat writer sectoriel FAT16
 Le volume FAT16 accepte un writer sectoriel explicite caller-owned, désactivé par défaut, avec contrôle du montage et de la plage LBA. Cette primitive prépare les futures écritures FAT/entrées de répertoire sans introduire LFN, FAT32 ou allocation de clusters prématurément. Validation locale : **415/415 tests verts**.
+
+### AOS-1097 à AOS-1112 — provisionnement OpenAI sécurisé
+Ajout de `SYS_LLM_OPENAI_CREDENTIAL` et d’un bearer fixe, borné, validé et effaçable dans le noyau. Le token n’est utilisé que pour OpenAI, jamais retourné ni affiché, et est refusé pendant une session active. Validation locale : **415/415 tests verts**.

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -180,8 +180,10 @@
 #define SYS_LLM_RESET_FOR_REQUEST 96
 /* Aucun argument ; tente un FIN TCP si la session est établie puis purge localement la session. */
 #define SYS_LLM_CLOSE 97
+/* EBX = os_llm_openai_credential_request_t* ; copie un bearer borné dans le noyau. */
+#define SYS_LLM_OPENAI_CREDENTIAL 98
 
-#define MAX_SYSCALLS 98
+#define MAX_SYSCALLS 99
 
 /* Requête POD sans pointeur : hostname, ports et budgets uniquement. */
 #define OS_LLM_HOSTNAME_MAX 96U
@@ -190,6 +192,7 @@
 #define OS_LLM_PATH_MAX 64U
 #define OS_LLM_PROMPT_MAX 1024U
 #define OS_LLM_TEXT_MAX 2048U
+#define OS_LLM_BEARER_MAX 128U
 typedef struct {
     char hostname[OS_LLM_HOSTNAME_MAX];
     uint32_t xid;
@@ -212,6 +215,9 @@ typedef struct {
     uint8_t prompt[OS_LLM_PROMPT_MAX];
 } os_llm_request_t;
 
+/* Credential OpenAI POD : le token n’est jamais retourné par un syscall. */
+typedef struct { char bearer[OS_LLM_BEARER_MAX]; } os_llm_openai_credential_request_t;
+
 /* Sortie copiée par valeur : texte extrait et code HTTP, jamais un buffer TLS interne. */
 typedef struct {
     uint16_t text_length;
@@ -230,6 +236,8 @@ typedef struct {
 #define OS_LLM_REQUEST_BAD_PHASE (-98)
 #define OS_LLM_REQUEST_UNCONFIGURED (-99)
 #define OS_LLM_REQUEST_FAILED (-100)
+#define OS_LLM_CREDENTIAL_BAD_ARGUMENT (-109)
+#define OS_LLM_CREDENTIAL_BAD_PHASE (-110)
 #define OS_LLM_TEXT_BAD_ARGUMENT (-101)
 #define OS_LLM_TEXT_BAD_PHASE (-102)
 #define OS_LLM_TEXT_FAILED (-103)

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -40,7 +40,7 @@ void print_string(const char* str);
 
 static ne2k_device_t boot_ne2k_device;
 static ne2k_io_t boot_ne2k_io;
-/* Contexte persistant appartenant au noyau ; aucun buffer, endpoint ou secret n’y est stocké. */
+/* Contexte persistant appartenant au noyau ; le seul secret est le bearer borné et effaçable ci-dessous. */
 static ne2k_llm_network_context_t boot_llm_network;
 /* Espaces de travail noyau fixes : aucun buffer du chemin DHCP→LLM n’est alloué. */
 static net_arp_cache_t boot_llm_arp_cache;
@@ -55,6 +55,8 @@ static x509_certificate_view_t boot_llm_trust_anchor;
 static uint8_t boot_llm_trust_anchor_ready;
 static rtc_io_t boot_llm_rtc_io;
 static char boot_llm_hostname[OS_LLM_HOSTNAME_MAX];
+static char boot_llm_openai_bearer[OS_LLM_BEARER_MAX];
+static uint8_t boot_llm_openai_bearer_ready;
 static uint8_t boot_llm_client_random[NET_TLS_X25519_KEY_LENGTH];
 static uint8_t boot_llm_client_private[NET_TLS_X25519_KEY_LENGTH];
 static uint8_t boot_llm_rdrand_supported;
@@ -268,6 +270,7 @@ static int kernel_llm_text_field_is_valid(const char* field, uint16_t capacity) 
     return 0;
 }
 
+int kernel_llm_configure_openai(const os_llm_openai_credential_request_t* request){uint16_t index;if(!request||!kernel_llm_text_field_is_valid(request->bearer,OS_LLM_BEARER_MAX))return OS_LLM_CREDENTIAL_BAD_ARGUMENT;if(boot_llm_network.session.phase!=NE2K_LLM_CONNECTION_IDLE)return OS_LLM_CREDENTIAL_BAD_PHASE;kernel_llm_clear_bytes((uint8_t*)boot_llm_openai_bearer,sizeof(boot_llm_openai_bearer));for(index=0U;index<OS_LLM_BEARER_MAX;index++){boot_llm_openai_bearer[index]=request->bearer[index];if(request->bearer[index]=='\0')break;}boot_llm_openai_bearer_ready=1U;return 0;}
 int kernel_llm_request(const os_llm_request_t* request) {
     int status;
     if (!request || !kernel_llm_text_field_is_valid(request->model, OS_LLM_MODEL_MAX) ||
@@ -277,8 +280,7 @@ int kernel_llm_request(const os_llm_request_t* request) {
         return OS_LLM_REQUEST_BAD_REQUEST;
     if (!boot_ne2k_present || boot_llm_network.session.phase != NE2K_LLM_CONNECTION_TLS_COMPLETE)
         return OS_LLM_REQUEST_BAD_PHASE;
-    /* Aucun canal Ring 3 ne fournit de bearer token ; OpenAI attend un provisionnement noyau dédié. */
-    if (request->provider == NE2K_LLM_PROVIDER_OPENAI) return OS_LLM_REQUEST_UNCONFIGURED;
+    if (request->provider == NE2K_LLM_PROVIDER_OPENAI && !boot_llm_openai_bearer_ready) return OS_LLM_REQUEST_UNCONFIGURED;
     if (request->streaming) {
         if (net_llm_sse_response_init(&boot_llm_sse_response, boot_llm_sse_http_buffer,
                                       sizeof(boot_llm_sse_http_buffer), boot_llm_sse_event_buffer,
@@ -287,7 +289,8 @@ int kernel_llm_request(const os_llm_request_t* request) {
             &boot_ne2k_device, &boot_ne2k_io, &boot_llm_arp_cache, boot_llm_frame, sizeof(boot_llm_frame),
             boot_llm_network.lease.ipv4, &boot_llm_network.session, &boot_llm_network.connection,
             &boot_llm_tls_client, request->provider, boot_llm_http_json, sizeof(boot_llm_http_json),
-            boot_llm_http_request, sizeof(boot_llm_http_request), boot_llm_hostname, request->path, 0,
+            boot_llm_http_request, sizeof(boot_llm_http_request), boot_llm_hostname, request->path,
+            request->provider == NE2K_LLM_PROVIDER_OPENAI ? boot_llm_openai_bearer : 0,
             request->model, request->prompt, request->prompt_length, boot_llm_http_tls_record,
             sizeof(boot_llm_http_tls_record), 2U);
     } else {
@@ -299,7 +302,8 @@ int kernel_llm_request(const os_llm_request_t* request) {
             &boot_ne2k_device, &boot_ne2k_io, &boot_llm_arp_cache, boot_llm_frame, sizeof(boot_llm_frame),
             boot_llm_network.lease.ipv4, &boot_llm_network.session, &boot_llm_network.connection,
             &boot_llm_tls_client, request->provider, boot_llm_http_json, sizeof(boot_llm_http_json),
-            boot_llm_http_request, sizeof(boot_llm_http_request), boot_llm_hostname, request->path, 0,
+            boot_llm_http_request, sizeof(boot_llm_http_request), boot_llm_hostname, request->path,
+            request->provider == NE2K_LLM_PROVIDER_OPENAI ? boot_llm_openai_bearer : 0,
             request->model, request->prompt, request->prompt_length, boot_llm_http_tls_record,
             sizeof(boot_llm_http_tls_record), 2U);
     }
@@ -369,6 +373,8 @@ static void kernel_llm_clear_session_preserve_lease(void) {
     kernel_llm_clear_bytes((uint8_t*)&boot_llm_http_response, sizeof(boot_llm_http_response));
     kernel_llm_clear_bytes((uint8_t*)&boot_llm_sse_response, sizeof(boot_llm_sse_response));
     kernel_llm_clear_bytes((uint8_t*)boot_llm_hostname, sizeof(boot_llm_hostname));
+    kernel_llm_clear_bytes((uint8_t*)boot_llm_openai_bearer, sizeof(boot_llm_openai_bearer));
+    boot_llm_openai_bearer_ready = 0U;
     kernel_llm_clear_tls_material();
     boot_llm_network.lease = retained_lease;
     boot_llm_network.session.phase = NE2K_LLM_CONNECTION_IDLE;

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -87,6 +87,7 @@ static net_llm_sse_response_t boot_llm_sse_response;
 static uint8_t boot_llm_http_provider;
 static uint8_t boot_llm_http_streaming;
 static uint8_t boot_ne2k_present;
+static void kernel_llm_clear_bytes(uint8_t* buffer, uint32_t length);
 static int kernel_llm_rdrand_supported(void);
 void ne2k_irq_handler(void) { ne2k_irq_service(); }
 

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -33,6 +33,7 @@ extern int kernel_llm_poll_text(os_llm_text_result_t* result);
 extern int kernel_llm_poll_sse(os_llm_text_result_t* result);
 extern int kernel_llm_reset_for_request(void);
 extern int kernel_llm_close(void);
+extern int kernel_llm_configure_openai(const os_llm_openai_credential_request_t* request);
 extern void print_char(char c, int x, int y, char color);
 extern void write_serial(char c);
 
@@ -337,6 +338,9 @@ void syscall_handler(cpu_state_t* cpu) {
             break;
         case SYS_LLM_CLOSE:
             cpu->eax = (uint32_t)kernel_llm_close();
+            break;
+        case SYS_LLM_OPENAI_CREDENTIAL:
+            cpu->eax = (uint32_t)kernel_llm_configure_openai((const os_llm_openai_credential_request_t*)cpu->ebx);
             break;
         case SYS_MKDIR:
             cpu->eax = (uint32_t)sys_mkdir((const char*)cpu->ebx);


### PR DESCRIPTION
## Résumé
- ajoute `SYS_LLM_OPENAI_CREDENTIAL` ;
- copie un bearer fixe et borné dans le noyau ;
- utilise le token uniquement pour OpenAI ;
- efface le credential au remplacement et à la fermeture ;
- ajoute documentation française et backlog.

## Validation locale
- `make test-all` : 415/415 tests verts ;
- `make -j2` : build i386 propre ;
- `git diff --check` : propre.