### PR TITLE
feat: expose passive TCP lifecycle in socket registry

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -12,8 +12,8 @@
 |---|---|
 | FAT16/FAT32 | FAT16 dispose des primitives d’écriture 8.3 et LFN ; FAT32 valide le BPB, lit et écrit les FAT 28 bits répliquées, alloue et chaîne les clusters, crée des fichiers avec rollback, étend la chaîne racine et encode une entrée LFN ASCII UTF-16LE bornée. |
 | LFN FAT32 | Le checksum 8.3, la publication multi-entrée et la reconstruction au listage sont livrés ; l’intégration VFS complète, Unicode hors ASCII et suppression/renommage restent à réaliser. |
-| Réseau utilisateur | Le registre TCP statique et six syscalls socket sont présents ; les requêtes et buffers socket sont validés page-par-page dans l’espace utilisateur VMM. La fondation TCP `LISTEN → SYN_RECEIVED → ESTABLISHED` est livrée ; son raccordement au registre socket, à la NIC et aux syscalls reste à intégrer. |
-| Validation | Le runner noyau passe **35/35** tests avec la fondation passive TCP ; la suite complète précédente était à **422/422** avant ce lot. La validation globale et le smoke QEMU seront relancés avant la fusion de la PR passive. |
+| Réseau utilisateur | Le registre TCP statique et six syscalls socket sont présents ; les requêtes et buffers socket sont validés page-par-page dans l’espace utilisateur VMM. Le registre expose maintenant listen, SYN entrant, construction SYN-ACK et ACK final ; l’émission/réception NE2000 et l’exposition de ces opérations par syscalls restent à intégrer. |
+| Validation | Le runner noyau passe **35/35** tests et la suite complète passe **425/425** après l’intégration du cycle passif au registre socket. La CI et le smoke QEMU de la PR suivante restent à valider. |
 | Mémoire | Les lots concernés n’introduisent aucune allocation dynamique ; les buffers restent statiques ou caller-owned. |
 
 AI-OS démarre sans OS préinstallé dans QEMU, charge une archive initrd TAR, lance un shell ELF en Ring 3 et peut exécuter localement GPT-2 124M si les deux actifs binaires sont intégrés à l’image. Il demeure un **prototype de noyau**, non un système d’exploitation généraliste.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -853,6 +853,6 @@ Voir [aos1305_fat32_root_extension.md](aos1305_fat32_root_extension.md).
 Voir [aos1321_fat32_lfn.md](aos1321_fat32_lfn.md).
 
 ### AOS-1333 à AOS-1344 — fondation TCP d’écoute passive
-`net_tcp_connection_listen`, `net_tcp_connection_accept_syn`, `net_tcp_connection_build_syn_ack` et l’extension de `net_tcp_connection_accept_ack` livrent les transitions bornées `LISTEN → SYN_RECEIVED → ESTABLISHED` sans allocation dynamique. Les ports, drapeaux, séquences et acquittements sont validés. Validation locale : **35/35 tests noyau**. Le raccordement au registre `net_socket`, aux syscalls, à la réception/émission NE2000 et à l’écoute réseau complète reste le prochain incrément.
+`net_tcp_connection_listen`, `net_tcp_connection_accept_syn`, `net_tcp_connection_build_syn_ack` et l’extension de `net_tcp_connection_accept_ack` livrent les transitions bornées `LISTEN → SYN_RECEIVED → ESTABLISHED` sans allocation dynamique. Le registre `net_socket` expose désormais `listen`, l’acceptation SYN, la construction caller-owned du SYN-ACK et l’ACK final. Les ports, drapeaux, séquences et acquittements sont validés. Validation locale : **35/35 tests noyau**, **425/425 tests complets**. L’émission/réception NE2000 et l’exposition de ces opérations par syscalls restent le prochain incrément.
 
 Voir [aos1333_1344_tcp_passive_foundation.md](aos1333_1344_tcp_passive_foundation.md).

--- a/kernel/net_socket.c
+++ b/kernel/net_socket.c
@@ -88,3 +88,34 @@ void net_socket_reset_all(void) {
     uint32_t i;
     for (i = 0U; i < NET_SOCKET_CAPACITY; i++) sockets[i].used = 0U;
 }
