### PR TITLE
feat(net): add static TCP socket registry

### DIFF
--- a/docs/aos1209_tcp_socket_registry.md
+++ b/docs/aos1209_tcp_socket_registry.md
@@ -1,0 +1,43 @@
+# AOS-1209 à AOS-1224 — registre socket TCP statique
+
+> **État :** implémenté et validé localement. **Suite globale : 418/418 tests verts.**
+
+## Objectif
+
+Ce macro-lot introduit un registre de quatre sockets TCP statiques, indépendant de la session LLM. Il fournit un cycle de vie minimal pour les connexions caller-owned : ouverture, acceptation d’un SYN-ACK, émission d’un segment de données, alimentation de la file de réception depuis un segment TCP validé, lecture bornée et fermeture.
+
+Aucune allocation dynamique n’est utilisée. Chaque slot contient une `net_tcp_connection_t` et une file RX fixe de 1024 octets. Les segments d’émission restent fournis par l’appelant ; le registre ne possède donc pas de buffer réseau global à durée indéterminée.
+
+## Contrat
+
+```c
+int net_socket_open(uint16_t local_port, uint16_t remote_port,
+                    uint32_t local_sequence);
+int net_socket_accept_syn_ack(int socket_id, const net_tcp_view_t* view);
+int net_socket_send(int socket_id, const uint8_t* payload, uint16_t length,
+                    uint8_t* segment, uint16_t capacity, uint16_t* out_length);
+int net_socket_feed(int socket_id, const uint8_t* segment, uint16_t length);
+int net_socket_receive(int socket_id, uint8_t* buffer, uint16_t capacity,
+                       uint16_t* out_length);
+int net_socket_close(int socket_id);
+```
+
+`net_socket_send` délègue la construction et la progression de séquence à `net_tcp_connection_build_data` et `net_tcp_connection_commit_send`. `net_socket_feed` parse le segment et ne copie le payload qu’après acceptation de la séquence et de l’ACK par la primitive TCP existante. La fermeture libère le slot sans toucher aux autres connexions.
+
+| Aspect | Valeur |
+|---|---:|
+| Slots simultanés | 4 |
+| File RX par slot | 1024 octets |
+| Taille TX maximale | 1500 octets |
+| Allocation dynamique | Aucune |
+| État transport | `SYN_SENT`, `ESTABLISHED` et états TCP existants |
+| Tests noyau | 34/34 |
+| Suite globale | 418/418 |
+
+## Limites explicites
+
+Ce lot ne réalise pas encore l’envoi matériel via la NIC, la résolution DNS, l’écoute passive ni les syscalls utilisateurs `socket/connect/send/recv/close`. Le registre fournit la couche de descripteurs et de buffers nécessaire à cette exposition ultérieure, sans coupler l’API générique au client TLS/LLM.
+
+Le prochain incrément doit ajouter des structures POD de syscall, une validation des pointeurs utilisateur conforme aux conventions existantes, puis relier les opérations au dispatch syscall. Les chemins TLS/HTTP continueront d’utiliser leur session spécialisée jusqu’à leur migration contrôlée.
+
+**Auteur :** Manus AI

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -810,3 +810,8 @@ Voir [aos1177_fat16_create_file.md](aos1177_fat16_create_file.md) pour le contra
 `fat16_create_lfn_file` publie une séquence LFN ASCII bornée en UTF-16LE avec checksum de l’alias 8.3, puis l’entrée courte et les données déjà persistées. `fat16_list_root` valide l’ordre, le checksum et reconstruit le nom long dans `OS_NAME_MAX` sans allocation dynamique. Les caractères non ASCII sont représentés de manière conservative lors du listage ; la recherche directe par nom long dans les APIs de lecture et l’Unicode complet restent le prochain incrément LFN. Validation noyau : **33/33 tests verts** et suite globale **417/417 tests verts**.
 
 Voir [aos1193_fat16_lfn.md](aos1193_fat16_lfn.md).
