### PR TITLE
feat: expose passive sockets to user syscalls

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -12,8 +12,8 @@
 |---|---|
 | FAT16/FAT32 | FAT16 dispose des primitives d’écriture 8.3 et LFN ; FAT32 valide le BPB, lit et écrit les FAT 28 bits répliquées, alloue et chaîne les clusters, crée des fichiers avec rollback, étend la chaîne racine et encode une entrée LFN ASCII UTF-16LE bornée. |
 | LFN FAT32 | Le checksum 8.3, la publication multi-entrée et la reconstruction au listage sont livrés ; l’intégration VFS complète, Unicode hors ASCII et suppression/renommage restent à réaliser. |
-| Réseau utilisateur | Le registre TCP statique et six syscalls socket sont présents ; les requêtes et buffers socket sont validés page-par-page dans l’espace utilisateur VMM. Le registre expose maintenant listen, SYN entrant, construction SYN-ACK et ACK final ; l’émission/réception NE2000 et l’exposition de ces opérations par syscalls restent à intégrer. |
-| Validation | Le runner noyau passe **35/35** tests et la suite complète passe **425/425** après l’intégration du cycle passif au registre socket. La CI et le smoke QEMU de la PR suivante restent à valider. |
+| Réseau utilisateur | Le registre TCP statique expose le cycle actif et passif ; les syscalls 99–108 valident les requêtes et buffers page-par-page dans l’espace utilisateur VMM. Les opérations passives `listen`, SYN entrant, SYN-ACK et ACK final sont disponibles. L’émission/réception NE2000 automatique reste à intégrer. |
+| Validation | Le runner noyau passe **35/35** tests et la suite complète passe **425/425** avec le registre et les syscalls passifs. La CI et le smoke QEMU de la PR suivante restent à valider. |
 | Mémoire | Les lots concernés n’introduisent aucune allocation dynamique ; les buffers restent statiques ou caller-owned. |
 
 AI-OS démarre sans OS préinstallé dans QEMU, charge une archive initrd TAR, lance un shell ELF en Ring 3 et peut exécuter localement GPT-2 124M si les deux actifs binaires sont intégrés à l’image. Il demeure un **prototype de noyau**, non un système d’exploitation généraliste.

--- a/docs/aos1333_1344_tcp_passive_foundation.md
+++ b/docs/aos1333_1344_tcp_passive_foundation.md
@@ -17,11 +17,11 @@ Les états `LISTEN` et `SYN_RECEIVED` sont ajoutés sans modifier la représenta
 
 ## Limites
 
-Ce lot ne publie pas encore de syscall `listen`/`accept`, ne réserve pas automatiquement un slot dans le registre `net_socket`, ne scrute pas la NIC NE2000 et n’émet pas encore le SYN-ACK sur le réseau. Le raccordement registre/socket/NIC constituera le prochain lot ; les buffers et l’état restent caller-owned.
+Le registre `net_socket` expose désormais `net_socket_listen`, `net_socket_accept_syn`, `net_socket_build_syn_ack` et `net_socket_accept_ack`. Les syscalls `SYS_SOCKET_LISTEN` (105), `SYS_SOCKET_ACCEPT_SYN` (106), `SYS_SOCKET_BUILD_SYN_ACK` (107) et `SYS_SOCKET_ACCEPT_ACK` (108) valident les vues et buffers Ring 3 par page avant d’appeler le registre. La réception/émission NE2000 et l’injection automatique des trames restent hors périmètre ; les buffers et l’état restent caller-owned.
 
 ## Validation
 
-Le runner noyau passe **35/35 tests**. Les nouveaux tests vérifient la séquence `LISTEN → SYN_RECEIVED → ESTABLISHED`, le décodage du SYN-ACK généré et le rejet d’un SYN accompagné à tort d’un ACK. La suite complète doit être relancée avant la PR afin de confirmer l’absence de régression globale.
+Le runner noyau passe **35/35 tests** et la suite complète passe **425/425 tests**. Les tests vérifient la séquence `LISTEN → SYN_RECEIVED → ESTABLISHED`, le décodage du SYN-ACK généré, le rejet d’un SYN accompagné à tort d’un ACK et le cycle équivalent dans le registre socket. Les wrappers syscall réutilisent la validation VMM page-par-page déjà appliquée aux six syscalls socket actifs.
 
 ## Mémoire
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -853,6 +853,6 @@ Voir [aos1305_fat32_root_extension.md](aos1305_fat32_root_extension.md).
 Voir [aos1321_fat32_lfn.md](aos1321_fat32_lfn.md).
 
 ### AOS-1333 à AOS-1344 — fondation TCP d’écoute passive
