### PR TITLE
feat(fat16): add bounded long filename entries

### DIFF
--- a/docs/aos1193_fat16_lfn.md
+++ b/docs/aos1193_fat16_lfn.md
@@ -1,0 +1,53 @@
+# AOS-1193 à AOS-1208 — Sous-lot LFN FAT16 borné
+
+> **État :** implémenté localement. **Validation noyau : 33/33 tests verts.**
+
+## Périmètre
+
+Ce sous-lot ajoute la publication d’un fichier FAT16 accompagné d’entrées **Long File Name** et la reconstruction de son nom dans le listage de la racine. L’implémentation utilise uniquement des buffers automatiques de taille fixe et des données fournies par l’appelant ; elle n’introduit aucun `kmalloc`.
+
+Le nom long accepté est constitué de caractères ASCII imprimables, sans séparateur de chemin, et est limité à `OS_NAME_MAX - 1` octets. Chaque caractère est stocké sous forme de code UTF-16LE sur un octet utile et un octet nul. Ce choix constitue un sous-ensemble sûr avant l’ajout de la conversion UTF-8/UTF-16 complète.
+
+## Publication
+
+L’API est la suivante :
+
+```c
+int fat16_create_lfn_file(const fat16_volume_t* volume,
+                          const char* long_name,
+                          const char* short_name,
+                          uint8_t attributes,
+                          const uint8_t* data,
+                          uint32_t size,
+                          uint16_t* out_first_cluster);
+```
+
+L’orchestrateur crée d’abord le contenu et l’alias 8.3 par `fat16_create_file`. Il réserve ensuite les slots contigus suivants, marque l’ancien slot court comme supprimé, écrit les entrées LFN dans l’ordre FAT16 requis, puis écrit l’entrée courte finale. L’octet ordinal du premier slot porte le marqueur `0x40`, tandis que les ordinals suivants sont décroissants jusqu’à `1`.
+
+Chaque entrée LFN contient l’attribut `0x0F`, un type nul, le checksum de l’alias 8.3 et les trois champs UTF-16LE aux offsets FAT16 standards. Le checksum est recalculé lors du listage pour empêcher l’association d’un nom long à un alias différent.
+
+## Reconstruction
+
+`fat16_list_root` conserve une vue caller-owned de la séquence LFN courante. Il accepte une séquence uniquement si les ordinals sont continus, si le checksum reste identique et si le checksum final correspond à l’entrée courte suivante. Les entrées invalides ou interrompues sont ignorées et l’alias court est alors utilisé comme représentation de repli.
+
+Le résultat est copié dans `os_fat16_dirent_t.name`, dont la capacité est `OS_NAME_MAX`. Les valeurs UTF-16 hors ASCII sont remplacées par `?` dans ce sous-lot ; aucune conversion Unicode complète n’est prétendue.
+
+| Élément | Statut |
+|---|---|
+| Écriture LFN ASCII bornée | Implémentée |
+| Encodage UTF-16LE des caractères ASCII | Implémenté |
+| Checksum alias 8.3 | Implémenté |
+| Reconstruction dans `fat16_list_root` | Implémentée |
+| Recherche directe par nom long dans `read`/`open` | Prochain incrément |
+| UTF-8 complet, caractères non BMP et normalisation | Prochain incrément |
+| FAT32 | Hors périmètre de ce lot |
+
+## Validation
+
+Le test LFN crée `Session-2026-A` avec l’alias `SESS01.TXT`, vérifie la suppression de l’ancien slot, les ordinals `0x42` et `0x01`, l’attribut LFN, l’encodage des caractères et la restitution du nom long par `fat16_list_root`. La suite noyau est verte à **33/33** et la suite complète est verte à **417/417**.
+
+## Contraintes et suite
+
+Le lot ne modifie pas l’ABI de `os_fat16_dirent_t`, ne dépend d’aucune allocation dynamique et conserve l’alias court pour les APIs de lecture existantes. Le prochain incrément doit factoriser la recherche d’entrée afin d’accepter soit l’alias 8.3, soit le nom long validé, puis ajouter les tests de `read_file`, `read_file_range`, `open_file` et du curseur.
+
+**Auteur :** Manus AI

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -805,3 +805,8 @@ Voir [aos1161_fat16_root_entry.md](aos1161_fat16_root_entry.md) pour le contrat 
 La fonction ne fournit toujours pas de nom long LFN et ne modifie pas les règles FAT32. Elle constitue la fondation du stockage persistant des sessions LLM avant l’ajout des métadonnées LFN et de la généralisation FAT32.
 
 Voir [aos1177_fat16_create_file.md](aos1177_fat16_create_file.md) pour le contrat, la séquence transactionnelle et les limites.