+
+### AOS-1209 à AOS-1224 — registre socket TCP statique
+Le registre caller-owned fournit quatre slots TCP avec ouverture, acceptation SYN-ACK, émission bornée, alimentation RX après validation TCP, lecture et fermeture. Aucun buffer dynamique ni couplage à la session LLM n’est introduit. Validation locale : **418/418 tests verts**. L’exposition par syscalls `socket/connect/send/recv/close`, l’émission NIC et l’écoute passive sont le prochain incrément.
+
+Voir [aos1209_tcp_socket_registry.md](aos1209_tcp_socket_registry.md).

--- a/kernel/net_socket.c
+++ b/kernel/net_socket.c
@@ -1,0 +1,90 @@
+#include "net_socket.h"
+
+static net_socket_slot_t sockets[NET_SOCKET_CAPACITY];
+
+static int valid_id(int socket_id) {
+    return socket_id >= 0 && (uint32_t)socket_id < NET_SOCKET_CAPACITY && sockets[socket_id].used;
+}
+
+int net_socket_open(uint16_t local_port, uint16_t remote_port, uint32_t local_sequence) {
+    uint32_t i;
+    for (i = 0U; i < NET_SOCKET_CAPACITY; i++) {
+        if (!sockets[i].used) {
+            sockets[i].used = 1U;
+            sockets[i].receive_length = 0U;
+            sockets[i].receive_offset = 0U;
+            if (net_tcp_connection_open(&sockets[i].connection, local_port, remote_port, local_sequence) != 0) {
+                sockets[i].used = 0U;
+                return NET_SOCKET_PROTOCOL;
+            }
+            return (int)i;
+        }
+    }
+    return NET_SOCKET_NO_SLOT;
+}
+
+int net_socket_close(int socket_id) {
+    if (!valid_id(socket_id)) return NET_SOCKET_NOT_OPEN;
+    sockets[socket_id].used = 0U;
+    return 0;
+}
+
+int net_socket_accept_syn_ack(int socket_id, const net_tcp_view_t* view) {
+    if (!valid_id(socket_id) || !view) return NET_SOCKET_BAD_ARGUMENT;
+    return net_tcp_connection_accept_syn_ack(&sockets[socket_id].connection, view) == 0 ? 0 : NET_SOCKET_PROTOCOL;
+}
+
+int net_socket_send(int socket_id, const uint8_t* payload, uint16_t length,
+                    uint8_t* segment, uint16_t capacity, uint16_t* out_length) {
+    int built;
+    if (!valid_id(socket_id) || !payload || !segment || !out_length) return NET_SOCKET_BAD_ARGUMENT;
+    if (sockets[socket_id].connection.state != NET_TCP_STATE_ESTABLISHED) return NET_SOCKET_NOT_CONNECTED;
+    if (length == 0U || length > NET_SOCKET_TX_CAPACITY) return NET_SOCKET_BUFFER_SMALL;
+    built = net_tcp_connection_build_data(&sockets[socket_id].connection, segment, capacity,
+                                          payload, length, 3U);
+    if (built < 0) return NET_SOCKET_PROTOCOL;
+    if (net_tcp_connection_commit_send(&sockets[socket_id].connection, length) != 0) return NET_SOCKET_PROTOCOL;
+    *out_length = (uint16_t)built;
+    return 0;
+}
+
+int net_socket_feed(int socket_id, const uint8_t* segment, uint16_t length) {
+    net_tcp_view_t view;
+    uint16_t accepted = 0U;
+    uint16_t available;
+    if (!valid_id(socket_id) || !segment) return NET_SOCKET_BAD_ARGUMENT;
+    if (net_tcp_parse(segment, length, &view) != 0) return NET_SOCKET_PROTOCOL;
+    if (net_tcp_connection_accept_data(&sockets[socket_id].connection, &view, &accepted) != 0) return NET_SOCKET_PROTOCOL;
+    available = (uint16_t)(NET_SOCKET_RX_CAPACITY - sockets[socket_id].receive_length);
+    if (accepted > available) return NET_SOCKET_BUFFER_SMALL;
+    for (uint16_t i = 0U; i < accepted; i++) sockets[socket_id].receive_buffer[sockets[socket_id].receive_length + i] = view.payload[i];
+    sockets[socket_id].receive_length = (uint16_t)(sockets[socket_id].receive_length + accepted);
+    return 0;
+}
+
+int net_socket_receive(int socket_id, uint8_t* buffer, uint16_t capacity, uint16_t* out_length) {
+    uint16_t available, amount;
+    if (!valid_id(socket_id) || !buffer || !out_length) return NET_SOCKET_BAD_ARGUMENT;
+    available = (uint16_t)(sockets[socket_id].receive_length - sockets[socket_id].receive_offset);
+    amount = available < capacity ? available : capacity;
+    for (uint16_t i = 0U; i < amount; i++) buffer[i] = sockets[socket_id].receive_buffer[sockets[socket_id].receive_offset + i];
+    sockets[socket_id].receive_offset = (uint16_t)(sockets[socket_id].receive_offset + amount);
+    if (sockets[socket_id].receive_offset == sockets[socket_id].receive_length) {
+        sockets[socket_id].receive_offset = 0U;
+        sockets[socket_id].receive_length = 0U;
+    }
+    *out_length = amount;
+    return 0;
+}
+
+int net_socket_get_state(int socket_id, uint8_t* out_state) {
+    if (!valid_id(socket_id)) return NET_SOCKET_NOT_OPEN;
+    if (!out_state) return NET_SOCKET_BAD_ARGUMENT;
+    *out_state = sockets[socket_id].connection.state;
+    return 0;
+}
+
+void net_socket_reset_all(void) {
+    uint32_t i;
+    for (i = 0U; i < NET_SOCKET_CAPACITY; i++) sockets[i].used = 0U;
+}