-`net_tcp_connection_listen`, `net_tcp_connection_accept_syn`, `net_tcp_connection_build_syn_ack` et l’extension de `net_tcp_connection_accept_ack` livrent les transitions bornées `LISTEN → SYN_RECEIVED → ESTABLISHED` sans allocation dynamique. Le registre `net_socket` expose désormais `listen`, l’acceptation SYN, la construction caller-owned du SYN-ACK et l’ACK final. Les ports, drapeaux, séquences et acquittements sont validés. Validation locale : **35/35 tests noyau**, **425/425 tests complets**. L’émission/réception NE2000 et l’exposition de ces opérations par syscalls restent le prochain incrément.
+`net_tcp_connection_listen`, `net_tcp_connection_accept_syn`, `net_tcp_connection_build_syn_ack` et l’extension de `net_tcp_connection_accept_ack` livrent les transitions bornées `LISTEN → SYN_RECEIVED → ESTABLISHED` sans allocation dynamique. Le registre `net_socket` et les syscalls 105–108 exposent désormais `listen`, l’acceptation SYN, la construction caller-owned du SYN-ACK et l’ACK final, avec validation VMM page-par-page. Les ports, drapeaux, séquences et acquittements sont validés. Validation locale : **35/35 tests noyau**, **425/425 tests complets**. L’émission/réception NE2000 automatique reste le prochain incrément.
 
 Voir [aos1333_1344_tcp_passive_foundation.md](aos1333_1344_tcp_passive_foundation.md).

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -194,7 +194,15 @@
 #define SYS_SOCKET_RECEIVE 103
 /* EBX = descripteur socket. */
 #define SYS_SOCKET_CLOSE 104
