### PR TITLE
feat: add passive TCP listen foundation

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -12,8 +12,8 @@
 |---|---|
 | FAT16/FAT32 | FAT16 dispose des primitives d’écriture 8.3 et LFN ; FAT32 valide le BPB, lit et écrit les FAT 28 bits répliquées, alloue et chaîne les clusters, crée des fichiers avec rollback, étend la chaîne racine et encode une entrée LFN ASCII UTF-16LE bornée. |
 | LFN FAT32 | Le checksum 8.3, la publication multi-entrée et la reconstruction au listage sont livrés ; l’intégration VFS complète, Unicode hors ASCII et suppression/renommage restent à réaliser. |
-| Réseau utilisateur | Le registre TCP statique et six syscalls socket sont présents ; les requêtes et buffers socket sont maintenant validés page-par-page dans l’espace utilisateur VMM. L’écoute passive complète et le raccordement LLM HTTP/TLS restent à intégrer. |
-| Validation | Le runner FAT32 passe **4/4** tests ; la suite complète exécute **422 tests** avec succès après l’ajout du scénario LFN multi-entrée. La CI de la PR #379 a validé compilation, tests et smoke QEMU ; la validation socket est également couverte par la suite globale. |
+| Réseau utilisateur | Le registre TCP statique et six syscalls socket sont présents ; les requêtes et buffers socket sont validés page-par-page dans l’espace utilisateur VMM. La fondation TCP `LISTEN → SYN_RECEIVED → ESTABLISHED` est livrée ; son raccordement au registre socket, à la NIC et aux syscalls reste à intégrer. |
+| Validation | Le runner noyau passe **35/35** tests avec la fondation passive TCP ; la suite complète précédente était à **422/422** avant ce lot. La validation globale et le smoke QEMU seront relancés avant la fusion de la PR passive. |
 | Mémoire | Les lots concernés n’introduisent aucune allocation dynamique ; les buffers restent statiques ou caller-owned. |
 
 AI-OS démarre sans OS préinstallé dans QEMU, charge une archive initrd TAR, lance un shell ELF en Ring 3 et peut exécuter localement GPT-2 124M si les deux actifs binaires sont intégrés à l’image. Il demeure un **prototype de noyau**, non un système d’exploitation généraliste.