--- a/kernel/net_socket.h
+++ b/kernel/net_socket.h
@@ -1,0 +1,38 @@
+#ifndef AIOS_NET_SOCKET_H
+#define AIOS_NET_SOCKET_H
+
+#include <stdint.h>
+#include "net_tcp.h"
+
+#define NET_SOCKET_CAPACITY 4U
+#define NET_SOCKET_RX_CAPACITY 1024U
+#define NET_SOCKET_TX_CAPACITY 1500U
+
+#define NET_SOCKET_CLOSED 0
+#define NET_SOCKET_BAD_ARGUMENT -1
+#define NET_SOCKET_NO_SLOT -2
+#define NET_SOCKET_NOT_OPEN -3
+#define NET_SOCKET_NOT_CONNECTED -4
+#define NET_SOCKET_BUFFER_SMALL -5
+#define NET_SOCKET_PROTOCOL -6
+
+typedef struct {
+    uint8_t used;
+    net_tcp_connection_t connection;
+    uint8_t receive_buffer[NET_SOCKET_RX_CAPACITY];
+    uint16_t receive_length;
+    uint16_t receive_offset;
+} net_socket_slot_t;
+
+int net_socket_open(uint16_t local_port, uint16_t remote_port, uint32_t local_sequence);
+int net_socket_close(int socket_id);
+int net_socket_send(int socket_id, const uint8_t* payload, uint16_t length,
+                    uint8_t* segment, uint16_t capacity, uint16_t* out_length);
+int net_socket_feed(int socket_id, const uint8_t* segment, uint16_t length);
+int net_socket_receive(int socket_id, uint8_t* buffer, uint16_t capacity,
+                       uint16_t* out_length);
+int net_socket_accept_syn_ack(int socket_id, const net_tcp_view_t* view);
+int net_socket_get_state(int socket_id, uint8_t* out_state);
+void net_socket_reset_all(void);
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -160,6 +160,11 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_sha256: $(UNIT_DIR)/kernel/test_sha256.c ..
 	@echo "Compiled kernel test: $(notdir $@)"
 
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_socket: $(UNIT_DIR)/kernel/test_net_socket.c ../kernel/net_socket.c ../kernel/net_tcp.c ../kernel/net_tls_record.c ../kernel/sha256.c ../kernel/aes_gcm.c ../kernel/x509_der.c ../kernel/x25519.c ../kernel/rsa_verify.c ../kernel/bigint.c ../kernel/ecdsa_p256.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_socket.c ../kernel/net_tcp.c ../kernel/net_tls_record.c ../kernel/sha256.c ../kernel/aes_gcm.c ../kernel/x509_der.c ../kernel/x25519.c ../kernel/rsa_verify.c ../kernel/bigint.c ../kernel/ecdsa_p256.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_net_tcp: $(UNIT_DIR)/kernel/test_net_tcp.c ../kernel/net_http_tls.c ../kernel/net_tcp.c ../kernel/net_tls_record.c ../kernel/sha256.c ../kernel/aes_gcm.c ../kernel/x509_der.c ../kernel/rsa_verify.c ../kernel/bigint.c ../kernel/ecdsa_p256.c ../kernel/x25519.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/net_http_tls.c ../kernel/net_tcp.c ../kernel/net_tls_record.c ../kernel/sha256.c ../kernel/aes_gcm.c ../kernel/x509_der.c ../kernel/rsa_verify.c ../kernel/bigint.c ../kernel/ecdsa_p256.c ../kernel/x25519.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -160,7 +160,11 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_rtc.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/rtc.c"
     fi