-#define MAX_SYSCALLS 105
+/* EBX = port local, ECX = séquence initiale. */
+#define SYS_SOCKET_LISTEN 105
+/* EBX = descripteur, ECX = os_socket_passive_view_t* avec SYN entrant. */
+#define SYS_SOCKET_ACCEPT_SYN 106
+/* EBX = descripteur, ECX = buffer SYN-ACK, EDX = capacité, ESI = out_length. */
+#define SYS_SOCKET_BUILD_SYN_ACK 107
+/* EBX = descripteur, ECX = os_socket_passive_view_t* avec ACK final. */
+#define SYS_SOCKET_ACCEPT_ACK 108
+#define MAX_SYSCALLS 109
 
 typedef struct {
     uint16_t source_port;
@@ -222,6 +230,13 @@ typedef struct {
     uint16_t capacity;
     uint16_t* out_length;
 } os_socket_receive_request_t;
+typedef struct {
+    uint16_t source_port;
+    uint16_t destination_port;
+    uint32_t sequence;
+    uint32_t acknowledgment;
+    uint8_t flags;
+} os_socket_passive_view_t;
 
 #define OS_SOCKET_BAD_ARGUMENT (-120)
 #define OS_SOCKET_NO_SLOT (-121)

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -315,6 +315,21 @@ void syscall_handler(cpu_state_t* cpu) {
         case SYS_SOCKET_OPEN:
             cpu->eax = (uint32_t)sys_socket_open((uint16_t)cpu->ebx, (uint16_t)cpu->ecx, cpu->edx);
             break;
+        case SYS_SOCKET_LISTEN:
+            cpu->eax = (uint32_t)sys_socket_listen((uint16_t)cpu->ebx, cpu->ecx);
+            break;
+        case SYS_SOCKET_ACCEPT_SYN:
+            cpu->eax = (uint32_t)sys_socket_accept_syn((int)cpu->ebx,
+                (const os_socket_passive_view_t*)cpu->ecx);
+            break;
+        case SYS_SOCKET_BUILD_SYN_ACK:
+            cpu->eax = (uint32_t)sys_socket_build_syn_ack((int)cpu->ebx,
+                (uint8_t*)cpu->ecx, (uint16_t)cpu->edx, (uint16_t*)cpu->esi);
+            break;
+        case SYS_SOCKET_ACCEPT_ACK:
+            cpu->eax = (uint32_t)sys_socket_accept_ack((int)cpu->ebx,
+                (const os_socket_passive_view_t*)cpu->ecx);
+            break;
         case SYS_SOCKET_ACCEPT_SYN_ACK:
             cpu->eax = (uint32_t)sys_socket_accept_syn_ack((int)cpu->ebx,
                 (const os_socket_syn_ack_t*)cpu->ecx);
@@ -619,6 +634,36 @@ static int syscall_user_range(const void* pointer, uint32_t length, int write) {
 int sys_socket_open(uint16_t local_port, uint16_t remote_port, uint32_t local_sequence) {
     if (!current_task || current_task->type != TASK_TYPE_USER) return OS_SOCKET_BAD_ARGUMENT;
     return net_socket_open(local_port, remote_port, local_sequence);
+}
+
+int sys_socket_listen(uint16_t local_port, uint32_t local_sequence) {
+    if (!current_task || current_task->type != TASK_TYPE_USER) return OS_SOCKET_BAD_ARGUMENT;
+    return net_socket_listen(local_port, local_sequence);
+}
+
+static int sys_socket_passive_view_copy(const os_socket_passive_view_t* source, net_tcp_view_t* target) {
+    if (!syscall_user_range(source, sizeof(*source), 0) || !target) return OS_SOCKET_BAD_ARGUMENT;
+    target->source_port = source->source_port; target->destination_port = source->destination_port;
+    target->sequence = source->sequence; target->acknowledgment = source->acknowledgment;
+    target->flags = source->flags; target->payload = 0; target->payload_length = 0U;
+    return 0;
+}
+
+int sys_socket_accept_syn(int socket_id, const os_socket_passive_view_t* view) {
+    net_tcp_view_t tcp_view;
+    if (sys_socket_passive_view_copy(view, &tcp_view) != 0) return OS_SOCKET_BAD_ARGUMENT;
+    return net_socket_accept_syn(socket_id, &tcp_view);
+}
+
+int sys_socket_build_syn_ack(int socket_id, uint8_t* segment, uint16_t capacity, uint16_t* out_length) {
+    if (!syscall_user_range(segment, capacity, 1) || !syscall_user_range(out_length, sizeof(*out_length), 1)) return OS_SOCKET_BAD_ARGUMENT;
+    return net_socket_build_syn_ack(socket_id, segment, capacity, out_length);
+}
+
+int sys_socket_accept_ack(int socket_id, const os_socket_passive_view_t* view) {
+    net_tcp_view_t tcp_view;
+    if (sys_socket_passive_view_copy(view, &tcp_view) != 0) return OS_SOCKET_BAD_ARGUMENT;
+    return net_socket_accept_ack(socket_id, &tcp_view);
 }
 
 int sys_socket_accept_syn_ack(int socket_id, const os_socket_syn_ack_t* view) {

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -70,6 +70,10 @@ int sys_task_supervision_notify_budget_status(os_task_supervision_notify_budget_
 int sys_fat16_read(const char* name, char* buffer, uint32_t max);
 int sys_fat16_list(os_fat16_dirent_t* out, uint32_t capacity);
 int sys_socket_open(uint16_t local_port, uint16_t remote_port, uint32_t local_sequence);
+int sys_socket_listen(uint16_t local_port, uint32_t local_sequence);
+int sys_socket_accept_syn(int socket_id, const os_socket_passive_view_t* view);
+int sys_socket_build_syn_ack(int socket_id, uint8_t* segment, uint16_t capacity, uint16_t* out_length);
+int sys_socket_accept_ack(int socket_id, const os_socket_passive_view_t* view);
 int sys_socket_accept_syn_ack(int socket_id, const os_socket_syn_ack_t* view);
 int sys_socket_send(const os_socket_send_request_t* request);
 int sys_socket_feed(const os_socket_feed_request_t* request);


### PR DESCRIPTION
## Résumé

- Ajoute les syscalls 105 à 108 pour listen, SYN entrant, SYN-ACK et ACK final.
- Valide les vues et buffers utilisateur par page via le VMM.
- Met à jour l’ABI, les tests/documentations et conserve le mode sans allocation dynamique.

## Validation

- Suite noyau : 35/35
- Suite complète : 425/425
- `git diff --check` vert