### PR TITLE
feat(fs): extend FAT32 root directory

### DIFF
--- a/docs/aos1305_fat32_root_extension.md
+++ b/docs/aos1305_fat32_root_extension.md
@@ -1,0 +1,21 @@
+# AOS-1305 à AOS-1320 — extension automatique du répertoire racine FAT32
+
+> **État :** implémenté et validé localement. **Suite globale : 420/420 tests verts.**
+
+`fat32_extend_root_directory` parcourt la chaîne du répertoire racine jusqu’à son dernier cluster EOC, réserve un nouveau cluster, l’efface dans le buffer statique borné, l’écrit dans la région de données puis remplace l’EOC du dernier cluster par le nouveau lien. En cas d’échec d’écriture ou de chaînage, l’entrée du cluster nouvellement réservé est libérée.
+
+L’API restitue le nouveau cluster à l’appelant et ne publie aucune entrée LFN. La création 8.3 peut utiliser cette primitive lorsque la recherche de slot libre arrive en fin de chaîne ; l’intégration automatique dans `fat32_create_root_entry` est conservée comme étape suivante afin de garder le comportement d’échec actuel explicitement observable.
+
+| Propriété | Garantie |
+|---|---|
+| Chaîne analysée | racine FAT32 et liens validés avec garde bornée |
+| Nouveau cluster | réservé EOC puis nettoyé avant usage |
+| Persistance | écriture des secteurs caller-owned via writer explicite |
+| Échec | nouveau cluster libéré, chaîne précédente intacte |
+| LFN | non inclus dans ce sous-lot |
+| Tests noyau | 36/36 |
+| Suite globale | 420/420 |
+
+Le prochain sous-lot peut intégrer cette extension dans la publication d’entrées LFN FAT32 et ajouter la génération checksum/UTF-16LE, sans modifier l’ABI publique existante.
+
+**Auteur :** Manus AI

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -840,3 +840,8 @@ Voir [aos1273_fat32_data_root.md](aos1273_fat32_data_root.md).
 `fat32_create_file` réserve, écrit et chaîne une ou plusieurs unités FAT32, puis publie l’entrée racine 8.3. Toute erreur libère la chaîne partielle dans toutes les FAT ; le buffer de données reste caller-owned. Validation locale : **419/419 tests verts**. L’extension automatique du répertoire et les LFN FAT32 restent les prochains incréments.
 
 Voir [aos1289_fat32_create_file.md](aos1289_fat32_create_file.md).
+
+### AOS-1305 à AOS-1320 — extension automatique du répertoire racine FAT32
+Le répertoire racine FAT32 peut être étendu de façon caller-owned : le dernier cluster EOC est trouvé, un cluster est réservé et nettoyé, puis le lien est persisté dans toutes les FAT. En cas d’erreur, le cluster nouveau est libéré. Validation locale : **420/420 tests verts**. L’intégration à la publication LFN et l’UTF-16LE restent le prochain incrément.
+
+Voir [aos1305_fat32_root_extension.md](aos1305_fat32_root_extension.md).

--- a/kernel/fs/fat32.c
+++ b/kernel/fs/fat32.c
@@ -186,3 +186,23 @@ int fat32_create_file(const fat32_volume_t* volume, const char* name, uint8_t at
     *out_first_cluster = first;
     return 0;
 }
+
+int fat32_extend_root_directory(const fat32_volume_t* volume, uint32_t* out_cluster) {
+    uint32_t last, next, allocated, guard = 0U;
+    if (!volume || !out_cluster || !fat32_is_mounted(volume) || !volume->write_sector) return OS_FAT16_NOT_MOUNTED;
+    last = volume->root_cluster;
+    while (guard++ <= volume->cluster_count) {
+        if (fat32_read_fat_entry(volume, last, &next) != 0) return OS_FAT16_CORRUPT;
+        if (next >= FAT32_EOC_MIN) break;
+        if (next < 2U || next > volume->cluster_count + 1U || next == FAT32_BAD_CLUSTER) return OS_FAT16_CORRUPT;
+        last = next;
+    }
+    if (fat32_allocate_cluster(volume, &allocated) != 0) return OS_FAT16_NOT_FOUND;
+    for (uint32_t i = 0U; i < (uint32_t)volume->sectors_per_cluster * 512U; i++) fat32_file_cluster[i] = 0U;
+    if (fat32_write_cluster(volume, allocated, fat32_file_cluster) != 0 || fat32_link_clusters(volume, last, allocated) != 0) {
+        (void)fat32_write_fat_entry(volume, allocated, 0U);
+        return OS_FAT16_CORRUPT;
+    }
+    *out_cluster = allocated;
+    return 0;
+}