-    if [ "$(basename "$test_file")" = "test_net_tcp.c" ] || [ "$(basename "$test_file")" = "test_net_http_tls.c" ]; then
+    if [ "$(basename "$test_file")" = "test_net_socket.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/net_socket.c"
+        extra_src="$extra_src $BASE_DIR/kernel/x25519.c"
+    fi
+    if [ "$(basename "$test_file")" = "test_net_socket.c" ] || [ "$(basename "$test_file")" = "test_net_tcp.c" ] || [ "$(basename "$test_file")" = "test_net_http_tls.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/net_tcp.c"
         extra_src="$extra_src $BASE_DIR/kernel/net_tls_record.c"
         extra_src="$extra_src $BASE_DIR/kernel/sha256.c"

--- a/tests/unit/kernel/test_net_socket.c
+++ b/tests/unit/kernel/test_net_socket.c
@@ -1,0 +1,47 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/net_socket.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_socket_lifecycle_send_receive(void) {
+    int id;
+    uint8_t segment[64] = {0};
+    uint8_t received[8] = {0};
+    uint8_t payload[4] = {'P', 'I', 'N', 'G'};
+    uint16_t segment_length = 0U, received_length = 0U;
+    uint8_t state = 0U;
+    net_tcp_view_t view;
+
+    net_socket_reset_all();
+    id = net_socket_open(49152U, 443U, 100U);
+    TEST_ASSERT_TRUE(id >= 0);
+    TEST_ASSERT_EQUAL(0, net_socket_get_state(id, &state));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_SYN_SENT, state);
+    view = (net_tcp_view_t){443U, 49152U, 700U, 101U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0};
+    TEST_ASSERT_EQUAL(0, net_socket_accept_syn_ack(id, &view));
+    TEST_ASSERT_EQUAL(0, net_socket_get_state(id, &state));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_ESTABLISHED, state);
+    TEST_ASSERT_EQUAL(0, net_socket_send(id, payload, sizeof(payload), segment, sizeof(segment), &segment_length));
+    TEST_ASSERT_EQUAL(24U, segment_length);
+    TEST_ASSERT_EQUAL(0, net_tcp_parse(segment, segment_length, &view));
+    TEST_ASSERT_EQUAL(4U, view.payload_length);
+    TEST_ASSERT_EQUAL('P', view.payload[0]);
+    TEST_ASSERT_EQUAL(24, net_tcp_build_data(segment, sizeof(segment), 443U, 49152U,
+                                              701U, 104U, payload, sizeof(payload)));
+    TEST_ASSERT_EQUAL(0, net_socket_feed(id, segment, 24U));
+    TEST_ASSERT_EQUAL(0, net_socket_receive(id, received, sizeof(received), &received_length));
+    TEST_ASSERT_EQUAL(4U, received_length);
+    TEST_ASSERT_EQUAL('P', received[0]);
+    TEST_ASSERT_EQUAL('G', received[3]);
+    TEST_ASSERT_EQUAL(0, net_socket_close(id));
+    TEST_ASSERT_EQUAL(NET_SOCKET_NOT_OPEN, net_socket_get_state(id, &state));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_socket_lifecycle_send_receive);
+    unity_print_results();
+    unity_cleanup();
+    return 0;
+}


