### PR TITLE
feat(fs): write FAT32 clusters and root entries

### DIFF
--- a/docs/aos1273_fat32_data_root.md
+++ b/docs/aos1273_fat32_data_root.md
@@ -1,0 +1,21 @@
+# AOS-1273 à AOS-1288 — données et entrée racine FAT32
+
+> **État :** implémenté et validé localement. **Suite globale : 419/419 tests verts.**
+
+Ce macro-lot ajoute l’écriture complète d’un cluster FAT32 dans un buffer caller-owned et la publication d’une entrée racine 8.3. Le nom est validé sans chemin ni caractères interdits, puis normalisé en majuscules dans les onze octets 8.3. L’entrée stocke l’attribut, le cluster initial sur 28 bits réparti entre les champs haut et bas et la taille little-endian sur 32 bits.
+
+La recherche parcourt la chaîne du répertoire racine FAT32, secteur par secteur, et réutilise le premier slot libre ou supprimé. Si la chaîne se termine sans slot disponible, aucune allocation implicite n’est réalisée : l’appelant devra allouer et chaîner un nouveau cluster de répertoire dans un incrément ultérieur. L’écriture du cluster de données est séparée de la publication, ce qui permet de persister les données avant d’exposer l’entrée.
+
+| Élément | Contrat |
+|---|---|
+| Données | `fat32_write_cluster`, buffer de `sectors_per_cluster * 512` octets |
+| Nom | 8.3 ASCII borné, alias explicite, pas de LFN |
+| Racine | chaîne FAT32 à partir de `root_cluster` |
+| Entrée | attribut, cluster haut/bas, taille 32 bits |
+| Allocation dynamique | aucune |
+| Tests noyau | 35/35 |
+| Suite globale | 419/419 |
+
+Les entrées LFN FAT32, l’extension automatique de la chaîne de répertoire et l’orchestrateur fichier avec rollback multi-clusters restent à traiter. Le lot est volontairement borné pour conserver une publication persistante après écriture réussie des données.
+
+**Auteur :** Manus AI

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -830,3 +830,8 @@ Voir [aos1241_fat32_mount_read.md](aos1241_fat32_mount_read.md).
 Le writer FAT32 caller-owned réalise une lecture-modification-écriture 28 bits, préserve les bits réservés et réplique chaque entrée dans toutes les FAT. L’allocation marque EOC et le chaînage exige une source EOC ainsi qu’une cible déjà allouée. Validation locale : **419/419 tests verts**. L’écriture de données, le rollback de chaîne et les entrées de répertoire FAT32 restent le prochain incrément.
 
 Voir [aos1257_fat32_write_chain.md](aos1257_fat32_write_chain.md).
+
+### AOS-1273 à AOS-1288 — données et entrée racine FAT32
+Le système écrit un cluster FAT32 caller-owned et publie une entrée racine 8.3 après validation du nom, de l’attribut, du cluster initial et de la taille. La recherche parcourt la chaîne racine sans allocation implicite. Validation locale : **419/419 tests verts**. LFN FAT32, extension automatique du répertoire et orchestration avec rollback multi-clusters restent les prochains incréments.
+
+Voir [aos1273_fat32_data_root.md](aos1273_fat32_data_root.md).

--- a/kernel/fs/fat32.c
+++ b/kernel/fs/fat32.c
@@ -100,3 +100,54 @@ int fat32_read_cluster(const fat32_volume_t* volume, uint32_t cluster, uint8_t* 
     for (i = 0U; i < volume->sectors_per_cluster; i++) if (volume->read_sector(lba + i, buffer + i * 512U) != 0) return OS_FAT16_CORRUPT;
     return 0;
 }