--- a/kernel/fs/fat32.h
+++ b/kernel/fs/fat32.h
@@ -35,6 +35,7 @@ int fat32_cluster_lba(const fat32_volume_t* volume, uint32_t cluster, uint32_t* 
 int fat32_read_cluster(const fat32_volume_t* volume, uint32_t cluster, uint8_t* buffer);
 int fat32_write_cluster(const fat32_volume_t* volume, uint32_t cluster, const uint8_t* buffer);
 int fat32_create_root_entry(const fat32_volume_t* volume, const char* name, uint8_t attributes, uint32_t first_cluster, uint32_t size);
+int fat32_extend_root_directory(const fat32_volume_t* volume, uint32_t* out_cluster);
 int fat32_create_file(const fat32_volume_t* volume, const char* name, uint8_t attributes, const uint8_t* data, uint32_t size, uint32_t* out_first_cluster);
 
 #endif

--- a/tests/unit/kernel/test_fat32.c
+++ b/tests/unit/kernel/test_fat32.c
@@ -45,4 +45,16 @@ void test_fat32_mount_and_read_cluster(void) {
     }
 }
 
-int main(void) { unity_init(); RUN_TEST(test_fat32_mount_and_read_cluster); unity_print_results(); unity_cleanup(); return 0; }
+void test_fat32_extend_full_root(void) {
+    fat32_volume_t volume; uint32_t next;
+    for (uint32_t i = 0U; i < sizeof(disk); i++) disk[i] = 0U;
+    disk[13] = 2U; put16(disk + 11U, 512U); put16(disk + 14U, 32U); disk[16] = 2U;
+    put32(disk + 32U, 200000U); put32(disk + 36U, 1000U); put32(disk + 44U, 2U); put16(disk + 510U, 0xaa55U);
+    for (uint32_t i = 0U; i < 1024U; i++) disk[2032U * 512U + i] = 0x41U;
+    disk[32U * 512U + 8U] = 0xf8U; disk[32U * 512U + 9U] = 0xffU; disk[32U * 512U + 10U] = 0xffU; disk[32U * 512U + 11U] = 0x0fU;
+    TEST_ASSERT_EQUAL(0, fat32_mount(&volume, read_sector, 0U)); TEST_ASSERT_EQUAL(0, fat32_attach_writer(&volume, write_sector));
+    TEST_ASSERT_EQUAL(0, fat32_extend_root_directory(&volume, &next)); TEST_ASSERT_EQUAL(3U, next);
+    TEST_ASSERT_EQUAL(3U, disk[32U * 512U + 8U]); TEST_ASSERT_EQUAL(0U, disk[2034U * 512U]);
+}
+
+int main(void) { unity_init(); RUN_TEST(test_fat32_mount_and_read_cluster); RUN_TEST(test_fat32_extend_full_root); unity_print_results(); unity_cleanup(); return 0; }


### PR DESCRIPTION
# AOS-1305 à AOS-1320 — extension automatique du répertoire racine FAT32

> **État :** implémenté et validé localement. **Suite globale : 420/420 tests verts.**

`fat32_extend_root_directory` parcourt la chaîne du répertoire racine jusqu’à son dernier cluster EOC, réserve un nouveau cluster, l’efface dans le buffer statique borné, l’écrit dans la région de données puis remplace l’EOC du dernier cluster par le nouveau lien. En cas d’échec d’écriture ou de chaînage, l’entrée du cluster nouvellement réservé est libérée.

L’API restitue le nouveau cluster à l’appelant et ne publie aucune entrée LFN. La création 8.3 peut utiliser cette primitive lorsque la recherche de slot libre arrive en fin de chaîne ; l’intégration automatique dans `fat32_create_root_entry` est conservée comme étape suivante afin de garder le comportement d’échec actuel explicitement observable.

| Propriété | Garantie |
|---|---|
| Chaîne analysée | racine FAT32 et liens validés avec garde bornée |
| Nouveau cluster | réservé EOC puis nettoyé avant usage |
| Persistance | écriture des secteurs caller-owned via writer explicite |
| Échec | nouveau cluster libéré, chaîne précédente intacte |
| LFN | non inclus dans ce sous-lot |
| Tests noyau | 36/36 |
| Suite globale | 420/420 |

Le prochain sous-lot peut intégrer cette extension dans la publication d’entrées LFN FAT32 et ajouter la génération checksum/UTF-16LE, sans modifier l’ABI publique existante.

**Auteur :** Manus AI