### PR DESCRIPTION
# AOS-1209 à AOS-1224 — registre socket TCP statique

> **État :** implémenté et validé localement. **Suite globale : 418/418 tests verts.**

## Objectif

Ce macro-lot introduit un registre de quatre sockets TCP statiques, indépendant de la session LLM. Il fournit un cycle de vie minimal pour les connexions caller-owned : ouverture, acceptation d’un SYN-ACK, émission d’un segment de données, alimentation de la file de réception depuis un segment TCP validé, lecture bornée et fermeture.

Aucune allocation dynamique n’est utilisée. Chaque slot contient une `net_tcp_connection_t` et une file RX fixe de 1024 octets. Les segments d’émission restent fournis par l’appelant ; le registre ne possède donc pas de buffer réseau global à durée indéterminée.

## Contrat

```c
int net_socket_open(uint16_t local_port, uint16_t remote_port,
                    uint32_t local_sequence);
int net_socket_accept_syn_ack(int socket_id, const net_tcp_view_t* view);
int net_socket_send(int socket_id, const uint8_t* payload, uint16_t length,
                    uint8_t* segment, uint16_t capacity, uint16_t* out_length);
int net_socket_feed(int socket_id, const uint8_t* segment, uint16_t length);
int net_socket_receive(int socket_id, uint8_t* buffer, uint16_t capacity,
                       uint16_t* out_length);
int net_socket_close(int socket_id);
```

`net_socket_send` délègue la construction et la progression de séquence à `net_tcp_connection_build_data` et `net_tcp_connection_commit_send`. `net_socket_feed` parse le segment et ne copie le payload qu’après acceptation de la séquence et de l’ACK par la primitive TCP existante. La fermeture libère le slot sans toucher aux autres connexions.

| Aspect | Valeur |
|---|---:|
| Slots simultanés | 4 |
| File RX par slot | 1024 octets |
| Taille TX maximale | 1500 octets |
| Allocation dynamique | Aucune |
| État transport | `SYN_SENT`, `ESTABLISHED` et états TCP existants |
| Tests noyau | 34/34 |
| Suite globale | 418/418 |

## Limites explicites

Ce lot ne réalise pas encore l’envoi matériel via la NIC, la résolution DNS, l’écoute passive ni les syscalls utilisateurs `socket/connect/send/recv/close`. Le registre fournit la couche de descripteurs et de buffers nécessaire à cette exposition ultérieure, sans coupler l’API générique au client TLS/LLM.

Le prochain incrément doit ajouter des structures POD de syscall, une validation des pointeurs utilisateur conforme aux conventions existantes, puis relier les opérations au dispatch syscall. Les chemins TLS/HTTP continueront d’utiliser leur session spécialisée jusqu’à leur migration contrôlée.

**Auteur :** Manus AI
