### PR TITLE
feat(fs): add FAT32 replicated writes and chaining

### DIFF
--- a/docs/aos1257_fat32_write_chain.md
+++ b/docs/aos1257_fat32_write_chain.md
@@ -1,0 +1,20 @@
+# AOS-1257 à AOS-1272 — écriture et chaînage FAT32
+
+> **État :** implémenté et validé localement. **Suite globale : 419/419 tests verts.**
+
+Ce macro-lot étend le volume FAT32 avec un writer explicitement attaché par l’appelant. `fat32_write_fat_entry` réalise une lecture-modification-écriture de l’entrée quatre octets, conserve les quatre bits réservés de poids fort et réplique la nouvelle valeur 28 bits dans chaque copie FAT. `fat32_allocate_cluster` recherche une entrée libre et la marque EOC ; `fat32_link_clusters` remplace uniquement l’EOC d’un cluster source par un cluster cible déjà réservé.
+
+| Opération | Garantie |
+|---|---|
+| Attachement writer | explicite, aucun writer implicite au montage |
+| Entrée FAT | 4 octets, masque 28 bits, bits réservés préservés |
+| Réplication | toutes les FAT déclarées dans le BPB |
+| Allocation | première entrée libre, marquée `0x0ffffff8` |
+| Chaînage | source EOC et cible déjà allouée uniquement |
+| Allocation dynamique | aucune |
+| Tests noyau | 35/35 |
+| Suite globale | 419/419 |
+
+Les entrées de répertoire FAT32, l’écriture de données par cluster et le rollback multi-clusters restent distincts. Cette séparation permet de réutiliser le contrat writer sans publier une entrée de fichier avant la persistance complète de sa chaîne.
+
+**Auteur :** Manus AI

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -825,3 +825,8 @@ Voir [aos1225_socket_syscalls.md](aos1225_socket_syscalls.md).
 Le volume FAT32 valide le BPB, calcule la région de données, lit les entrées FAT 28 bits et restitue un cluster dans un buffer caller-owned. Aucun chemin FAT16 n’est modifié et aucune allocation dynamique n’est introduite. Validation locale : **419/419 tests verts**. La création/écriture FAT32, les entrées LFN FAT32 et les syscalls de montage restent les prochains incréments.
 
 Voir [aos1241_fat32_mount_read.md](aos1241_fat32_mount_read.md).
+
+### AOS-1257 à AOS-1272 — écriture et chaînage FAT32
+Le writer FAT32 caller-owned réalise une lecture-modification-écriture 28 bits, préserve les bits réservés et réplique chaque entrée dans toutes les FAT. L’allocation marque EOC et le chaînage exige une source EOC ainsi qu’une cible déjà allouée. Validation locale : **419/419 tests verts**. L’écriture de données, le rollback de chaîne et les entrées de répertoire FAT32 restent le prochain incrément.
+
+Voir [aos1257_fat32_write_chain.md](aos1257_fat32_write_chain.md).

--- a/kernel/fs/fat32.c
+++ b/kernel/fs/fat32.c
@@ -4,6 +4,7 @@ static uint8_t fat32_sector[512];
 
 static uint16_t le16(const uint8_t* p) { return (uint16_t)p[0] | ((uint16_t)p[1] << 8U); }
 static uint32_t le32(const uint8_t* p) { return (uint32_t)p[0] | ((uint32_t)p[1] << 8U) | ((uint32_t)p[2] << 16U) | ((uint32_t)p[3] << 24U); }