+
+int fat32_write_cluster(const fat32_volume_t* volume, uint32_t cluster, const uint8_t* buffer) {
+    uint32_t lba, i;
+    if (!volume || !buffer || !volume->write_sector || fat32_cluster_lba(volume, cluster, &lba) != 0) return OS_FAT16_NOT_MOUNTED;
+    for (i = 0U; i < volume->sectors_per_cluster; i++) if (volume->write_sector(lba + i, buffer + i * 512U) != 0) return OS_FAT16_CORRUPT;
+    return 0;
+}
+
+static int fat32_short_name(const char* input, uint8_t out[11]) {
+    uint32_t i = 0U, base = 0U, ext = 0U, dot = 0U;
+    if (!input || !input[0]) return OS_FAT16_BAD_PATH;
+    for (i = 0U; input[i]; i++) {
+        char c = input[i];
+        if (c == '/') return OS_FAT16_BAD_PATH;
+        if (c == '.') { if (dot || base == 0U) return OS_FAT16_BAD_PATH; dot = 1U; continue; }
+        if (c <= ' ' || c == '"' || c == '*' || c == '+' || c == ',' || c == ':' || c == ';' || c == '<' || c == '=' || c == '>' || c == '?' || c == '[' || c == '\\' || c == ']' || c == '|') return OS_FAT16_BAD_PATH;
+        if (!dot) { if (base >= 8U) return OS_FAT16_BAD_PATH; out[base++] = (uint8_t)(c >= 'a' && c <= 'z' ? c - 32 : c); }
+        else { if (ext >= 3U) return OS_FAT16_BAD_PATH; out[8U + ext++] = (uint8_t)(c >= 'a' && c <= 'z' ? c - 32 : c); }
+    }
+    if (base == 0U) return OS_FAT16_BAD_PATH;
+    while (base < 8U) out[base++] = ' ';
+    while (ext < 3U) out[8U + ext++] = ' ';
+    return 0;
+}
+
+int fat32_create_root_entry(const fat32_volume_t* volume, const char* name, uint8_t attributes, uint32_t first_cluster, uint32_t size) {
+    uint8_t short_name[11]; uint32_t cluster, next, lba, sector_index, entry_index, i;
+    if (!volume || !fat32_is_mounted(volume) || !volume->write_sector) return OS_FAT16_NOT_MOUNTED;
+    if (first_cluster < 2U || first_cluster > volume->cluster_count + 1U) return OS_FAT16_CORRUPT;
+    if (fat32_short_name(name, short_name) != 0) return OS_FAT16_BAD_PATH;
+    cluster = volume->root_cluster;
+    for (i = 0U; i <= volume->cluster_count; i++) {
+        if (fat32_cluster_lba(volume, cluster, &lba) != 0) return OS_FAT16_CORRUPT;
+        for (sector_index = 0U; sector_index < volume->sectors_per_cluster; sector_index++) {
+            if (volume->read_sector(lba + sector_index, fat32_sector) != 0) return OS_FAT16_CORRUPT;
+            for (entry_index = 0U; entry_index < 16U; entry_index++) {
+                uint8_t* entry = fat32_sector + entry_index * 32U;
+                if (entry[0] != 0U && entry[0] != 0xe5U) continue;
+                for (uint32_t j = 0U; j < 32U; j++) entry[j] = 0U;
+                for (uint32_t j = 0U; j < 11U; j++) entry[j] = short_name[j];
+                entry[11] = attributes; entry[20] = (uint8_t)(first_cluster >> 24U); entry[21] = (uint8_t)(first_cluster >> 16U);
+                entry[26] = (uint8_t)first_cluster; entry[27] = (uint8_t)(first_cluster >> 8U);
+                entry[28] = (uint8_t)size; entry[29] = (uint8_t)(size >> 8U); entry[30] = (uint8_t)(size >> 16U); entry[31] = (uint8_t)(size >> 24U);
+                return volume->write_sector(lba + sector_index, fat32_sector) == 0 ? 0 : OS_FAT16_CORRUPT;
+            }
+        }
+        if (fat32_read_fat_entry(volume, cluster, &next) != 0 || next >= FAT32_EOC_MIN) return OS_FAT16_NOT_FOUND;
+        cluster = next;
+    }
+    return OS_FAT16_NOT_FOUND;
+}