--- a/docs/aos1333_1344_tcp_passive_foundation.md
+++ b/docs/aos1333_1344_tcp_passive_foundation.md
@@ -1,0 +1,40 @@
+# AOS-1333 à AOS-1344 — fondation TCP d’écoute passive
+
+## Objectif
+
+Ce macro-lot ajoute la fondation déterministe de l’écoute TCP passive sans allocation dynamique. Une connexion caller-owned peut être placée dans l’état `LISTEN`, accepter un SYN entrant correspondant à son port local, produire un segment SYN-ACK, puis passer à `ESTABLISHED` après l’ACK final.
+
+## Contrat livré
+
+| Primitive | Contrat |
+|---|---|
+| `net_tcp_connection_listen` | Initialise une connexion avec port local, séquence initiale caller-owned et état `LISTEN`. |
+| `net_tcp_connection_accept_syn` | Accepte uniquement un SYN entrant sans ACK, mémorise le quadruplet distant et passe à `SYN_RECEIVED`. |
+| `net_tcp_connection_build_syn_ack` | Construit un segment SYN-ACK de 20 octets minimum avec les séquences validées. |
+| `net_tcp_connection_accept_ack` | Accepte l’ACK final exact et passe de `SYN_RECEIVED` à `ESTABLISHED`. |
+
+Les états `LISTEN` et `SYN_RECEIVED` sont ajoutés sans modifier la représentation existante de `net_tcp_connection_t`. Les contrôles rejettent les ports nuls, les ports de destination incohérents, les drapeaux SYN+ACK reçus au premier stade et les séquences ou acquittements incorrects.
+
+## Limites
+
+Ce lot ne publie pas encore de syscall `listen`/`accept`, ne réserve pas automatiquement un slot dans le registre `net_socket`, ne scrute pas la NIC NE2000 et n’émet pas encore le SYN-ACK sur le réseau. Le raccordement registre/socket/NIC constituera le prochain lot ; les buffers et l’état restent caller-owned.
+
+## Validation
+
+Le runner noyau passe **35/35 tests**. Les nouveaux tests vérifient la séquence `LISTEN → SYN_RECEIVED → ESTABLISHED`, le décodage du SYN-ACK généré et le rejet d’un SYN accompagné à tort d’un ACK. La suite complète doit être relancée avant la PR afin de confirmer l’absence de régression globale.
+
+## Mémoire
+
+Aucune allocation dynamique n’est introduite. Les buffers de segment sont fournis par l’appelant et les transitions modifient uniquement la structure de connexion passée en argument.
+
+## Auteur
+
+Manus AI
+
+## Références
+
+Aucune source externe n’est nécessaire : ce document décrit les contrats et tests présents dans le dépôt AI-OS.
+
+[1]: ../kernel/net_tcp.h
+[2]: ../kernel/net_tcp.c
+[3]: ../tests/unit/kernel/test_net_tcp.c

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -851,3 +851,8 @@ Voir [aos1305_fat32_root_extension.md](aos1305_fat32_root_extension.md).
 `fat32_lfn_checksum` calcule le checksum de l’alias 8.3 et `fat32_encode_lfn_entry` encode une entrée LFN de 32 octets en UTF-16LE ASCII borné, sans allocation dynamique. `fat32_create_lfn_file` publie désormais une séquence multi-entrée dans la chaîne racine, et `fat32_list_root` reconstruit le nom après validation des ordinals et du checksum dans un buffer caller-owned. Le contrat accepte au plus 13 caractères par entrée et 20 entrées par fichier, refuse les caractères non ASCII et conserve l’alias 8.3 en repli si la séquence est invalide. Validation actuelle : **4/4 tests FAT32** et **422 tests exécutés avec succès** ; l’intégration complète au VFS, Unicode hors ASCII et suppression/renommage LFN restent à réaliser.
 
 Voir [aos1321_fat32_lfn.md](aos1321_fat32_lfn.md).
+
+### AOS-1333 à AOS-1344 — fondation TCP d’écoute passive
+`net_tcp_connection_listen`, `net_tcp_connection_accept_syn`, `net_tcp_connection_build_syn_ack` et l’extension de `net_tcp_connection_accept_ack` livrent les transitions bornées `LISTEN → SYN_RECEIVED → ESTABLISHED` sans allocation dynamique. Les ports, drapeaux, séquences et acquittements sont validés. Validation locale : **35/35 tests noyau**. Le raccordement au registre `net_socket`, aux syscalls, à la réception/émission NE2000 et à l’écoute réseau complète reste le prochain incrément.
+
+Voir [aos1333_1344_tcp_passive_foundation.md](aos1333_1344_tcp_passive_foundation.md).

--- a/kernel/net_tcp.c
+++ b/kernel/net_tcp.c
@@ -22,6 +22,12 @@ int net_tcp_build_syn(uint8_t* segment, uint32_t capacity, uint16_t source_port,
     return build_control(segment, capacity, source_port, destination_port, sequence, 0U, NET_TCP_FLAG_SYN);
 }
 