+static void put32(uint8_t* p, uint32_t v) { p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8U); p[2] = (uint8_t)(v >> 16U); p[3] = (uint8_t)(v >> 24U); }
 static int power_of_two(uint8_t value) { return value != 0U && (value & (uint8_t)(value - 1U)) == 0U; }
 
 int fat32_mount(fat32_volume_t* volume, fat16_read_sector_fn read_sector, uint32_t base_lba) {
@@ -13,6 +14,8 @@ int fat32_mount(fat32_volume_t* volume, fat16_read_sector_fn read_sector, uint32
     if (!volume || !read_sector) return OS_FAT16_CORRUPT;
     volume->mounted = 0U;
     volume->read_sector = read_sector;
+    volume->write_sector = 0;
+
     volume->base_lba = base_lba;
     if (read_sector(base_lba, fat32_sector) != 0) return OS_FAT16_CORRUPT;
     if (le16(fat32_sector + 11U) != 512U || !power_of_two(fat32_sector[13]) || fat32_sector[13] > 128U) return OS_FAT16_CORRUPT;
@@ -35,6 +38,45 @@ int fat32_mount(fat32_volume_t* volume, fat16_read_sector_fn read_sector, uint32
 }
 
 int fat32_is_mounted(const fat32_volume_t* volume) { return volume && volume->mounted && volume->read_sector; }
+
+int fat32_attach_writer(fat32_volume_t* volume, fat16_write_sector_fn write_sector) {
+    if (!volume || !fat32_is_mounted(volume) || !write_sector) return OS_FAT16_NOT_MOUNTED;
+    volume->write_sector = write_sector;
+    return 0;
+}
+
+int fat32_write_fat_entry(const fat32_volume_t* volume, uint32_t cluster, uint32_t next) {
+    uint32_t byte_offset, fat, lba, offset, current, updated;
+    if (!volume || !fat32_is_mounted(volume) || !volume->write_sector || cluster < 2U || cluster > volume->cluster_count + 1U || next > FAT32_MAX_CLUSTER) return OS_FAT16_CORRUPT;
+    byte_offset = cluster * 4U; offset = byte_offset & 511U;
+    if (offset > 508U) return OS_FAT16_CORRUPT;
+    for (fat = 0U; fat < volume->fat_count; fat++) {
+        lba = volume->fat_lba + fat * volume->fat_sectors + (byte_offset >> 9U);
+        if (volume->read_sector(lba, fat32_sector) != 0) return OS_FAT16_CORRUPT;
+        current = le32(fat32_sector + offset); updated = (current & 0xf0000000U) | next;
+        put32(fat32_sector + offset, updated);
+        if (volume->write_sector(lba, fat32_sector) != 0) return OS_FAT16_CORRUPT;
+    }
+    return 0;
+}
+
+int fat32_allocate_cluster(const fat32_volume_t* volume, uint32_t* out_cluster) {
+    uint32_t cluster, value;
+    if (!volume || !out_cluster || !fat32_is_mounted(volume) || !volume->write_sector) return OS_FAT16_NOT_MOUNTED;
+    for (cluster = 2U; cluster <= volume->cluster_count + 1U; cluster++) {
+        if (fat32_read_fat_entry(volume, cluster, &value) != 0) return OS_FAT16_CORRUPT;
+        if (value == 0U && fat32_write_fat_entry(volume, cluster, FAT32_EOC_MIN) == 0) { *out_cluster = cluster; return 0; }
+    }
+    return OS_FAT16_NOT_FOUND;
+}
+
+int fat32_link_clusters(const fat32_volume_t* volume, uint32_t source, uint32_t target) {
+    uint32_t source_value, target_value;
+    if (!volume || source < 2U || target < 2U || source == target) return OS_FAT16_CORRUPT;
+    if (fat32_read_fat_entry(volume, source, &source_value) != 0 || fat32_read_fat_entry(volume, target, &target_value) != 0) return OS_FAT16_CORRUPT;
+    if (source_value < FAT32_EOC_MIN || source_value == FAT32_BAD_CLUSTER || target_value == 0U || target_value == FAT32_BAD_CLUSTER) return OS_FAT16_CORRUPT;
+    return fat32_write_fat_entry(volume, source, target);
+}
 
 int fat32_cluster_lba(const fat32_volume_t* volume, uint32_t cluster, uint32_t* out_lba) {
     if (!fat32_is_mounted(volume) || !out_lba || cluster < 2U || cluster > volume->cluster_count + 1U) return OS_FAT16_CORRUPT;

--- a/kernel/fs/fat32.h
+++ b/kernel/fs/fat32.h
@@ -10,6 +10,7 @@
 
 typedef struct {
     fat16_read_sector_fn read_sector;
+    fat16_write_sector_fn write_sector;
     uint32_t base_lba;
     uint32_t total_sectors;
     uint32_t fat_lba;
@@ -25,6 +26,10 @@ typedef struct {
 
 int fat32_mount(fat32_volume_t* volume, fat16_read_sector_fn read_sector, uint32_t base_lba);
 int fat32_is_mounted(const fat32_volume_t* volume);
+int fat32_attach_writer(fat32_volume_t* volume, fat16_write_sector_fn write_sector);
+int fat32_write_fat_entry(const fat32_volume_t* volume, uint32_t cluster, uint32_t next);
+int fat32_allocate_cluster(const fat32_volume_t* volume, uint32_t* out_cluster);
+int fat32_link_clusters(const fat32_volume_t* volume, uint32_t source, uint32_t target);
 int fat32_read_fat_entry(const fat32_volume_t* volume, uint32_t cluster, uint32_t* out_next);
 int fat32_cluster_lba(const fat32_volume_t* volume, uint32_t cluster, uint32_t* out_lba);
 int fat32_read_cluster(const fat32_volume_t* volume, uint32_t cluster, uint8_t* buffer);

--- a/tests/unit/kernel/test_fat32.c
+++ b/tests/unit/kernel/test_fat32.c
@@ -7,6 +7,11 @@ static int read_sector(uint32_t lba, void* buffer) {
     for (uint32_t i = 0U; i < 512U; i++) ((uint8_t*)buffer)[i] = disk[lba * 512U + i];
     return 0;
 }
+static int write_sector(uint32_t lba, const void* buffer) {
+    if (lba >= 2048U || !buffer) return -1;
+    for (uint32_t i = 0U; i < 512U; i++) disk[lba * 512U + i] = ((const uint8_t*)buffer)[i];
+    return 0;
+}
 static void put16(uint8_t* p, uint16_t v) { p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8U); }
 static void put32(uint8_t* p, uint32_t v) { p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8U); p[2] = (uint8_t)(v >> 16U); p[3] = (uint8_t)(v >> 24U); }
 void setUp(void) { for (uint32_t i = 0U; i < sizeof(disk); i++) disk[i] = 0U; }
@@ -21,6 +26,11 @@ void test_fat32_mount_and_read_cluster(void) {
     TEST_ASSERT_EQUAL(0, fat32_cluster_lba(&volume, 2U, &lba)); TEST_ASSERT_EQUAL(2032U, lba);
     disk[32U * 512U + 8U] = 0xf8U; disk[32U * 512U + 9U] = 0xffU; disk[32U * 512U + 10U] = 0xffU; disk[32U * 512U + 11U] = 0x0fU;
     TEST_ASSERT_EQUAL(0, fat32_read_fat_entry(&volume, 2U, &next)); TEST_ASSERT_EQUAL(FAT32_EOC_MIN, next);
+    TEST_ASSERT_EQUAL(0, fat32_attach_writer(&volume, write_sector));
+    TEST_ASSERT_EQUAL(0, fat32_allocate_cluster(&volume, &next)); TEST_ASSERT_EQUAL(3U, next);
+    TEST_ASSERT_EQUAL(0, fat32_read_fat_entry(&volume, 3U, &next)); TEST_ASSERT_EQUAL(FAT32_EOC_MIN, next);
+    TEST_ASSERT_EQUAL(0, fat32_link_clusters(&volume, 2U, 3U));
+    TEST_ASSERT_EQUAL(0, fat32_read_fat_entry(&volume, 2U, &next)); TEST_ASSERT_EQUAL(3U, next);
 }
 
 int main(void) { unity_init(); RUN_TEST(test_fat32_mount_and_read_cluster); unity_print_results(); unity_cleanup(); return 0; }


### PR DESCRIPTION
# AOS-1257 à AOS-1272 — écriture et chaînage FAT32

> **État :** implémenté et validé localement. **Suite globale : 419/419 tests verts.**

Ce macro-lot étend le volume FAT32 avec un writer explicitement attaché par l’appelant. `fat32_write_fat_entry` réalise une lecture-modification-écriture de l’entrée quatre octets, conserve les quatre bits réservés de poids fort et réplique la nouvelle valeur 28 bits dans chaque copie FAT. `fat32_allocate_cluster` recherche une entrée libre et la marque EOC ; `fat32_link_clusters` remplace uniquement l’EOC d’un cluster source par un cluster cible déjà réservé.

| Opération | Garantie |
|---|---|
| Attachement writer | explicite, aucun writer implicite au montage |
| Entrée FAT | 4 octets, masque 28 bits, bits réservés préservés |
| Réplication | toutes les FAT déclarées dans le BPB |
| Allocation | première entrée libre, marquée `0x0ffffff8` |
| Chaînage | source EOC et cible déjà allouée uniquement |
| Allocation dynamique | aucune |
| Tests noyau | 35/35 |
| Suite globale | 419/419 |

Les entrées de répertoire FAT32, l’écriture de données par cluster et le rollback multi-clusters restent distincts. Cette séparation permet de réutiliser le contrat writer sans publier une entrée de fichier avant la persistance complète de sa chaîne.

**Auteur :** Manus AI