+
+### AOS-1193 à AOS-1208 — sous-lot LFN FAT16 borné
+`fat16_create_lfn_file` publie une séquence LFN ASCII bornée en UTF-16LE avec checksum de l’alias 8.3, puis l’entrée courte et les données déjà persistées. `fat16_list_root` valide l’ordre, le checksum et reconstruit le nom long dans `OS_NAME_MAX` sans allocation dynamique. Les caractères non ASCII sont représentés de manière conservative lors du listage ; la recherche directe par nom long dans les APIs de lecture et l’Unicode complet restent le prochain incrément LFN. Validation noyau : **33/33 tests verts** et suite globale **417/417 tests verts**.
+
+Voir [aos1193_fat16_lfn.md](aos1193_fat16_lfn.md).

--- a/kernel/fs/fat16.c
+++ b/kernel/fs/fat16.c
@@ -236,21 +236,140 @@ int fat16_create_file(const fat16_volume_t* v, const char* name, uint8_t attribu
     return 0;
 }
 
+static uint8_t fat16_lfn_checksum(const uint8_t* short_name) {
+    uint32_t i;
+    uint8_t sum = 0U;
+    for (i = 0U; i < 11U; i++) sum = (uint8_t)(((sum & 1U) ? 0x80U : 0U) + (sum >> 1U) + short_name[i]);
+    return sum;
+}
+
+static int fat16_write_root_slot(const fat16_volume_t* v, uint32_t index, const uint8_t* entry) {
+    uint32_t byte_offset = index * FAT16_ENTRY_SIZE;
+    uint32_t lba = v->root_lba + (byte_offset / FAT16_SECTOR_SIZE);
+    uint32_t offset = byte_offset % FAT16_SECTOR_SIZE, i;
+    if (index >= v->root_entries || read_at(v, lba, sector) != 0) return OS_FAT16_CORRUPT;
+    for (i = 0U; i < FAT16_ENTRY_SIZE; i++) sector[offset + i] = entry[i];
+    return fat16_write_sector(v, lba, sector);
+}
+
+static void fat16_lfn_put(uint8_t* entry, uint32_t offset, uint32_t pos, const char* name, uint32_t length) {
+    uint32_t i;
+    uint32_t limit = offset == 1U ? 5U : (offset == 14U ? 6U : 2U);
+    for (i = 0U; i < limit; i++) {
+        uint32_t at = pos + i;
+        uint16_t value = at < length ? (uint8_t)name[at] : (at == length ? 0U : 0xFFFFU);
+        entry[offset + i * 2U] = (uint8_t)value;
+        entry[offset + i * 2U + 1U] = (uint8_t)(value >> 8U);
+    }
+}
+
+int fat16_create_lfn_file(const fat16_volume_t* v, const char* long_name,
+                          const char* short_name, uint8_t attributes,
+                          const uint8_t* data, uint32_t size, uint16_t* out_first_cluster) {
+    uint8_t alias[11], entry[FAT16_ENTRY_SIZE];
+    uint32_t length = 0U, i, alias_index = v ? v->root_entries : 0U, count, start;
+    uint16_t first = 0U;
+    int rc;
+    if (!v || !long_name || !short_name || !out_first_cluster) return OS_FAT16_BAD_PATH;
+    while (long_name[length]) {
+        if (length >= OS_NAME_MAX - 1U || (uint8_t)long_name[length] < 0x20U || long_name[length] == '/' || long_name[length] == '\\') return OS_FAT16_BAD_PATH;
+        length++;
+    }
+    if (length == 0U || make_short_name(short_name, alias) != 0) return OS_FAT16_BAD_PATH;
+    count = (length + 12U) / 13U;
+    if (count == 0U || count > 20U) return OS_FAT16_BAD_PATH;
+    rc = fat16_create_file(v, short_name, attributes, data, size, &first);
+    if (rc != 0) return rc;
+    for (i = 0U; i < v->root_entries; i++) {
+        if (read_root_entry(v, i, entry) != 0) return OS_FAT16_CORRUPT;
+        if (entry_matches(entry, alias)) { alias_index = i; break; }
+    }
+    if (alias_index >= v->root_entries || alias_index + count + 1U >= v->root_entries) return OS_FAT16_NOT_FOUND;
+    start = alias_index + 1U;
+    for (i = 0U; i < count + 1U; i++) {
+        if (read_root_entry(v, start + i, entry) != 0) return OS_FAT16_CORRUPT;
+        if (entry[0] != 0U && entry[0] != 0xE5U) return OS_FAT16_NOT_FOUND;
+    }
+    entry[0] = 0xE5U;
+    rc = fat16_write_root_slot(v, alias_index, entry);
+    if (rc != 0) return rc;
+    for (i = 0U; i < count; i++) {
+        uint32_t ordinal = count - i;
+        uint32_t pos = (ordinal - 1U) * 13U;
+        uint32_t j;
+        for (j = 0U; j < 32U; j++) entry[j] = 0xFFU;
+        entry[0] = (uint8_t)ordinal | (i == 0U ? 0x40U : 0U);
+        entry[11] = 0x0FU; entry[12] = 0U; entry[13] = fat16_lfn_checksum(alias);
+        entry[26] = 0U; entry[27] = 0U;
+        fat16_lfn_put(entry, 1U, pos, long_name, length);
+        fat16_lfn_put(entry, 14U, pos + 5U, long_name, length);
+        fat16_lfn_put(entry, 28U, pos + 11U, long_name, length);
+        rc = fat16_write_root_slot(v, start + i, entry);
+        if (rc != 0) return rc;
+    }
+    for (i = 0U; i < 32U; i++) entry[i] = 0U;
+    for (i = 0U; i < 11U; i++) entry[i] = alias[i];
+    entry[11] = attributes; entry[26] = (uint8_t)first; entry[27] = (uint8_t)(first >> 8U);
+    entry[28] = (uint8_t)size; entry[29] = (uint8_t)(size >> 8U);
+    entry[30] = (uint8_t)(size >> 16U); entry[31] = (uint8_t)(size >> 24U);
+    rc = fat16_write_root_slot(v, start + count, entry);
+    if (rc != 0) return rc;
+    *out_first_cluster = first;
+    return 0;
+}
+
+static void fat16_lfn_get(uint8_t* entry, uint32_t offset, uint32_t pos, char* out, uint32_t max) {
+    uint32_t i;
+    uint32_t limit = offset == 1U ? 5U : (offset == 14U ? 6U : 2U);
+    for (i = 0U; i < limit; i++) {
+        uint32_t at = pos + i;
+        uint16_t value = (uint16_t)entry[offset + i * 2U] | ((uint16_t)entry[offset + i * 2U + 1U] << 8U);
+        if (at >= max - 1U || value == 0U || value == 0xFFFFU) continue;
+        out[at] = value < 0x80U ? (char)value : '?';
+    }
+}
+
 int fat16_list_root(const fat16_volume_t* v, os_fat16_dirent_t* out, uint32_t capacity) {
     uint32_t i;
     uint32_t count = 0U;
     uint8_t entry[FAT16_ENTRY_SIZE];
+    char lfn[OS_NAME_MAX];
+    uint32_t lfn_length = 0U;
+    uint8_t lfn_sum = 0U, lfn_expected = 0U, lfn_valid = 0U;
     if (!fat16_is_mounted(v)) return OS_FAT16_NOT_MOUNTED;
     if (!out || capacity == 0U) return OS_FAT16_BAD_PATH;
     for (i = 0U; i < v->root_entries; i++) {
+        uint8_t ordinal;
         if (read_root_entry(v, i, entry) != 0) return OS_FAT16_CORRUPT;
         if (entry[0] == 0x00U) break;
-        if (entry[0] == 0xE5U || entry[11] == 0x0FU || (entry[11] & 0x08U)) continue;
+        if (entry[0] == 0xE5U) { lfn_valid = 0U; continue; }
+        if (entry[11] == 0x0FU) {
+            ordinal = entry[0] & 0x1FU;
+            if ((entry[0] & 0x40U) != 0U) {
+                lfn_length = ordinal * 13U;
+                if (lfn_length >= OS_NAME_MAX) { lfn_valid = 0U; continue; }
+                for (uint32_t j = 0U; j < OS_NAME_MAX; j++) lfn[j] = '\0';
+                lfn_sum = entry[13]; lfn_expected = ordinal; lfn_valid = 1U;
+            }
+            if (!lfn_valid || ordinal == 0U || ordinal != lfn_expected || entry[13] != lfn_sum) { lfn_valid = 0U; continue; }
+            fat16_lfn_get(entry, 1U, (uint32_t)(ordinal - 1U) * 13U, lfn, OS_NAME_MAX);
+            fat16_lfn_get(entry, 14U, (uint32_t)(ordinal - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
+            fat16_lfn_get(entry, 28U, (uint32_t)(ordinal - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            lfn_expected--;
+            continue;
+        }
+        if ((entry[11] & 0x08U) != 0U) { lfn_valid = 0U; continue; }
         if (count >= capacity) return (int)count;
-        copy_name(out[count].name, entry);
+        if (lfn_valid && lfn_expected == 0U && fat16_lfn_checksum(entry) == lfn_sum) {
+            uint32_t end = 0U;
+            while (end < OS_NAME_MAX - 1U && lfn[end]) end++;
+            lfn[end] = '\0';
+            for (uint32_t j = 0U; j <= end; j++) out[count].name[j] = lfn[j];
+        } else copy_name(out[count].name, entry);
         out[count].size = le32(entry + 28U);
         out[count].flags = (entry[11] & 0x10U) ? OS_DIRENT_DIR : OS_DIRENT_FILE;
         count++;
+        lfn_valid = 0U;
     }
     return (int)count;
 }

--- a/kernel/fs/fat16.h
+++ b/kernel/fs/fat16.h
@@ -56,6 +56,11 @@ int fat16_create_root_entry(const fat16_volume_t* volume, const char* name,
 int fat16_create_file(const fat16_volume_t* volume, const char* name,
                       uint8_t attributes, const uint8_t* data, uint32_t size,
                       uint16_t* out_first_cluster);
+/* Crée un fichier avec une séquence LFN ASCII bornée et un alias 8.3 explicite. */
+int fat16_create_lfn_file(const fat16_volume_t* volume, const char* long_name,
+                          const char* short_name, uint8_t attributes,
+                          const uint8_t* data, uint32_t size,
+                          uint16_t* out_first_cluster);
 int fat16_list_root(const fat16_volume_t* volume, os_fat16_dirent_t* out,
                     uint32_t capacity);
 int fat16_read_file(const fat16_volume_t* volume, const char* name,

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -629,6 +629,47 @@ static void test_creates_persistent_file(void) {
     TEST_ASSERT_EQUAL(600, fat16_read_file(&volume, "persist.bin", (char*)readback, sizeof(readback)));
     for (i = 0U; i < sizeof(data); i++) TEST_ASSERT_EQUAL(data[i], readback[i]);
 }
+static void test_creates_lfn_file(void) {
+    fat16_volume_t volume;
+    uint8_t data[3] = {'L', 'F', 'N'};
+    uint16_t first = 0U;
+    os_fat16_dirent_t entries[4];
+    uint32_t root = 35U * 512U;
+    make_volume();
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, fat16_attach_writer(&volume, write_sector));
+    TEST_ASSERT_EQUAL(0, fat16_create_lfn_file(&volume, "Session-2026-A", "SESS01.TXT",
+                                               0x20U, data, sizeof(data), &first));
+    TEST_ASSERT_EQUAL(3U, first);
+    TEST_ASSERT_EQUAL(0xE5U, disk[root + 32U]);
+    TEST_ASSERT_EQUAL(0x42U, disk[root + 64U]);
+    TEST_ASSERT_EQUAL(0x0FU, disk[root + 64U + 11U]);
+    TEST_ASSERT_EQUAL('A', disk[root + 64U + 1U]);
+    TEST_ASSERT_EQUAL(0x01U, disk[root + 96U]);
+    TEST_ASSERT_EQUAL('S', disk[root + 96U + 1U]);
+    TEST_ASSERT_EQUAL('S', disk[root + 128U]);
+    TEST_ASSERT_EQUAL('E', disk[root + 128U + 1U]);
+    TEST_ASSERT_EQUAL('S', disk[root + 128U + 2U]);
+    TEST_ASSERT_EQUAL('S', disk[root + 128U + 3U]);
+    TEST_ASSERT_EQUAL('T', disk[root + 128U + 8U]);
+    TEST_ASSERT_EQUAL(2, fat16_list_root(&volume, entries, 4U));
+    TEST_ASSERT_EQUAL('S', entries[1].name[0]);
+    TEST_ASSERT_EQUAL('e', entries[1].name[1]);
+    TEST_ASSERT_EQUAL('s', entries[1].name[2]);
+    TEST_ASSERT_EQUAL('s', entries[1].name[3]);
+    TEST_ASSERT_EQUAL('i', entries[1].name[4]);
+    TEST_ASSERT_EQUAL('o', entries[1].name[5]);
+    TEST_ASSERT_EQUAL('n', entries[1].name[6]);
+    TEST_ASSERT_EQUAL('-', entries[1].name[7]);
+    TEST_ASSERT_EQUAL('2', entries[1].name[8]);
+    TEST_ASSERT_EQUAL('0', entries[1].name[9]);
+    TEST_ASSERT_EQUAL('2', entries[1].name[10]);
+    TEST_ASSERT_EQUAL('6', entries[1].name[11]);
+    TEST_ASSERT_EQUAL('-', entries[1].name[12]);
+    TEST_ASSERT_EQUAL('A', entries[1].name[13]);
+    TEST_ASSERT_EQUAL('\0', entries[1].name[14]);
+    TEST_ASSERT_EQUAL(3U, entries[1].size);
+}
 static void test_rejects_bad_name_and_small_buffer(void) {
     fat16_volume_t volume;
     char content[4];
@@ -648,6 +689,7 @@ int main(void) {
     RUN_TEST(test_rejects_bad_name_and_small_buffer);
     RUN_TEST(test_writes_only_with_explicit_writer);
     RUN_TEST(test_creates_persistent_file);
+    RUN_TEST(test_creates_lfn_file);
     unity_print_results();
     unity_cleanup();
     return 0;


### PR DESCRIPTION
# AOS-1193 à AOS-1208 — Sous-lot LFN FAT16 borné

> **État :** implémenté localement. **Validation noyau : 33/33 tests verts.**

## Périmètre

Ce sous-lot ajoute la publication d’un fichier FAT16 accompagné d’entrées **Long File Name** et la reconstruction de son nom dans le listage de la racine. L’implémentation utilise uniquement des buffers automatiques de taille fixe et des données fournies par l’appelant ; elle n’introduit aucun `kmalloc`.

Le nom long accepté est constitué de caractères ASCII imprimables, sans séparateur de chemin, et est limité à `OS_NAME_MAX - 1` octets. Chaque caractère est stocké sous forme de code UTF-16LE sur un octet utile et un octet nul. Ce choix constitue un sous-ensemble sûr avant l’ajout de la conversion UTF-8/UTF-16 complète.

## Publication

L’API est la suivante :

```c
int fat16_create_lfn_file(const fat16_volume_t* volume,
                          const char* long_name,
                          const char* short_name,
                          uint8_t attributes,
                          const uint8_t* data,
                          uint32_t size,
                          uint16_t* out_first_cluster);
```

L’orchestrateur crée d’abord le contenu et l’alias 8.3 par `fat16_create_file`. Il réserve ensuite les slots contigus suivants, marque l’ancien slot court comme supprimé, écrit les entrées LFN dans l’ordre FAT16 requis, puis écrit l’entrée courte finale. L’octet ordinal du premier slot porte le marqueur `0x40`, tandis que les ordinals suivants sont décroissants jusqu’à `1`.

Chaque entrée LFN contient l’attribut `0x0F`, un type nul, le checksum de l’alias 8.3 et les trois champs UTF-16LE aux offsets FAT16 standards. Le checksum est recalculé lors du listage pour empêcher l’association d’un nom long à un alias différent.

## Reconstruction

`fat16_list_root` conserve une vue caller-owned de la séquence LFN courante. Il accepte une séquence uniquement si les ordinals sont continus, si le checksum reste identique et si le checksum final correspond à l’entrée courte suivante. Les entrées invalides ou interrompues sont ignorées et l’alias court est alors utilisé comme représentation de repli.

Le résultat est copié dans `os_fat16_dirent_t.name`, dont la capacité est `OS_NAME_MAX`. Les valeurs UTF-16 hors ASCII sont remplacées par `?` dans ce sous-lot ; aucune conversion Unicode complète n’est prétendue.

| Élément | Statut |
|---|---|
| Écriture LFN ASCII bornée | Implémentée |
| Encodage UTF-16LE des caractères ASCII | Implémenté |
| Checksum alias 8.3 | Implémenté |
| Reconstruction dans `fat16_list_root` | Implémentée |
| Recherche directe par nom long dans `read`/`open` | Prochain incrément |
| UTF-8 complet, caractères non BMP et normalisation | Prochain incrément |
| FAT32 | Hors périmètre de ce lot |

## Validation

Le test LFN crée `Session-2026-A` avec l’alias `SESS01.TXT`, vérifie la suppression de l’ancien slot, les ordinals `0x42` et `0x01`, l’attribut LFN, l’encodage des caractères et la restitution du nom long par `fat16_list_root`. La suite noyau est verte à **33/33** et la suite complète est verte à **417/417**.

## Contraintes et suite

Le lot ne modifie pas l’ABI de `os_fat16_dirent_t`, ne dépend d’aucune allocation dynamique et conserve l’alias court pour les APIs de lecture existantes. Le prochain incrément doit factoriser la recherche d’entrée afin d’accepter soit l’alias 8.3, soit le nom long validé, puis ajouter les tests de `read_file`, `read_file_range`, `open_file` et du curseur.

**Auteur :** Manus AI