+int net_tcp_build_syn_ack(uint8_t* segment, uint32_t capacity, uint16_t source_port,
+                          uint16_t destination_port, uint32_t sequence, uint32_t acknowledgment) {
+    return build_control(segment, capacity, source_port, destination_port, sequence,
+                         acknowledgment, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK);
+}
+
 int net_tcp_build_ack(uint8_t* segment, uint32_t capacity, uint16_t source_port,
                       uint16_t destination_port, uint32_t sequence, uint32_t acknowledgment) {
     return build_control(segment, capacity, source_port, destination_port, sequence, acknowledgment, NET_TCP_FLAG_ACK);
@@ -86,6 +92,33 @@ int net_tcp_connection_open(net_tcp_connection_t* connection,uint16_t local_port
     connection->pending_payload=0; connection->pending_length=0U; connection->retransmit_count=0U;
     connection->retransmit_limit=0U; connection->receive_window=0xffffU;
     connection->state=NET_TCP_STATE_SYN_SENT; return 0;
+}
+
+int net_tcp_connection_listen(net_tcp_connection_t* connection, uint16_t local_port,
+                              uint32_t local_sequence) {
+    if (!connection || local_port == 0U) return -1;
+    connection->local_port = local_port; connection->remote_port = 0U;
+    connection->local_sequence = local_sequence; connection->remote_sequence = 0U;
+    connection->pending_payload = 0; connection->pending_length = 0U;
+    connection->retransmit_count = 0U; connection->retransmit_limit = 0U;
+    connection->receive_window = 0xffffU; connection->state = NET_TCP_STATE_LISTEN;
+    return 0;
+}
+
+int net_tcp_connection_accept_syn(net_tcp_connection_t* connection, const net_tcp_view_t* view) {
+    if (!connection || !view || connection->state != NET_TCP_STATE_LISTEN ||
+        view->source_port == 0U || view->destination_port != connection->local_port ||
+        (view->flags & NET_TCP_FLAG_SYN) == 0U || (view->flags & NET_TCP_FLAG_ACK) != 0U) return -1;
+    connection->remote_port = view->source_port; connection->remote_sequence = view->sequence + 1U;
+    connection->state = NET_TCP_STATE_SYN_RECEIVED; return 0;
+}
+
+int net_tcp_connection_build_syn_ack(const net_tcp_connection_t* connection,
+                                     uint8_t* segment, uint32_t capacity) {
+    if (!connection || !segment || connection->state != NET_TCP_STATE_SYN_RECEIVED) return -1;
+    return net_tcp_build_syn_ack(segment, capacity, connection->local_port,
+                                 connection->remote_port, connection->local_sequence,
+                                 connection->remote_sequence);
 }
 
 int net_tcp_connection_retry_init(net_tcp_connection_retry_t* retry,uint8_t retry_limit){if(!retry)return -1;retry->retry_limit=retry_limit;retry->retries_used=0U;return 0;}
@@ -295,9 +328,15 @@ int net_tcp_connection_begin_close(net_tcp_connection_t* connection,uint8_t* seg
 }
 
 int net_tcp_connection_accept_ack(net_tcp_connection_t* connection,const net_tcp_view_t* view) {
-    if (!connection || !view || (connection->state != NET_TCP_STATE_ESTABLISHED && connection->state != NET_TCP_STATE_FIN_WAIT_1)) return -1;
+    if (!connection || !view || (connection->state != NET_TCP_STATE_ESTABLISHED &&
+        connection->state != NET_TCP_STATE_FIN_WAIT_1 && connection->state != NET_TCP_STATE_SYN_RECEIVED)) return -1;
     if (view->source_port != connection->remote_port || view->destination_port != connection->local_port ||
-        (view->flags & NET_TCP_FLAG_ACK) == 0U || view->acknowledgment > connection->local_sequence) return -2;
+        (view->flags & NET_TCP_FLAG_ACK) == 0U) return -2;
+    if (connection->state == NET_TCP_STATE_SYN_RECEIVED) {
+        if (view->sequence != connection->remote_sequence || view->acknowledgment != connection->local_sequence + 1U) return -3;
+        connection->local_sequence++; connection->state = NET_TCP_STATE_ESTABLISHED; return 0;
+    }
+    if (view->acknowledgment > connection->local_sequence) return -2;
     if (connection->pending_length != 0U && view->acknowledgment < connection->local_sequence) return -3;
     if (connection->pending_length != 0U) {
         connection->pending_payload = 0; connection->pending_length = 0U;

--- a/kernel/net_tcp.h
+++ b/kernel/net_tcp.h
@@ -18,6 +18,8 @@
 #define NET_TCP_STATE_FIN_WAIT_2 4U
 #define NET_TCP_STATE_CLOSE_WAIT 5U
 #define NET_TCP_STATE_LAST_ACK 6U
+#define NET_TCP_STATE_LISTEN 7U
+#define NET_TCP_STATE_SYN_RECEIVED 8U
 
 typedef struct { uint16_t source_port; uint16_t destination_port; uint32_t sequence; uint32_t acknowledgment; uint8_t flags; const uint8_t* payload; uint16_t payload_length; } net_tcp_view_t;
 typedef struct { net_tls_record_accumulator_t record_accumulator; net_tls_handshake_accumulator_t handshake_accumulator; } net_tcp_tls_stream_t;
@@ -41,6 +43,9 @@ typedef struct {
 int net_tcp_build_syn(uint8_t* segment, uint32_t capacity,
                       uint16_t source_port, uint16_t destination_port,
                       uint32_t sequence);
+int net_tcp_build_syn_ack(uint8_t* segment, uint32_t capacity,
+                          uint16_t source_port, uint16_t destination_port,
+                          uint32_t sequence, uint32_t acknowledgment);
 int net_tcp_build_ack(uint8_t* segment, uint32_t capacity,
                       uint16_t source_port, uint16_t destination_port,
                       uint32_t sequence, uint32_t acknowledgment);
@@ -63,6 +68,12 @@ int net_tcp_is_syn_ack_for(const net_tcp_view_t* view, uint16_t local_port,
 int net_tcp_connection_open(net_tcp_connection_t* connection,
                             uint16_t local_port, uint16_t remote_port,
                             uint32_t local_sequence);
+int net_tcp_connection_listen(net_tcp_connection_t* connection, uint16_t local_port,
+                              uint32_t local_sequence);
+int net_tcp_connection_accept_syn(net_tcp_connection_t* connection,
+                                  const net_tcp_view_t* view);
+int net_tcp_connection_build_syn_ack(const net_tcp_connection_t* connection,
+                                     uint8_t* segment, uint32_t capacity);
 /* Initialise un budget de reprises appartenant à l’appelant. */
 int net_tcp_connection_retry_init(net_tcp_connection_retry_t* retry,uint8_t retry_limit);
 /* Consomme une reprise ; retourne 1 si une nouvelle tentative est autorisée, 0 si le budget est épuisé. */

--- a/tests/unit/kernel/test_net_tcp.c
+++ b/tests/unit/kernel/test_net_tcp.c
@@ -11,6 +11,8 @@ static void build_stream_signed_exchange(uint8_t exchange[108]){uint16_t i;excha
 
 void setUp(void) {}
 void tearDown(void) {}
+void test_passive_listen_syn_ack(void);
+void test_passive_listen_rejects_ack_syn(void);
 
 void test_build_and_parse_syn_ack(void) {
     uint8_t segment[32] = {0}; net_tcp_view_t view;
@@ -292,6 +294,30 @@ void test_tcp_tls_ecdhe_ecdsa_postflight_and_application(void) {
 void test_tcp_rto_bounded_timer(void){net_tcp_rto_timer_t timer;net_tcp_connection_t connection;static const uint8_t payload[]={'x'};connection=(net_tcp_connection_t){0};connection.state=NET_TCP_STATE_ESTABLISHED;connection.pending_payload=payload;connection.pending_length=1U;connection.retransmit_limit=3U;TEST_ASSERT_EQUAL(0,net_tcp_rto_init(&timer,10U));TEST_ASSERT_EQUAL(0,net_tcp_rto_arm(&timer,100U,40U));TEST_ASSERT_EQUAL(0,net_tcp_rto_ready(&timer,109U));TEST_ASSERT_EQUAL(1,net_tcp_rto_ready(&timer,110U));TEST_ASSERT_EQUAL(0,net_tcp_rto_consume(&timer,&connection,109U,40U));TEST_ASSERT_EQUAL(1,net_tcp_rto_consume(&timer,&connection,110U,40U));TEST_ASSERT_EQUAL(1U,connection.retransmit_count);TEST_ASSERT_EQUAL(20U,timer.delay);TEST_ASSERT_EQUAL(0,net_tcp_rto_ready(&timer,129U));TEST_ASSERT_EQUAL(1,net_tcp_rto_ready(&timer,130U));TEST_ASSERT_EQUAL(1,net_tcp_rto_consume(&timer,&connection,130U,40U));TEST_ASSERT_EQUAL(2U,connection.retransmit_count);TEST_ASSERT_EQUAL(40U,timer.delay);TEST_ASSERT_EQUAL(-1,net_tcp_rto_init(&timer,0U));TEST_ASSERT_EQUAL(-1,net_tcp_rto_arm(&timer,0U,5U));}
 int main(void) {
     unity_init(); RUN_TEST(test_build_and_parse_syn_ack); RUN_TEST(test_connection_builds_first_ack); RUN_TEST(test_build_and_parse_ack_payload); RUN_TEST(test_connection_advances_sequences_and_accepts_data); RUN_TEST(test_tls_record_is_composed_into_tcp); RUN_TEST(test_accept_tls_record_on_tcp_view); RUN_TEST(test_accept_tls_handshake_transactional); RUN_TEST(test_accept_tls_postflight_transactional); RUN_TEST(test_tcp_tls_aes_gcm_transport); RUN_TEST(test_tcp_tls_x25519_flight_postflight_and_application);
-    RUN_TEST(test_tcp_tls_ecdhe_ecdsa_postflight_and_application); RUN_TEST(test_tcp_tls_authenticated_fragment_stream); RUN_TEST(test_receive_window_is_bounded); RUN_TEST(test_build_data_tracks_until_commit); RUN_TEST(test_ack_confirms_pending_payload); RUN_TEST(test_fin_close_transitions); RUN_TEST(test_bounded_retransmission_metadata); RUN_TEST(test_connection_retry_reopens_bounded_syn); RUN_TEST(test_tcp_rto_bounded_timer); unity_print_results(); unity_cleanup();
+    RUN_TEST(test_tcp_tls_ecdhe_ecdsa_postflight_and_application); RUN_TEST(test_tcp_tls_authenticated_fragment_stream); RUN_TEST(test_receive_window_is_bounded); RUN_TEST(test_build_data_tracks_until_commit); RUN_TEST(test_ack_confirms_pending_payload); RUN_TEST(test_fin_close_transitions); RUN_TEST(test_bounded_retransmission_metadata); RUN_TEST(test_connection_retry_reopens_bounded_syn); RUN_TEST(test_tcp_rto_bounded_timer); RUN_TEST(test_passive_listen_syn_ack); RUN_TEST(test_passive_listen_rejects_ack_syn); unity_print_results(); unity_cleanup();
     return (unity_stats.tests_failed == 0) ? 0 : 1;
+}
+
+void test_passive_listen_syn_ack(void) {
+    net_tcp_connection_t connection = {0};
+    net_tcp_view_t syn = {40000U, 8080U, 900U, 0U, NET_TCP_FLAG_SYN, 0, 0};
+    net_tcp_view_t ack = {40000U, 8080U, 901U, 1235U, NET_TCP_FLAG_ACK, 0, 0};
+    uint8_t segment[NET_TCP_HEADER_SIZE] = {0};
+    net_tcp_view_t parsed;
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_listen(&connection, 8080U, 1234U));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_LISTEN, connection.state);
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_syn(&connection, &syn));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_SYN_RECEIVED, connection.state);
+    TEST_ASSERT_EQUAL(NET_TCP_HEADER_SIZE, net_tcp_connection_build_syn_ack(&connection, segment, sizeof(segment)));
+    TEST_ASSERT_EQUAL(0, net_tcp_parse(segment, sizeof(segment), &parsed));
+    TEST_ASSERT_EQUAL(NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, parsed.flags);
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_accept_ack(&connection, &ack));
+    TEST_ASSERT_EQUAL(NET_TCP_STATE_ESTABLISHED, connection.state);
+}
+
+void test_passive_listen_rejects_ack_syn(void) {
+    net_tcp_connection_t connection = {0};
+    TEST_ASSERT_EQUAL(0, net_tcp_connection_listen(&connection, 8080U, 1234U));
+    TEST_ASSERT_NOT_EQUAL(0, net_tcp_connection_accept_syn(&connection,
+        &(net_tcp_view_t){40000U, 8080U, 900U, 1U, NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, 0, 0}));
 }


### PR DESCRIPTION
## Résumé

- Ajoute les états TCP LISTEN et SYN_RECEIVED.
- Ajoute l’acceptation d’un SYN entrant et la construction SYN-ACK caller-owned.
- Valide l’ACK final avant passage à ESTABLISHED.
- Ajoute deux tests TCP et documente les limites d’intégration socket/NIC.

## Validation

- Suite noyau : 35/35
- Suite complète : 424 tests, 424 passés, 0 échec
- `git diff --check` vert