+
+int net_socket_listen(uint16_t local_port, uint32_t local_sequence) {
+    uint32_t i;
+    for (i = 0U; i < NET_SOCKET_CAPACITY; i++) if (!sockets[i].used) {
+        sockets[i].used = 1U; sockets[i].receive_length = 0U; sockets[i].receive_offset = 0U;
+        if (net_tcp_connection_listen(&sockets[i].connection, local_port, local_sequence) != 0) {
+            sockets[i].used = 0U; return NET_SOCKET_BAD_ARGUMENT;
+        }
+        return (int)i;
+    }
+    return NET_SOCKET_NO_SLOT;
+}
+
+int net_socket_accept_syn(int socket_id, const net_tcp_view_t* view) {
+    if (!valid_id(socket_id) || !view) return NET_SOCKET_BAD_ARGUMENT;
+    return net_tcp_connection_accept_syn(&sockets[socket_id].connection, view) == 0 ? 0 : NET_SOCKET_PROTOCOL;
+}
+
+int net_socket_build_syn_ack(int socket_id, uint8_t* segment, uint16_t capacity, uint16_t* out_length) {
+    int built;
+    if (!valid_id(socket_id) || !segment || !out_length) return NET_SOCKET_BAD_ARGUMENT;
+    built = net_tcp_connection_build_syn_ack(&sockets[socket_id].connection, segment, capacity);
+    if (built < 0) return NET_SOCKET_PROTOCOL;
+    *out_length = (uint16_t)built;
+    return 0;
+}
+
+int net_socket_accept_ack(int socket_id, const net_tcp_view_t* view) {
+    if (!valid_id(socket_id) || !view) return NET_SOCKET_BAD_ARGUMENT;
+    return net_tcp_connection_accept_ack(&sockets[socket_id].connection, view) == 0 ? 0 : NET_SOCKET_PROTOCOL;
+}

--- a/kernel/net_socket.h
+++ b/kernel/net_socket.h
@@ -25,6 +25,10 @@ typedef struct {
 } net_socket_slot_t;
 
 int net_socket_open(uint16_t local_port, uint16_t remote_port, uint32_t local_sequence);
+int net_socket_listen(uint16_t local_port, uint32_t local_sequence);
+int net_socket_accept_syn(int socket_id, const net_tcp_view_t* view);
+int net_socket_build_syn_ack(int socket_id, uint8_t* segment, uint16_t capacity, uint16_t* out_length);
+int net_socket_accept_ack(int socket_id, const net_tcp_view_t* view);
 int net_socket_close(int socket_id);
 int net_socket_send(int socket_id, const uint8_t* payload, uint16_t length,
                     uint8_t* segment, uint16_t capacity, uint16_t* out_length);

--- a/tests/unit/kernel/test_net_socket.c
+++ b/tests/unit/kernel/test_net_socket.c
@@ -4,6 +4,21 @@
 void setUp(void) {}
 void tearDown(void) {}
 
+void test_socket_passive_lifecycle(void) {
+    int id; uint8_t segment[32] = {0}; uint16_t segment_length = 0U; uint8_t state = 0U;
+    net_tcp_view_t syn = {40000U, 8080U, 900U, 0U, NET_TCP_FLAG_SYN, 0, 0};
+    net_tcp_view_t ack = {40000U, 8080U, 901U, 1235U, NET_TCP_FLAG_ACK, 0, 0};
+    net_socket_reset_all();
+    id = net_socket_listen(8080U, 1234U); TEST_ASSERT_TRUE(id >= 0);
+    TEST_ASSERT_EQUAL(0, net_socket_get_state(id, &state)); TEST_ASSERT_EQUAL(NET_TCP_STATE_LISTEN, state);
+    TEST_ASSERT_EQUAL(0, net_socket_accept_syn(id, &syn));
+    TEST_ASSERT_EQUAL(0, net_socket_build_syn_ack(id, segment, sizeof(segment), &segment_length));
+    TEST_ASSERT_EQUAL(NET_TCP_HEADER_SIZE, segment_length); TEST_ASSERT_EQUAL(NET_TCP_FLAG_SYN | NET_TCP_FLAG_ACK, segment[13]);
+    TEST_ASSERT_EQUAL(0, net_socket_accept_ack(id, &ack));
+    TEST_ASSERT_EQUAL(0, net_socket_get_state(id, &state)); TEST_ASSERT_EQUAL(NET_TCP_STATE_ESTABLISHED, state);
+    TEST_ASSERT_EQUAL(0, net_socket_close(id));
+}
+
 void test_socket_lifecycle_send_receive(void) {
     int id;
     uint8_t segment[64] = {0};
@@ -41,6 +56,7 @@ void test_socket_lifecycle_send_receive(void) {
 int main(void) {
     unity_init();
     RUN_TEST(test_socket_lifecycle_send_receive);
+    RUN_TEST(test_socket_passive_lifecycle);
     unity_print_results();
     unity_cleanup();
     return 0;


### PR DESCRIPTION
## Résumé

- Expose `listen`, acceptation SYN, construction SYN-ACK et ACK final dans le registre socket statique.
- Conserve les buffers caller-owned et l’absence de kmalloc.
- Ajoute un test du cycle passif et met à jour l’état réel/backlog.

## Validation

- Suite noyau : 35/35
- Suite complète : 425/425
- `git diff --check` vert