--- a/kernel/fs/fat32.h
+++ b/kernel/fs/fat32.h
@@ -33,5 +33,7 @@ int fat32_link_clusters(const fat32_volume_t* volume, uint32_t source, uint32_t 
 int fat32_read_fat_entry(const fat32_volume_t* volume, uint32_t cluster, uint32_t* out_next);
 int fat32_cluster_lba(const fat32_volume_t* volume, uint32_t cluster, uint32_t* out_lba);
 int fat32_read_cluster(const fat32_volume_t* volume, uint32_t cluster, uint8_t* buffer);
+int fat32_write_cluster(const fat32_volume_t* volume, uint32_t cluster, const uint8_t* buffer);
+int fat32_create_root_entry(const fat32_volume_t* volume, const char* name, uint8_t attributes, uint32_t first_cluster, uint32_t size);
 
 #endif

--- a/tests/unit/kernel/test_fat32.c
+++ b/tests/unit/kernel/test_fat32.c
@@ -31,6 +31,13 @@ void test_fat32_mount_and_read_cluster(void) {
     TEST_ASSERT_EQUAL(0, fat32_read_fat_entry(&volume, 3U, &next)); TEST_ASSERT_EQUAL(FAT32_EOC_MIN, next);
     TEST_ASSERT_EQUAL(0, fat32_link_clusters(&volume, 2U, 3U));
     TEST_ASSERT_EQUAL(0, fat32_read_fat_entry(&volume, 2U, &next)); TEST_ASSERT_EQUAL(3U, next);
+    { uint8_t data[1024U]; for (uint32_t i = 0U; i < sizeof(data); i++) data[i] = (uint8_t)(i & 0xffU);
+      TEST_ASSERT_EQUAL(0, fat32_write_cluster(&volume, 3U, data));
+      TEST_ASSERT_EQUAL(0, fat32_create_root_entry(&volume, "SESSION.BIN", 0x20U, 3U, 1024U));
+      TEST_ASSERT_EQUAL('S', disk[2032U * 512U]); TEST_ASSERT_EQUAL('E', disk[2032U * 512U + 1U]);
+      TEST_ASSERT_EQUAL('B', disk[2032U * 512U + 8U]); TEST_ASSERT_EQUAL('N', disk[2032U * 512U + 10U]);
+      TEST_ASSERT_EQUAL(0x20U, disk[2032U * 512U + 11U]); TEST_ASSERT_EQUAL(0x00U, disk[2032U * 512U + 20U]);
+      TEST_ASSERT_EQUAL(3U, disk[2032U * 512U + 26U]); TEST_ASSERT_EQUAL(0U, disk[2032U * 512U + 28U]); TEST_ASSERT_EQUAL(4U, disk[2032U * 512U + 29U]); }
 }
 
 int main(void) { unity_init(); RUN_TEST(test_fat32_mount_and_read_cluster); unity_print_results(); unity_cleanup(); return 0; }


### PR DESCRIPTION
# AOS-1273 à AOS-1288 — données et entrée racine FAT32

> **État :** implémenté et validé localement. **Suite globale : 419/419 tests verts.**

Ce macro-lot ajoute l’écriture complète d’un cluster FAT32 dans un buffer caller-owned et la publication d’une entrée racine 8.3. Le nom est validé sans chemin ni caractères interdits, puis normalisé en majuscules dans les onze octets 8.3. L’entrée stocke l’attribut, le cluster initial sur 28 bits réparti entre les champs haut et bas et la taille little-endian sur 32 bits.

La recherche parcourt la chaîne du répertoire racine FAT32, secteur par secteur, et réutilise le premier slot libre ou supprimé. Si la chaîne se termine sans slot disponible, aucune allocation implicite n’est réalisée : l’appelant devra allouer et chaîner un nouveau cluster de répertoire dans un incrément ultérieur. L’écriture du cluster de données est séparée de la publication, ce qui permet de persister les données avant d’exposer l’entrée.

| Élément | Contrat |
|---|---|
| Données | `fat32_write_cluster`, buffer de `sectors_per_cluster * 512` octets |
| Nom | 8.3 ASCII borné, alias explicite, pas de LFN |
| Racine | chaîne FAT32 à partir de `root_cluster` |
| Entrée | attribut, cluster haut/bas, taille 32 bits |
| Allocation dynamique | aucune |
| Tests noyau | 35/35 |
| Suite globale | 419/419 |

Les entrées LFN FAT32, l’extension automatique de la chaîne de répertoire et l’orchestrateur fichier avec rollback multi-clusters restent à traiter. Le lot est volontairement borné pour conserver une publication persistante après écriture réussie des données.

**Auteur :** Manus AI
