### PR TITLE
llm: run local GPT-2 GGUF from FAT16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ OS_IMAGE = build/ai_os.bin
 ISO_IMAGE = build/ai_os.iso
 INITRD_IMAGE = my_initrd.tar
 DISK_IMAGE ?= build/overlay.img
+GGUF_DISK_IMAGE ?= build/gpt2_gguf_fat16.img
+GPT2_GGUF_DEPLOY_MODEL ?= models/gpt2-Q3_K_M.gguf
 DISK_SECTORS ?= 4224
 FAT_BASE_LBA ?= 64
 QEMU_DISK_OPTS = -drive file=$(DISK_IMAGE),format=raw,if=ide,cache=writethrough
@@ -33,7 +35,7 @@ BIN_DEST_DIR := $(INITRD_DIR)/bin
 # Liste des fichiers objets - MISE À JOUR avec tous les nouveaux fichiers
 OBJECTS = build/boot.o build/idt_loader.o build/isr_stubs.o build/paging.o build/context_switch.o build/userspace_switch.o \
           build/string.o build/pmm.o build/heap.o build/gdt_asm.o build/gdt.o build/idt.o build/vmm.o build/task.o \
-          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/rtc.o build/fat16.o build/fat32.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
+          build/syscall.o build/elf.o build/initrd.o build/overlay.o build/ata.o build/rtc.o build/fat16.o build/fat32.o build/gpt2_model.o build/gpt2_gguf.o build/gpt2_gguf_loader.o build/gpt2_quant.o build/gpt2_gguf_infer.o build/gpt2_tokenizer.o build/gpt2_sample.o build/gpt2_infer.o build/interrupts.o \
           build/keyboard.o build/timer.o build/ipc.o build/service_registry.o build/multiboot.o build/kernel.o build/vga_console.o build/kbd_buffer.o build/net_ethernet_arp.o build/net_nic.o build/pci.o build/ne2k.o build/net_dhcp.o build/net_ipv4_udp.o build/net_dns.o build/net_tcp.o build/net_socket.o build/net_llm_socket.o build/sha256.o build/aes_gcm.o build/x509_der.o build/bigint.o build/ecdsa_p256.o build/x25519.o build/rsa_verify.o build/net_tls_record.o build/net_http_tls.o
 
 # L'ABI partagée influence notamment la taille de task_t et des messages IPC.
@@ -291,6 +293,10 @@ build/gpt2_sample.o: kernel/llm/gpt2_sample.c kernel/llm/gpt2_sample.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 # Noyau d'inference GPT-2 CPU freestanding.
+build/gpt2_gguf_infer.o: kernel/llm/gpt2_gguf_infer.c kernel/llm/gpt2_gguf_infer.h kernel/llm/gpt2_gguf_loader.h kernel/llm/gpt2_sample.h kernel/fs/fat16.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
 build/gpt2_infer.o: kernel/llm/gpt2_infer.c kernel/llm/gpt2_infer.h kernel/llm/gpt2_sample.h kernel/llm/gpt2_model.h kernel/mem/heap.h
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -564,7 +570,7 @@ $(DISK_IMAGE):
 	dd if=/dev/zero of=$@ bs=512 count=$(DISK_SECTORS) status=none
 	python3 tests/scripts/make_fat16_image.py --image $@
 
-.PHONY: disk fat16-fixture
+.PHONY: disk fat16-fixture gguf-disk
 disk: $(DISK_IMAGE)
 
 fat16-fixture: $(DISK_IMAGE)
@@ -687,3 +693,10 @@ help:
 
 .PHONY: all kernel-only run run-gui test-build info-initrd info-user user-program userspace-all clean distclean help pack-initrd test-setup test-quick test-kernel test-userspace test-all test-performance test-valgrind test-clean pre-commit-tests ci-tests qemu-smoke gpt2-recovery gpt2-benchmark gpt2-tests ci deps disk gui-captures gui-record
 
+
+gguf-disk:
+	@python3 scripts/make_gguf_fat16_image.py --model $(GPT2_GGUF_DEPLOY_MODEL) --image $(GGUF_DISK_IMAGE)
+
+.PHONY: qemu-gguf-smoke
+qemu-gguf-smoke: $(OS_IMAGE) pack-initrd gguf-disk
+	@OVERLAY_DISK="$(abspath $(GGUF_DISK_IMAGE))" python3 tests/scripts/ci_qemu_gguf_local_smoke.py

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AI-OS est un **prototype de hobby OS i386 32-bit** démarrant par Multiboot. Ce 
 | Découverte Foundation | Registre volatile de 8 services et 8 abonnements ; retrait, transfert par propriétaire, notifications et purge immédiate à la terminaison ; pas de capabilities |
 | Fichiers | Archive initrd TAR en lecture seule, overlay AIOV V2 sur ATA PIO (64 nœuds, V1 compatible), volume FAT16 et primitives FAT32 d’écriture/chaînage/rollback hors intégration VFS complète |
 | IA locale | GPT-2 124M `llm.c v3`, BPE UTF-8, cache KV, SSE2 et top-k sur workspace statique borné, sans réseau au boot ni allocation dynamique dans le moteur d’inférence |
-| GGUF | Sonde GGUF v3, contexte de génération préparé depuis les rôles globaux et couches réelles, exécution FAT16 d’un token vers les logits avec cache KV/workspace caller-owned, lecture dense F32/F16 et kernels Q3_K/Q4_K/Q6_K ; intégration shell, tokenizer et échantillonnage local restent ouverts |
+| GGUF | Runtime GPT-2 GGUF v3 local : catalogue FAT16 borné à 2 MiB, embeddings Q3_K, matrices Q3_K/Q4_K/Q6_K, bloc avec biais MLP, cache KV statique, top-k et shell `ai-model use gpt2.gguf`, sans allocation dynamique |
 | Réseau | Pilote NE2000 ISA, `SYS_NET_STATUS`, codecs ARP/IPv4/UDP/DHCP/DNS/TCP/TLS record, renouvellement, réacquisition et backoff DHCP caller-owned différés hors IRQ0, conservation fournisseur et reprise HTTP/SSE contrôlées, reprise SSE fine `Last-Event-ID`, registre TCP statique, orchestrateur noyau DHCP/DNS/ARP/SYN→TLS→HTTP/SSE socket et FIN+ACK transactionnel ; client OpenAI Chat Completions activable depuis le shell, campagne externe réelle en attente d’une clé API valide |
 
 Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `sort`, `head`, `tail`, `fat16-list`, `fat16-cat`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `service-publish`, `service-grant`, `service-find`, `service-status <nom>`, `service-watch`, `vfs-backend-probe <fichier>`, `vfs-backend-write-probe <fichier> <texte>`, `vfs-backend-remove-probe <fichier>`, `vfs-backend-rename-probe <src> <dst>`, `vfs-grant <pid>`, `vfs-backend-grant <pid>`, `vfs-backend-grant-read <pid>`, `vfs-backend-grant-mutate <pid>`, `vfs-backend-revoke <pid>`, `vfs-backend-status <pid>`, `vfs-backend-list`, `vfs-read <chemin>`, `vfs-stat <chemin>`, `vfs-list <repertoire/>`, `vfs-list-page <repertoire/> <depart>`, `vfs-mkdir`, `vfs-rmdir`, `vfs-stats`, `vfs-mount-add <prefixe/> <initrd|overlay>`, `vfs-mount-remove <prefixe/>`, `vfs-write <chemin> <texte>`, `vfs-remove <chemin>`, `vfs-rename <src> <dst>`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime`, `ai-credential`, `net-status` et `net-status json`. La liste complète, y compris la supervision de tâches, est dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
@@ -45,8 +45,10 @@ make run
 | Cible | Rôle |
 |---|---|
 | `make all` | Noyau, initrd et image overlay IDE (AIOV + FAT16 à partir du LBA 64) |
-| `make test-all` | Suite complète Unity/robustesse ; l’état courant validé est de 444 tests exécutés avec succès |
+| `make test-all` | Suite complète Unity/robustesse ; l’état courant validé est de 452 tests exécutés avec succès |
 | `make qemu-smoke` | Scénarios QEMU classiques : overlay, persistance, spawn/yield et exec |
+| `make gguf-disk` | Construit un disque FAT16 de déploiement contenant le modèle sous l’alias `GPT2.GGU` |
+| `make qemu-gguf-smoke` | Démarre le disque GGUF, sélectionne `gpt2.gguf` dans le shell et valide un token local |
 | `make integration-qemu` | Contrats QEMU AOS-022, AOS-024, AOS-025, NE2000, IPC, VFS avec montages dynamiques, mutations médiées, révocation, notifications, cycle de vie et transfert Foundation |
 | `make qemu-irq0-preemption` | Lance `spin` puis exige un shell toujours réactif |
 | `make qemu-ai-provider` | Vérifie le diagnostic réseau et le blocage OpenAI |
@@ -72,7 +74,8 @@ Les poids ne sont **pas** dans Git. Les actifs validés sont distribués par la 
 ```text
 models/
 ├── gpt2_124M.bin
-└── gpt2_tokenizer.bin
+├── gpt2_tokenizer.bin
+└── gpt2-Q3_K_M.gguf       # optionnel : source de `make gguf-disk`
 ```
 
 ```bash
@@ -84,17 +87,17 @@ curl -L -o models/gpt2-124m-assets.sha256 https://github.com/kamgueblondin/ai-os
 make all
 ```
 
-QEMU nécessite **1 Gio** de RAM quand ce checkpoint est dans l’initrd. Dans le shell, utilisez `ai hello`, `ai-provider local`, `ai-model list`, `ai-runtime` et `rc`. La génération est volontairement bornée à 64 jetons de contexte et quatre jetons nouveaux. Sous QEMU TCG sans KVM, le temps d’une courte génération reste de l’ordre de **7 à 9 secondes** : l’objectif inférieur à une seconde n’est pas atteint.
+QEMU nécessite **1 Gio** de RAM quand le checkpoint FP32 est dans l’initrd. Dans le shell, utilisez `ai hello`, `ai-provider local`, `ai-model list`, `ai-model use gpt2.gguf`, `ai-runtime` et `rc`. Le profil GGUF garde 64 jetons de contexte dans son cache KV et retourne un token par appel pour éviter de monopoliser le noyau pendant un forward quantifié sur FAT16.
 
 ## GGUF, OpenAI et réseau : limites assumées
 
-AI-OS valide la structure de fichiers GGUF v3 et fournit des kernels Q8_0/Q3_K/Q4_K/Q6_K, mais le chemin de génération livré reste le checkpoint FP32 `llm.c v3`. `ai-model` peut mémoriser un profil `.gguf`, sans le faire exécuter.
+AI-OS valide la structure GGUF v3 et exécute désormais le profil GPT-2 GGUF quantifié depuis FAT16. `make gguf-disk` conserve les poids hors initrd sous `GPT2.GGU`; le boot indexe seulement le catalogue et `ai-model use gpt2.gguf` sélectionne le syscall local dédié. Les lectures de QKV, MLP et logits sont séquentielles sur FAT16 et le workspace reste entièrement statique.
 
-Le profil `ai-provider openai` est un **stub contrôlé**. `net-status` / `net-status json` publient la présence réelle d’une NIC NE2000 ISA (smoke `make qemu-ne2k-status`) ; les codecs TCP/TLS et le registre socket statique existent, mais aucun chemin HTTP/TLS live ni client OpenAI n’est encore raccordé. Une commande `ai` avec le profil OpenAI ne transmet aucune requête. QEMU peut connecter `ne2k_isa` à un backend hôte ; le guest possède désormais un pilote, des codecs caller-owned et une API socket noyau, pas un client HTTP [1]. Les secrets OpenAI ne doivent jamais être inclus dans l’image, les logs série ou le dépôt.
+Le profil `ai-provider openai` est activable de façon contrôlée : la session noyau relie DHCP, DNS, socket TCP statique, TLS, HTTP/SSE et extraction de réponse. `net-status` / `net-status json` publient la présence réelle d’une NIC NE2000 ISA ; l’appel externe reste désactivé tant qu’un bearer n’est pas configuré par `ai-credential`. Les secrets OpenAI ne doivent jamais être inclus dans l’image, les logs série ou le dépôt.
 
 ## Tests et artefacts
 
-`make test-all` a validé **444 tests exécutés avec succès** dans l’état courant, dont FAT16/FAT32, console VGA, PCI, SHA-256/HMAC, codecs Ethernet/ARP/IPv4/UDP/DHCP/DNS/TCP, NE2000, orchestrateur noyau LLM TLS/HTTP/SSE sur socket, GPT-2/GGUF, IPC, VFS, services, shell et RAMFS. `make integration-qemu` ajoute les validations QEMU séparées, dont le smoke NE2000 et les contrats IPC, VFS et service ; il réinitialise son disque de contrat sans toucher à `build/overlay.img`. Les détails de périmètre et les limites restantes sont maintenus dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md) et [docs/todo.md](docs/todo.md).
+`make test-all` a validé **452 tests exécutés avec succès** dans l’état courant, dont FAT16/FAT32, curseur et saut FAT16, console VGA, PCI, SHA-256/HMAC, codecs Ethernet/ARP/IPv4/UDP/DHCP/DNS/TCP, NE2000, orchestrateur noyau LLM TLS/HTTP/SSE sur socket, GPT-2/GGUF, IPC, VFS, services, shell et RAMFS. `make qemu-gguf-smoke` complète les smokes QEMU en validant le disque GPT2.GGU et la génération locale sélectionnée dans le shell. Les détails de périmètre et les limites restantes sont maintenus dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md) et [docs/todo.md](docs/todo.md).
 
 Une ISO BIOS/GRUB peut être produite avec l’initrd. Lorsque les poids GPT-2 sont fournis, ils sont bien incorporés à l’ISO pour un fonctionnement local sur une machine vierge ; ils restent ignorés par Git.
 
@@ -104,7 +107,7 @@ Le backlog courant est [US/ai_os_us.md](US/ai_os_us.md). La vision MOHHOS est co
 
 - [x] GPT-2 local, cache KV, SSE2 et top-k borné
 - [x] Tokenizer BPE UTF-8 avec couverture de lettres Unicode ciblée
-- [x] Sonde GGUF v3, kernels Q3_K/Q4_K/Q6_K et mapping de couches
+- [x] Sonde GGUF v3, kernels Q3_K/Q4_K/Q6_K, mapping de couches et runtime FAT16 local via shell
 - [x] Tests QEMU versionnés
 - [x] Overlay ATA PIO V2, 64 nœuds et restauration V1
 - [x] Préemption IRQ0 sûre entre tâches Ring 3
@@ -143,7 +146,7 @@ Le backlog courant est [US/ai_os_us.md](US/ai_os_us.md). La vision MOHHOS est co
 - [x] Inventaire médié de capacités backend VFS : `vfs-backend-list` affiche jusqu’à quatre délégations actives et leurs masques au propriétaire public de `vfs`
 - [ ] Capabilities, révocation indépendante, identité vérifiée, routage général des réponses discordantes et externalisation d’un backend de chemins
 - [ ] Migration microkernel réelle
-- [ ] Inférence GGUF quantifiée bout-en-bout et latence QEMU inférieure à une seconde
+- [ ] Optimisation de la latence GGUF quantifiée sur QEMU ; l’inférence bout-en-bout est livrée
 - [ ] Bail DHCP live, DNS/TCP utilisateur, handshake TLS et client OpenAI effectif
 - [x] Écriture FAT16 8.3, création de fichiers FAT32, écriture/chaînage FAT32, extension de la racine et primitives LFN FAT32 bornées ; publication multi-entrée LFN, reconstruction LFN et intégration complète au VFS restent à livrer — [docs/aos_fat_volume.md](docs/aos_fat_volume.md)
 

--- a/docs/aos1569_1576_gguf_local_shell.md
+++ b/docs/aos1569_1576_gguf_local_shell.md
@@ -1,0 +1,88 @@
+# AOS-1569…1576 — Exécution locale GPT-2 GGUF depuis FAT16
+
+**Statut : livré et validé.** Ce macro-lot rend le profil `gpt2.gguf` exécutable depuis la commande `ai`, sans recopier les poids en mémoire et sans introduire d’allocation dynamique. Le modèle réel Q3_K est conservé sur un volume FAT16 et le noyau ne réside que le catalogue GGUF, le workspace de calcul et le cache KV borné.
+
+> **Principe d’exécution.** Le disque de déploiement expose le modèle réel sous l’alias FAT16 8.3 `GPT2.GGU`. Le noyau indexe son catalogue dans une fenêtre statique de 2 MiB, puis lit les poids par fenêtres au fur et à mesure du forward.
+
+## Périmètre livré
+
+| Axe | Livraison | Garantie principale |
+|---|---|---|
+| Catalogue GGUF | Indexage à deux bornes : fenêtre d’en-tête chargée et taille logique complète du fichier | Aucun poids n’est copié avec le catalogue ; les offsets sont validés contre la taille FAT16 réelle. |
+| Formats quantifiés | Déquantification caller-owned Q3_K, Q4_K et Q6_K pour les embeddings | Le modèle Q3_K réel, dont `token_embd.weight` est Q3_K et la tête de sortie Q6_K, est supporté. |
+| Bloc GPT-2 | Mapping des douze rôles par couche, y compris les biais `ffn_up` et `ffn_down` | Le forward applique les biais MLP réels au lieu de les neutraliser. |
+| Runtime local | État statique GPT-2 12 × 768, cache KV de 64 positions et top-k déterministe | Zéro `kmalloc`, `malloc`, `calloc` ou `realloc`. |
+| E/S FAT16 | Curseur, saut par chaîne FAT, projections QKV/MLP/logits séquentielles | Une projection ne reparcourt plus la chaîne de clusters pour chaque ligne. |
+| Shell et ABI | `SYS_GPT2_GGUF_GENERATE` (109), sélection par `ai-model use gpt2.gguf` | Le syscall FP32 historique reste inchangé. |
+| Déploiement | `make gguf-disk` et image FAT16 contenant `GPT2.GGU` et `FATOK.TXT` | Le modèle reste hors initrd ; l’image est compatible avec les smokes existants. |
+
+## Architecture mémoire et limites
+
+Le catalogue GGUF occupe au plus **2 MiB**. Le modèle Q3_K de référence reste sur le disque FAT16 ; il n’est jamais chargé dans le heap ni copié intégralement. Le profil statique cible GPT-2 124M avec 12 couches, 768 canaux, 12 têtes, un vocabulaire maximal de 50 257 tokens et un cache de contexte de 64 positions.
+
+| Ressource résidente | Bornage | Rôle |
+|---|---:|---|
+| Catalogue GGUF | 2 MiB | Métadonnées, descripteurs et offsets validés. |
+| Cache KV | 12 × 64 × 2 × 768 floats | K/V persistants par couche pour le préfixe courant. |
+| Workspace de bloc | 768 et 3 072 floats selon le buffer | Normalisations, QKV, attention, MLP et résidu. |
+| Logits | 50 257 floats | Échantillonnage top-k déterministe. |
+| Buffer de ligne | 630 octets | Plus grande ligne quantifiée Q6_K de 768 canaux. |
+
+Le profil GGUF produit volontairement **un token par appel shell**. Cette borne évite de monopoliser le noyau pendant une génération longue sur un périphérique bare-metal à E/S FAT16. Le cache KV conserve le préfixe déjà calculé ; les appels suivants réutilisent donc les positions compatibles.
+
+## Flux d’exécution
+
+```text
+ai-model use gpt2.gguf
+        │
+        ▼
+SYS_GPT2_GGUF_GENERATE (109)
+        │
+        ├── Tokenizer BPE initrd
+        ├── Vérification du profil GGUF FAT16 prêt
+        ├── Réutilisation / reconstruction du préfixe KV
+        ├── Embedding Q3_K ou dense par ligne
+        ├── 12 blocs : QKV → attention KV → MLP avec biais
+        ├── Normalisation finale
+        ├── Tête Q6_K lue séquentiellement sur FAT16
+        └── Top-k déterministe → détokenisation shell
+```
+
+Les projections QKV, attention, MLP et logits ouvrent un curseur FAT16, se positionnent sur le début du tenseur via la chaîne FAT, puis consomment les lignes dans l’ordre. Cette stratégie retire le coût pathologique d’un `fat16_read_file_range` depuis le début du fichier pour chaque ligne quantifiée.
+
+## Construction et essais
+
+La commande suivante construit un disque de déploiement d’environ 102 MiB à partir du modèle Q3_K local. Elle installe les poids sous `GPT2.GGU` et ajoute `FATOK.TXT` afin de rester compatible avec les diagnostics FAT16 standard.
+
+```sh
+make gguf-disk
+```
+
+Le test de bout en bout dédié reconstruit l’image, démarre QEMU, sélectionne le profil et attend un retour local du shell.
+
+```sh
+make qemu-gguf-smoke
+```
+
+Le smoke QEMU standard peut aussi démarrer sur ce disque sans le réécrire en définissant explicitement la conservation FAT16 :
+
+```sh
+AIOS_PRESERVE_FAT16=1 \
+OVERLAY_DISK="$PWD/build/gpt2_gguf_fat16.img" \
+make qemu-smoke DISK_IMAGE=build/gpt2_gguf_fat16.img
+```
+
+## Validation réalisée
+
+| Vérification | Résultat |
+|---|---|
+| Compilation freestanding i386 | Réussie. |
+| Unity complet | **452/452** tests verts, zéro test ignoré. |
+| Indexage du modèle Q3_K réel | Catalogue de 149 tenseurs dans une fenêtre de 2 MiB. |
+| Smoke QEMU standard sur disque de déploiement | Core, extras shell, persistance, spawn/yield/wait et exec validés. |
+| Smoke `qemu-gguf-smoke` | Boot GGUF, sélection `gpt2.gguf` et retour local validés. |
+| Analyse statique de la voie GGUF | Aucun appel à un allocateur dynamique. |
+
+## Limites et suite
+
+La livraison vise le profil GPT-2 124M GGUF quantifié, le format de fichier FAT16 8.3 et un contexte local de 64 tokens. Elle ne rend pas encore n’importe quel modèle GGUF ni n’importe quel tokenizer GGUF interchangeable : le tokenizer BPE GPT-2 fourni par l’initrd demeure le contrat de génération. La suite du backlog pourra généraliser les profils, exposer une politique de contexte plus riche et réduire davantage la latence par cache de pages de poids strictement statique.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,8 +56,8 @@
 - [x] `spawn` / `yield` coopératifs (cadre syscall user) et préemption IRQ0 sûre entre tâches Ring 3
 - [x] `exec` bloquant : parent `TASK_WAITING`, enfant reveille via `SYS_EXIT` (plus de `int $0x30` noyau)
 - [x] AOS-020…026 : sonde GGUF, BPE UTF-8, contrats QEMU, overlay V2, IRQ0, stub OpenAI, FAT16 lecture seule
-- [x] Kernels GGUF Q3_K/Q4_K/Q6_K, index et mapping ; génération shell encore FP32
-- [ ] Inférence GGUF bout-en-bout et latence locale &lt; 1 s ; le socle de workspace GPT-2 statique borné est désormais livré
+- [x] Kernels GGUF Q3_K/Q4_K/Q6_K, index, mapping, génération shell et échantillonnage local FAT16
+- [ ] Réduire la latence locale GGUF ; le forward bout-en-bout, le cache KV et les lectures séquentielles FAT16 sont désormais livrés
 - [x] Écriture FAT16 8.3, création de fichiers FAT32, écriture/chaînage FAT32, extension de racine et primitives LFN FAT32 — [aos_fat_volume.md](aos_fat_volume.md) ; intégration VFS complète, Unicode hors ASCII et suppression/renommage LFN restent à faire ; pas ext2
 - [x] Pilote NE2000 ISA et codecs ARP/IPv4/UDP/DHCP/DNS/TCP/TLS record (lots 113–154)
 - [x] Validation page-par-page des pointeurs socket utilisateur dans le VMM
@@ -86,10 +86,11 @@
 - [x] AOS-1545…1552 : forward de bloc transformeur GPT-2 Q4_K sur FAT16, cache KV et workspace caller-owned — [aos1545_1552_gguf_transformer_block.md](aos1545_1552_gguf_transformer_block.md)
 - [x] AOS-1553…1560 : préparation statique de génération GPT-2 GGUF, rôles globaux, couches contiguës et dimensions déduites — [aos1553_1560_gguf_generation_prepare.md](aos1553_1560_gguf_generation_prepare.md)
 - [x] AOS-1561…1568 : exécution GPT-2 GGUF token-vers-logits sur FAT16, cache KV et workspace caller-owned — [aos1561_1568_gguf_token_logits.md](aos1561_1568_gguf_token_logits.md)
+- [x] AOS-1569…1576 : runtime GPT-2 GGUF local, disque FAT16 de déploiement, shell, top-k et lectures séquentielles — [aos1569_1576_gguf_local_shell.md](aos1569_1576_gguf_local_shell.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)
-- [x] Tests complets du système corrigé (`make test-all` : 450 tests exécutés avec succès ; `make qemu-smoke` et `make integration-qemu`)
+- [x] Tests complets du système corrigé (`make test-all` : 452 tests exécutés avec succès ; `make qemu-smoke`, `make qemu-gguf-smoke` et `make integration-qemu`)
 - [x] Validation du fonctionnement en mode utilisateur (QEMU GTK + `sendkey`)
 - [x] Commit et push des corrections sur GitHub
 - [x] Documentation des corrections apportées ([ETAT_REEL.md](ETAT_REEL.md))

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -202,7 +202,9 @@
 #define SYS_SOCKET_BUILD_SYN_ACK 107
 /* EBX = descripteur, ECX = os_socket_passive_view_t* avec ACK final. */
 #define SYS_SOCKET_ACCEPT_ACK 108
-#define MAX_SYSCALLS 109
+/* prompt (EBX), buffer de réponse (ECX), taille du buffer (EDX), backend GGUF FAT16. */
+#define SYS_GPT2_GGUF_GENERATE 109
+#define MAX_SYSCALLS 110
 
 typedef struct {
     uint16_t source_port;

--- a/kernel/fs/fat16.c
+++ b/kernel/fs/fat16.c
@@ -493,7 +493,8 @@ int fat16_open_file(const fat16_volume_t* v, const char* name, fat16_file_t* out
         if (!entry_matches(entry, short_name)) continue;
         if (entry[11] & 0x10U) return OS_FAT16_BAD_PATH;
         out->volume = v;
-        out->cluster = le16(entry + 26U);
+        out->first_cluster = le16(entry + 26U);
+        out->cluster = out->first_cluster;
         out->size = le32(entry + 28U);
         out->position = 0U;
         out->cluster_offset = 0U;
@@ -502,6 +503,38 @@ int fat16_open_file(const fat16_volume_t* v, const char* name, fat16_file_t* out
         return 0;
     }
     return OS_FAT16_NOT_FOUND;
+}
+
+int fat16_file_seek(fat16_file_t* file, uint32_t offset) {
+    const fat16_volume_t* v;
+    uint32_t cluster_bytes;
+    uint32_t steps;
+    uint32_t i;
+    if (!file || !file->open || !file->volume || offset > file->size) return OS_FAT16_BAD_PATH;
+    v = file->volume;
+    cluster_bytes = (uint32_t)v->sectors_per_cluster * FAT16_SECTOR_SIZE;
+    if (cluster_bytes == 0U) return OS_FAT16_CORRUPT;
+    file->cluster = file->first_cluster;
+    file->position = 0U;
+    file->cluster_offset = 0U;
+    file->guard = 0U;
+    if (offset == file->size) {
+        file->position = offset;
+        return 0;
+    }
+    steps = offset / cluster_bytes;
+    if (steps > v->cluster_count) return OS_FAT16_CORRUPT;
+    for (i = 0U; i < steps; i++) {
+        if (file->cluster < 2U || file->cluster >= FAT16_EOC_MIN ||
+            file->cluster - 2U >= v->cluster_count ||
+            read_fat_entry(v, file->cluster, &file->cluster) != 0) return OS_FAT16_CORRUPT;
+    }
+    if (file->cluster < 2U || file->cluster >= FAT16_EOC_MIN ||
+        file->cluster - 2U >= v->cluster_count) return OS_FAT16_CORRUPT;
+    file->position = offset;
+    file->cluster_offset = offset % cluster_bytes;
+    file->guard = steps;
+    return 0;
 }
 
 int fat16_file_read(fat16_file_t* file, uint8_t* buffer, uint32_t max,

--- a/kernel/fs/fat16.h
+++ b/kernel/fs/fat16.h
@@ -27,6 +27,7 @@ typedef struct {
 
 typedef struct {
     const fat16_volume_t* volume;
+    uint16_t first_cluster;
     uint16_t cluster;
     uint32_t size;
     uint32_t position;
@@ -73,6 +74,8 @@ int fat16_open_file(const fat16_volume_t* volume, const char* name,
                     fat16_file_t* out);
 int fat16_file_read(fat16_file_t* file, uint8_t* buffer, uint32_t max,
                     uint32_t* out_read);
+/* Positionne un curseur ouvert sur un offset, en parcourant seulement la FAT. */
+int fat16_file_seek(fat16_file_t* file, uint32_t offset);
 const char* fat16_status(void);
 
 #endif

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -14,6 +14,7 @@
 #include "fs/fat16.h"
 #include "llm/gpt2_model.h"
 #include "llm/gpt2_gguf.h"
+#include "llm/gpt2_gguf_infer.h"
 #include "llm/gpt2_infer.h"
 #include "llm/gpt2_tokenizer.h"
 #include "keyboard.h"
@@ -1105,15 +1106,15 @@ void kmain(uint32_t multiboot_magic, uint32_t multiboot_addr) {
                     print_string("\n");
                 }
             }
+            if (gpt2_tokenizer_load_from_initrd("models/gpt2_tokenizer.bin") == 0) {
+                print_string("Tokenizer GPT-2 local charge depuis l'initrd.\n");
+            } else {
+                print_string(gpt2_tokenizer_status());
+                print_string("\n");
+            }
             if (gpt2_model_load_from_initrd("models/gpt2_124M.bin") == 0) {
                 const gpt2_model_t* gpt2 = gpt2_model_current();
                 print_string("Modele GPT-2 local charge depuis l'initrd.\n");
-                if (gpt2_tokenizer_load_from_initrd("models/gpt2_tokenizer.bin") == 0) {
-                    print_string("Tokenizer GPT-2 local charge depuis l'initrd.\n");
-                } else {
-                    print_string(gpt2_tokenizer_status());
-                    print_string("\n");
-                }
                 /* Les mini-checkpoints de validation executent un jeton CPU au boot. */
                 if (gpt2->config.vocab_size <= 8 && gpt2->config.channels <= 16) {
                     uint32_t seed_token = 0;
@@ -1143,6 +1144,12 @@ void kmain(uint32_t multiboot_magic, uint32_t multiboot_addr) {
         if (fat16_mount(fat16_root(), fat16_ata_read_sector, 64U) == 0) {
             print_string(fat16_status());
             print_string("\n");
+            if (gpt2_gguf_infer_init_fat16(fat16_root(), "GPT2.GGU") == 0) {
+                print_string(gpt2_gguf_infer_status());
+                print_string("\n");
+            } else {
+                print_string("GGUF FAT16 optionnel indisponible; profil .gguf desactive.\n");
+            }
         } else {
             print_string(fat16_status());
             print_string("\n");

--- a/kernel/llm/gpt2_gguf.c
+++ b/kernel/llm/gpt2_gguf.c
@@ -338,8 +338,8 @@ int gpt2_gguf_find_tensor(const uint8_t* blob, uint32_t blob_size,
 }
 
 
-int gpt2_gguf_build_index(const uint8_t* blob, uint32_t blob_size,
-                          gpt2_gguf_index_t* out) {
+static int gpt2_gguf_build_index_sized(const uint8_t* blob, uint32_t header_size,
+                                         uint32_t file_size, gpt2_gguf_index_t* out) {
     uint32_t offset = 0U;
     uint32_t magic;
     uint32_t version;
@@ -348,49 +348,94 @@ int gpt2_gguf_build_index(const uint8_t* blob, uint32_t blob_size,
     uint32_t tensor_count;
     uint32_t metadata_count;
     uint32_t i;
-    int status;
+    gpt2_gguf_info_t info;
 
-    if (!blob || !out) return -1;
-    status = gpt2_gguf_probe_blob(blob, blob_size, &out->info);
-    if (status != 0) return status;
-    out->blob = blob;
-    out->blob_size = blob_size;
-    out->tensor_count = 0U;
-    if (gguf_read_u32(blob, blob_size, &offset, &magic) != 0 ||
-        gguf_read_u32(blob, blob_size, &offset, &version) != 0 ||
-        gguf_read_u64(blob, blob_size, &offset, &tensor_count64) != 0 ||
-        gguf_read_u64(blob, blob_size, &offset, &metadata_count64) != 0 ||
+    if (!blob || !out || header_size == 0U || file_size < header_size) return -1;
+    info.version = 0U;
+    info.tensor_count = 0U;
+    info.metadata_count = 0U;
+    info.alignment = GGUF_DEFAULT_ALIGNMENT;
+    info.tensor_data_offset = 0U;
+    info.f32_tensors = 0U;
+    info.q8_0_tensors = 0U;
+    info.q3_k_tensors = 0U;
+    info.q4_k_tensors = 0U;
+    info.q6_k_tensors = 0U;
+    info.unsupported_quantized_tensors = 0U;
+    info.is_gpt2 = 0U;
+    info.is_valid = 0U;
+
+    if (gguf_read_u32(blob, header_size, &offset, &magic) != 0 || magic != GPT2_GGUF_MAGIC ||
+        gguf_read_u32(blob, header_size, &offset, &version) != 0 || version != GPT2_GGUF_VERSION ||
+        gguf_read_u64(blob, header_size, &offset, &tensor_count64) != 0 ||
+        gguf_read_u64(blob, header_size, &offset, &metadata_count64) != 0 ||
         tensor_count64 > GPT2_GGUF_MAX_TENSORS || metadata_count64 > GGUF_MAX_METADATA) return -2;
     tensor_count = (uint32_t)tensor_count64;
     metadata_count = (uint32_t)metadata_count64;
+    info.version = version;
+    info.tensor_count = tensor_count;
+    info.metadata_count = metadata_count;
+
     for (i = 0U; i < metadata_count; i++) {
+        const uint8_t* key;
         uint32_t key_length;
         uint32_t type;
-        if (gguf_read_string(blob, blob_size, &offset, 0, &key_length) != 0 ||
-            gguf_read_u32(blob, blob_size, &offset, &type) != 0 ||
-            gguf_skip_value(blob, blob_size, &offset, type, 0U) != 0) return -3;
+        if (gguf_read_string(blob, header_size, &offset, &key, &key_length) != 0 ||
+            gguf_read_u32(blob, header_size, &offset, &type) != 0) return -3;
+        if (gguf_key_equals(key, key_length, "general.architecture")) {
+            if (gguf_is_gpt2_value(blob, header_size, &offset, type, &info.is_gpt2) != 0) return -4;
+        } else if (gguf_key_equals(key, key_length, "general.alignment")) {
+            if (gguf_read_alignment_value(blob, header_size, &offset, type, &info.alignment) != 0) return -5;
+        } else if (gguf_skip_value(blob, header_size, &offset, type, 0U) != 0) return -6;
     }
+
     for (i = 0U; i < tensor_count; i++) {
         gpt2_gguf_tensor_t* tensor = &out->tensors[i];
         uint64_t data_offset64;
         uint32_t j;
-        if (gguf_read_string(blob, blob_size, &offset, &tensor->name, &tensor->name_length) != 0 ||
-            gguf_read_u32(blob, blob_size, &offset, &tensor->dimensions) != 0 ||
-            tensor->dimensions == 0U || tensor->dimensions > GGUF_MAX_DIMS) return -4;
+        if (gguf_read_string(blob, header_size, &offset, &tensor->name, &tensor->name_length) != 0 ||
+            gguf_read_u32(blob, header_size, &offset, &tensor->dimensions) != 0 ||
+            tensor->dimensions == 0U || tensor->dimensions > GGUF_MAX_DIMS) return -7;
         for (j = 0U; j < GGUF_MAX_DIMS; j++) tensor->shape[j] = 0U;
         for (j = 0U; j < tensor->dimensions; j++) {
-            if (gguf_read_u64(blob, blob_size, &offset, &tensor->shape[j]) != 0) return -5;
+            if (gguf_read_u64(blob, header_size, &offset, &tensor->shape[j]) != 0 ||
+                tensor->shape[j] == 0U) return -8;
         }
-        if (gguf_read_u32(blob, blob_size, &offset, &tensor->type) != 0 ||
-            gguf_read_u64(blob, blob_size, &offset, &data_offset64) != 0 ||
-            data_offset64 > 0xffffffffULL ||
-            gguf_tensor_byte_size(tensor->type, tensor->shape, tensor->dimensions, &tensor->byte_size) != 0) return -6;
-        if (data_offset64 > (uint64_t)(blob_size - out->info.tensor_data_offset) ||
-            tensor->byte_size > blob_size - out->info.tensor_data_offset - (uint32_t)data_offset64) return -7;
+        if (gguf_read_u32(blob, header_size, &offset, &tensor->type) != 0 ||
+            gguf_read_u64(blob, header_size, &offset, &data_offset64) != 0 ||
+            data_offset64 > 0xffffffffULL || ((uint32_t)data_offset64 % info.alignment) != 0U ||
+            gguf_tensor_byte_size(tensor->type, tensor->shape, tensor->dimensions, &tensor->byte_size) != 0) return -9;
         tensor->data_offset = (uint32_t)data_offset64;
+        if (tensor->type == GPT2_GGUF_TENSOR_F32) info.f32_tensors++;
+        else if (tensor->type == GPT2_GGUF_TENSOR_Q8_0) info.q8_0_tensors++;
+        else if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) info.q3_k_tensors++;
+        else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) info.q4_k_tensors++;
+        else if (tensor->type == GPT2_GGUF_TENSOR_Q6_K) info.q6_k_tensors++;
+        else if (tensor->type != GPT2_GGUF_TENSOR_F16) info.unsupported_quantized_tensors++;
     }
+    if (!info.is_gpt2 || gguf_align(offset, info.alignment, &info.tensor_data_offset) != 0 ||
+        info.tensor_data_offset > file_size) return -10;
+    for (i = 0U; i < tensor_count; i++) {
+        gpt2_gguf_tensor_t* tensor = &out->tensors[i];
+        if (tensor->data_offset > file_size - info.tensor_data_offset ||
+            tensor->byte_size > file_size - info.tensor_data_offset - tensor->data_offset) return -11;
+    }
+    info.is_valid = 1U;
+    out->info = info;
+    out->blob = blob;
+    out->blob_size = file_size;
     out->tensor_count = tensor_count;
     return 0;
+}
+
+int gpt2_gguf_build_index(const uint8_t* blob, uint32_t blob_size,
+                          gpt2_gguf_index_t* out) {
+    return gpt2_gguf_build_index_sized(blob, blob_size, blob_size, out);
+}
+
+int gpt2_gguf_build_index_header(const uint8_t* blob, uint32_t header_size,
+                                 uint32_t file_size, gpt2_gguf_index_t* out) {
+    return gpt2_gguf_build_index_sized(blob, header_size, file_size, out);
 }
 
 int gpt2_gguf_index_find(const gpt2_gguf_index_t* index, const char* name,
@@ -436,14 +481,14 @@ int gpt2_gguf_map_layer_role(const gpt2_gguf_index_t* index, uint32_t layer,
     static const char* const suffixes[] = {
         "attn_norm.weight", "attn_norm.bias", "attn_qkv.weight", "attn_qkv.bias",
         "attn_output.weight", "attn_output.bias", "ffn_norm.weight", "ffn_norm.bias",
-        "ffn_up.weight", "ffn_down.weight"
+        "ffn_up.weight", "ffn_down.weight", "ffn_up.bias", "ffn_down.bias"
     };
     uint32_t digits[10];
     uint32_t count = 0U;
     uint32_t position = 0U;
     uint32_t i;
     if (!index || !name || !out || capacity == 0U || (uint32_t)role < 5U ||
-        (uint32_t)role >= 15U) return -1;
+        (uint32_t)role >= 17U) return -1;
     if (gguf_append_name(name, capacity, &position, "blk." ) != 0) return -2;
     do {
         digits[count++] = layer % 10U;
@@ -469,7 +514,7 @@ int gpt2_gguf_map_layer(const gpt2_gguf_index_t* index, uint32_t layer,
     if (!index || !name || !out || capacity == 0U) return -1;
     out->layer_index = layer;
     out->present_mask = 0U;
-    for (i = 0U; i < 10U; i++) {
+    for (i = 0U; i < 12U; i++) {
         status = gpt2_gguf_map_layer_role(index, layer,
             (gpt2_gguf_role_t)(GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT + i),
             name, capacity, &out->tensors[i]);
@@ -484,7 +529,7 @@ int gpt2_gguf_layer_get(const gpt2_gguf_layer_t* layer, gpt2_gguf_role_t role,
                         gpt2_gguf_tensor_t* out) {
     uint32_t index;
     if (!layer || !out || (uint32_t)role < GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT ||
-        (uint32_t)role > GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT) return -1;
+        (uint32_t)role > GPT2_GGUF_ROLE_LAYER_FFN_DOWN_BIAS) return -1;
     index = (uint32_t)role - GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT;
     if ((layer->present_mask & (1U << index)) == 0U) return -8;
     *out = layer->tensors[index];
@@ -495,9 +540,9 @@ int gpt2_gguf_layer_get(const gpt2_gguf_layer_t* layer, gpt2_gguf_role_t role,
 int gpt2_gguf_validate_layer(const gpt2_gguf_layer_t* layer, uint32_t channels) {
     uint32_t i;
     if (!layer) return -1;
-    if (layer->present_mask != 0x3FFU) return -8;
+    if (layer->present_mask != 0xFFFU) return -8;
     if (channels == 0U || (channels % GPT2_QK_K) != 0U) return -9;
-    for (i = 0U; i < 10U; i++) {
+    for (i = 0U; i < 12U; i++) {
         const gpt2_gguf_tensor_t* tensor = &layer->tensors[i];
         if (tensor->dimensions == 0U || tensor->dimensions > 2U ||
             tensor->shape[0] == 0U || tensor->byte_size == 0U) return -9;
@@ -520,7 +565,7 @@ static int gpt2_gguf_shape_is(const gpt2_gguf_tensor_t* tensor, uint64_t first,
 
 int gpt2_gguf_validate_gpt2_layer(const gpt2_gguf_layer_t* layer, uint32_t channels) {
     const gpt2_gguf_tensor_t* t;
-    if (!layer || channels == 0U || layer->present_mask != 0x3FFU) return -8;
+    if (!layer || channels == 0U || layer->present_mask != 0xFFFU) return -8;
     if ((channels % GPT2_QK_K) != 0U) return -9;
     t = &layer->tensors[0]; if (!gpt2_gguf_shape_is(t, channels, 0U)) return -9;
     t = &layer->tensors[1]; if (!gpt2_gguf_shape_is(t, channels, 0U)) return -9;
@@ -532,6 +577,8 @@ int gpt2_gguf_validate_gpt2_layer(const gpt2_gguf_layer_t* layer, uint32_t chann
     t = &layer->tensors[7]; if (!gpt2_gguf_shape_is(t, channels, 0U)) return -9;
     t = &layer->tensors[8]; if (!gpt2_gguf_shape_is(t, channels, 4U * channels)) return -9;
     t = &layer->tensors[9]; if (!gpt2_gguf_shape_is(t, 4U * channels, channels)) return -9;
+    t = &layer->tensors[10]; if (!gpt2_gguf_shape_is(t, 4U * channels, 0U)) return -9;
+    t = &layer->tensors[11]; if (!gpt2_gguf_shape_is(t, channels, 0U)) return -9;
     return 0;
 }
 
@@ -573,7 +620,7 @@ int gpt2_gguf_validate_gpt2_layer_storage(const gpt2_gguf_layer_t* layer, uint32
     uint32_t i;
     int status = gpt2_gguf_validate_gpt2_layer(layer, channels);
     if (status != 0) return status;
-    for (i = 0U; i < 10U; i++) {
+    for (i = 0U; i < 12U; i++) {
         status = gpt2_gguf_validate_tensor_size(&layer->tensors[i]);
         if (status != 0) return status;
     }

--- a/kernel/llm/gpt2_gguf.h
+++ b/kernel/llm/gpt2_gguf.h
@@ -58,7 +58,9 @@ typedef enum {
     GPT2_GGUF_ROLE_LAYER_FFN_NORM_WEIGHT = 11U,
     GPT2_GGUF_ROLE_LAYER_FFN_NORM_BIAS = 12U,
     GPT2_GGUF_ROLE_LAYER_FFN_UP_WEIGHT = 13U,
-    GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT = 14U
+    GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT = 14U,
+    GPT2_GGUF_ROLE_LAYER_FFN_UP_BIAS = 15U,
+    GPT2_GGUF_ROLE_LAYER_FFN_DOWN_BIAS = 16U
 } gpt2_gguf_role_t;
 
 typedef struct {
@@ -78,7 +80,7 @@ typedef struct {
 } gpt2_gguf_info_t;
 
 typedef struct {
-    gpt2_gguf_tensor_t tensors[10];
+    gpt2_gguf_tensor_t tensors[12];
     uint32_t layer_index;
     uint32_t present_mask;
 } gpt2_gguf_layer_t;
@@ -106,6 +108,10 @@ int gpt2_gguf_find_tensor(const uint8_t* blob, uint32_t blob_size,
 /* Builds a caller-owned table so repeated lookups do not rescan the blob. */
 int gpt2_gguf_build_index(const uint8_t* blob, uint32_t blob_size,
                           gpt2_gguf_index_t* out);
+/* Indexe un en-tête GGUF déjà chargé. `header_size` borne toute lecture mémoire,
+ * tandis que `file_size` valide les plages des tenseurs laissés sur FAT16. */
+int gpt2_gguf_build_index_header(const uint8_t* blob, uint32_t header_size,
+                                 uint32_t file_size, gpt2_gguf_index_t* out);
 int gpt2_gguf_index_find(const gpt2_gguf_index_t* index, const char* name,
                          gpt2_gguf_tensor_t* out);
 /* Maps the stable GPT-2 GGUF names to semantic model roles. */

--- a/kernel/llm/gpt2_gguf_infer.c
+++ b/kernel/llm/gpt2_gguf_infer.c
@@ -1,0 +1,225 @@
+#include "gpt2_gguf_infer.h"
+#include "gpt2_gguf_loader.h"
+#include "gpt2_sample.h"
+
+#define GPT2_GGUF_INFER_HIDDEN (4U * GPT2_GGUF_INFER_MAX_CHANNELS)
+#define GPT2_GGUF_INFER_DENSE_BYTES (GPT2_GGUF_INFER_HIDDEN * (uint32_t)sizeof(float))
+#define GPT2_GGUF_INFER_ROW_BYTES (3U * GPT2_Q6_K_BLOCK_BYTES)
+#define GPT2_GGUF_INFER_FILENAME_MAX 13U
+
+static uint8_t gguf_header[GPT2_GGUF_INFER_HEADER_BYTES];
+static gpt2_gguf_loaded_model_t gguf_model;
+static gpt2_gguf_layer_t gguf_layers[GPT2_GGUF_INFER_MAX_LAYERS];
+static gpt2_gguf_generation_t gguf_generation;
+static gpt2_gguf_kv_cache_t gguf_cache;
+static gpt2_gguf_generation_workspace_t gguf_workspace;
+static const fat16_volume_t* gguf_volume;
+static char gguf_filename[GPT2_GGUF_INFER_FILENAME_MAX];
+static char gguf_layer_name[64];
+static uint32_t gguf_cache_tokens[GPT2_GGUF_INFER_MAX_CONTEXT];
+
+static float gguf_kv_storage[GPT2_GGUF_INFER_MAX_LAYERS * GPT2_GGUF_INFER_MAX_CONTEXT *
+                             2U * GPT2_GGUF_INFER_MAX_CHANNELS];
+static uint8_t gguf_dense_scratch[GPT2_GGUF_INFER_DENSE_BYTES];
+static uint8_t gguf_row_buffer[GPT2_GGUF_INFER_ROW_BYTES];
+static float gguf_position_embedding[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_attention_gamma[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_attention_beta[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_qkv_bias[3U * GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_attention_output_bias[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_ffn_gamma[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_ffn_beta[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_ffn_up_bias[GPT2_GGUF_INFER_HIDDEN];
+static float gguf_ffn_down_bias[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_final_gamma[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_final_beta[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_final_hidden[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_norm[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_query[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_key[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_value[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_head_outputs[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_key_scratch[GPT2_GGUF_INFER_MAX_CHANNELS / GPT2_GGUF_INFER_HEADS];
+static float gguf_scores[GPT2_GGUF_INFER_MAX_CONTEXT];
+static float gguf_attention[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_projected[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_hidden[GPT2_GGUF_INFER_HIDDEN];
+static float gguf_mlp_output[GPT2_GGUF_INFER_MAX_CHANNELS];
+static float gguf_logits[GPT2_GGUF_INFER_MAX_VOCAB];
+static uint8_t gguf_ready;
+static const char* gguf_status = "GGUF: profil local non initialise";
+
+static int gpt2_gguf_copy_filename(const char* filename) {
+    uint32_t i = 0U;
+    if (!filename) return -1;
+    while (filename[i] != '\0') {
+        if (i + 1U >= GPT2_GGUF_INFER_FILENAME_MAX) return -1;
+        gguf_filename[i] = filename[i];
+        i++;
+    }
+    if (i == 0U) return -1;
+    gguf_filename[i] = '\0';
+    return 0;
+}
+
+static void gpt2_gguf_workspace_bind(void) {
+    gguf_workspace.dense_scratch = gguf_dense_scratch;
+    gguf_workspace.dense_scratch_capacity = sizeof(gguf_dense_scratch);
+    gguf_workspace.position_embedding = gguf_position_embedding;
+    gguf_workspace.position_embedding_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.attention_gamma = gguf_attention_gamma;
+    gguf_workspace.attention_gamma_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.attention_beta = gguf_attention_beta;
+    gguf_workspace.attention_beta_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.qkv_bias = gguf_qkv_bias;
+    gguf_workspace.qkv_bias_capacity = 3U * GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.attention_output_bias = gguf_attention_output_bias;
+    gguf_workspace.attention_output_bias_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.ffn_gamma = gguf_ffn_gamma;
+    gguf_workspace.ffn_gamma_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.ffn_beta = gguf_ffn_beta;
+    gguf_workspace.ffn_beta_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.ffn_up_bias = gguf_ffn_up_bias;
+    gguf_workspace.ffn_up_bias_capacity = GPT2_GGUF_INFER_HIDDEN;
+    gguf_workspace.ffn_down_bias = gguf_ffn_down_bias;
+    gguf_workspace.ffn_down_bias_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.final_gamma = gguf_final_gamma;
+    gguf_workspace.final_gamma_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.final_beta = gguf_final_beta;
+    gguf_workspace.final_beta_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.final_hidden = gguf_final_hidden;
+    gguf_workspace.final_hidden_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.block.norm = gguf_norm;
+    gguf_workspace.block.norm_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.block.query = gguf_query;
+    gguf_workspace.block.query_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.block.key = gguf_key;
+    gguf_workspace.block.key_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.block.value = gguf_value;
+    gguf_workspace.block.value_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.block.head_outputs = gguf_head_outputs;
+    gguf_workspace.block.head_output_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.block.key_scratch = gguf_key_scratch;
+    gguf_workspace.block.key_scratch_capacity = GPT2_GGUF_INFER_MAX_CHANNELS / GPT2_GGUF_INFER_HEADS;
+    gguf_workspace.block.scores = gguf_scores;
+    gguf_workspace.block.score_capacity = GPT2_GGUF_INFER_MAX_CONTEXT;
+    gguf_workspace.block.attention = gguf_attention;
+    gguf_workspace.block.attention_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.block.projected = gguf_projected;
+    gguf_workspace.block.projected_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.block.hidden = gguf_hidden;
+    gguf_workspace.block.hidden_capacity = GPT2_GGUF_INFER_HIDDEN;
+    gguf_workspace.block.mlp_output = gguf_mlp_output;
+    gguf_workspace.block.mlp_output_capacity = GPT2_GGUF_INFER_MAX_CHANNELS;
+    gguf_workspace.block.row_buffer = gguf_row_buffer;
+    gguf_workspace.block.row_capacity = sizeof(gguf_row_buffer);
+}
+
+int gpt2_gguf_infer_init_fat16(const fat16_volume_t* volume, const char* filename) {
+    int status;
+    gguf_ready = 0U;
+    gguf_status = "GGUF: profil local non initialise";
+    if (!volume || gpt2_gguf_copy_filename(filename) != 0) {
+        gguf_status = "GGUF: nom FAT16 invalide";
+        return -1;
+    }
+    status = gpt2_gguf_load_fat16_header(volume, gguf_filename, gguf_header,
+                                         sizeof(gguf_header), &gguf_model);
+    if (status != 0) {
+        gguf_status = "GGUF: catalogue FAT16 indisponible";
+        return status;
+    }
+    status = gpt2_gguf_generation_prepare(&gguf_model, gguf_layer_name,
+                                           sizeof(gguf_layer_name), gguf_layers,
+                                           GPT2_GGUF_INFER_MAX_LAYERS,
+                                           &gguf_generation);
+    if (status != 0) {
+        gguf_status = "GGUF: roles GPT-2 incompatibles";
+        return status;
+    }
+    if (gguf_generation.runtime.layer_count == 0U ||
+        gguf_generation.runtime.layer_count > GPT2_GGUF_INFER_MAX_LAYERS ||
+        gguf_generation.runtime.channels == 0U ||
+        gguf_generation.runtime.channels > GPT2_GGUF_INFER_MAX_CHANNELS ||
+        gguf_generation.runtime.channels % GPT2_GGUF_INFER_HEADS != 0U ||
+        gguf_generation.vocabulary == 0U ||
+        gguf_generation.vocabulary > GPT2_GGUF_INFER_MAX_VOCAB ||
+        gguf_generation.max_positions == 0U) {
+        gguf_status = "GGUF: profil hors bornes statiques";
+        return -6;
+    }
+    status = gpt2_gguf_kv_cache_init(gguf_kv_storage, sizeof(gguf_kv_storage) / sizeof(float),
+                                      gguf_generation.runtime.layer_count,
+                                      GPT2_GGUF_INFER_MAX_CONTEXT,
+                                      gguf_generation.runtime.channels, &gguf_cache);
+    if (status != 0) {
+        gguf_status = "GGUF: cache KV statique insuffisant";
+        return status;
+    }
+    gpt2_gguf_workspace_bind();
+    gguf_volume = volume;
+    gguf_ready = 1U;
+    gguf_status = "GGUF: profil local FAT16 pret (cache KV actif)";
+    return 0;
+}
+
+static int gpt2_gguf_cache_matches(const uint32_t* tokens, uint32_t count) {
+    uint32_t i;
+    if (gguf_cache.count > count) return 0;
+    for (i = 0U; i < gguf_cache.count; i++) {
+        if (gguf_cache_tokens[i] != tokens[i]) return 0;
+    }
+    return 1;
+}
+
+int gpt2_gguf_generate_next_sampled(const uint32_t* tokens, uint32_t token_count,
+                                    uint32_t generated_count, uint32_t* next_token,
+                                    uint32_t* rng_state) {
+    uint32_t generated = generated_count;
+    uint32_t i;
+    int status;
+    if (!tokens || !next_token || !gguf_ready || !gguf_volume) {
+        gguf_status = "GGUF: profil local indisponible";
+        return -1;
+    }
+    if (token_count == 0U || token_count > GPT2_GGUF_INFER_MAX_CONTEXT ||
+        token_count > gguf_generation.max_positions) {
+        gguf_status = "GGUF: taille de contexte non supportee";
+        return -2;
+    }
+    for (i = 0U; i < token_count; i++) {
+        if (tokens[i] >= gguf_generation.vocabulary) {
+            gguf_status = "GGUF: identifiant de jeton invalide";
+            return -3;
+        }
+    }
+    if (!gpt2_gguf_cache_matches(tokens, token_count)) gpt2_gguf_kv_cache_reset(&gguf_cache);
+    while (gguf_cache.count < token_count) {
+        uint32_t position = gguf_cache.count;
+        status = gpt2_gguf_generation_token_fat16(&gguf_generation, &gguf_cache,
+                                                   tokens[position], position,
+                                                   GPT2_GGUF_INFER_HEADS, 0.00001f,
+                                                   gguf_volume, gguf_filename,
+                                                   &gguf_workspace, gguf_logits,
+                                                   sizeof(gguf_logits));
+        if (status != 0) {
+            gguf_status = "GGUF: echec de lecture ou forward FAT16";
+            return -20 + status;
+        }
+        gguf_cache_tokens[position] = tokens[position];
+    }
+    if (generated > token_count) generated = token_count;
+    *next_token = gpt2_sample_top_k(gguf_logits, gguf_generation.vocabulary,
+                                    generated ? tokens + token_count - generated : 0,
+                                    generated, rng_state);
+    gguf_status = "GGUF: jeton echantillonne localement (cache KV FAT16 actif)";
+    return 0;
+}
+
+int gpt2_gguf_infer_ready(void) {
+    return gguf_ready ? 1 : 0;
+}
+
+const char* gpt2_gguf_infer_status(void) {
+    return gguf_status;
+}

--- a/kernel/llm/gpt2_gguf_infer.h
+++ b/kernel/llm/gpt2_gguf_infer.h
@@ -1,0 +1,27 @@
+#ifndef AIOS_GPT2_GGUF_INFER_H
+#define AIOS_GPT2_GGUF_INFER_H
+
+#include <stdint.h>
+#include "../fs/fat16.h"
+
+/* Limites statiques du profil GPT-2 124M GGUF local. Les poids restent sur
+ * FAT16 ; seul le catalogue et le workspace sont résidents. */
+#define GPT2_GGUF_INFER_HEADER_BYTES (2U * 1024U * 1024U)
+#define GPT2_GGUF_INFER_MAX_CONTEXT 64U
+#define GPT2_GGUF_INFER_MAX_LAYERS 12U
+#define GPT2_GGUF_INFER_MAX_CHANNELS 768U
+#define GPT2_GGUF_INFER_MAX_VOCAB 50257U
+#define GPT2_GGUF_INFER_HEADS 12U
+
+/* Initialise le profil GGUF depuis un fichier FAT16 8.3, sans charger ses
+ * poids. Le fichier doit contenir un GPT-2 compatible avec les bornes ci-dessus. */
+int gpt2_gguf_infer_init_fat16(const fat16_volume_t* volume, const char* filename);
+/* Échantillonne le prochain token avec cache KV persistant et préfixe borné. */
+int gpt2_gguf_generate_next_sampled(const uint32_t* tokens, uint32_t token_count,
+                                    uint32_t generated_count, uint32_t* next_token,
+                                    uint32_t* rng_state);
+/* Indique la disponibilité du profil GGUF local. */
+int gpt2_gguf_infer_ready(void);
+const char* gpt2_gguf_infer_status(void);
+
+#endif

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -16,6 +16,28 @@ int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,
     return 0;
 }
 
+int gpt2_gguf_load_fat16_header(const fat16_volume_t* volume, const char* filename,
+                                uint8_t* header, uint32_t header_capacity,
+                                gpt2_gguf_loaded_model_t* out) {
+    fat16_file_t file;
+    uint32_t read = 0U;
+    uint32_t requested;
+    int status;
+    if (!volume || !filename || !header || header_capacity == 0U || !out) return -1;
+    if (!fat16_is_mounted(volume)) return OS_FAT16_NOT_MOUNTED;
+    status = fat16_open_file(volume, filename, &file);
+    if (status != 0) return status;
+    if (file.size == 0U) return -2;
+    requested = file.size < header_capacity ? file.size : header_capacity;
+    status = fat16_read_file_range(volume, filename, 0U, header, requested, &read);
+    if (status != 0) return status;
+    if (read == 0U) return -2;
+    status = gpt2_gguf_build_index_header(header, read, file.size, &out->index);
+    if (status != 0) return -100 + status;
+    out->bytes_loaded = read;
+    return 0;
+}
+
 
 int gpt2_gguf_read_tensor_fat16(const fat16_volume_t* volume, const char* filename,
                                 const gpt2_gguf_loaded_model_t* model,
@@ -294,7 +316,10 @@ int gpt2_gguf_generation_prepare(const gpt2_gguf_loaded_model_t* model,
         prepared.output_weight.shape[0] != channels ||
         prepared.output_weight.shape[1] != prepared.token_embedding.shape[1]) return -9;
     if ((prepared.token_embedding.type != GPT2_GGUF_TENSOR_F32 &&
-         prepared.token_embedding.type != GPT2_GGUF_TENSOR_F16) ||
+         prepared.token_embedding.type != GPT2_GGUF_TENSOR_F16 &&
+         prepared.token_embedding.type != GPT2_GGUF_TENSOR_Q3_K &&
+         prepared.token_embedding.type != GPT2_GGUF_TENSOR_Q4_K &&
+         prepared.token_embedding.type != GPT2_GGUF_TENSOR_Q6_K) ||
         (prepared.position_embedding.type != GPT2_GGUF_TENSOR_F32 &&
          prepared.position_embedding.type != GPT2_GGUF_TENSOR_F16) ||
         (prepared.output_norm_weight.type != GPT2_GGUF_TENSOR_F32 &&
@@ -399,6 +424,33 @@ int gpt2_gguf_read_quant_row_fat16(const fat16_volume_t* volume, const char* fil
     return 0;
 }
 
+int gpt2_gguf_read_quant_row_dequant_fat16(const fat16_volume_t* volume,
+                                           const char* filename,
+                                           const gpt2_gguf_loaded_model_t* model,
+                                           const gpt2_gguf_tensor_t* tensor,
+                                           uint32_t row_index, uint8_t* row_buffer,
+                                           uint32_t row_capacity, float* output,
+                                           uint32_t output_capacity) {
+    uint32_t read = 0U;
+    uint32_t width;
+    int status;
+    if (!tensor || !row_buffer || !output || tensor->dimensions == 0U ||
+        tensor->dimensions > 2U || tensor->shape[0] == 0U ||
+        tensor->shape[0] > 0xFFFFFFFFULL) return -1;
+    width = (uint32_t)tensor->shape[0];
+    if (output_capacity < width) return -6;
+    status = gpt2_gguf_read_quant_row_fat16(volume, filename, model, tensor,
+                                             row_index, row_buffer, row_capacity, &read);
+    if (status != 0) return status;
+    if (tensor->type == GPT2_GGUF_TENSOR_Q3_K)
+        return gpt2_q3_k_dequantize(row_buffer, width, output);
+    if (tensor->type == GPT2_GGUF_TENSOR_Q4_K)
+        return gpt2_q4_k_dequantize(row_buffer, width, output);
+    if (tensor->type == GPT2_GGUF_TENSOR_Q6_K)
+        return gpt2_q6_k_dequantize(row_buffer, width, output);
+    return -4;
+}
+
 
 int gpt2_gguf_dot_quant_row_buffer(const gpt2_gguf_tensor_t* tensor,
                                    const uint8_t* row_buffer, uint32_t row_capacity,
@@ -453,17 +505,42 @@ int gpt2_gguf_project_qkv_fat16(const fat16_volume_t* volume, const char* filena
                                 uint32_t row_capacity, float* query, uint32_t query_capacity,
                                 float* key, uint32_t key_capacity,
                                 float* value, uint32_t value_capacity) {
+    fat16_file_t file;
     uint32_t output_index;
+    uint32_t block_bytes;
+    uint32_t row_bytes;
+    uint32_t offset;
     int status;
-    if (!query || !key || !value || channels == 0U ||
+    if (!volume || !filename || !model || !tensor || !input || !row_buffer ||
+        !query || !key || !value || channels == 0U ||
         query_capacity < channels * sizeof(float) ||
         key_capacity < channels * sizeof(float) ||
         value_capacity < channels * sizeof(float)) return -6;
+    if (tensor->dimensions != 2U || tensor->shape[0] != channels ||
+        tensor->shape[1] != 3ULL * channels) return -9;
+    if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) block_bytes = GPT2_Q3_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) block_bytes = GPT2_Q4_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q6_K) block_bytes = GPT2_Q6_K_BLOCK_BYTES;
+    else return -4;
+    if ((channels % GPT2_QK_K) != 0U ||
+        channels / GPT2_QK_K > 0xFFFFFFFFU / block_bytes) return -7;
+    row_bytes = (channels / GPT2_QK_K) * block_bytes;
+    if (row_bytes == 0U || row_capacity < row_bytes ||
+        model->index.info.tensor_data_offset > 0xFFFFFFFFU - tensor->data_offset) return -6;
+    offset = model->index.info.tensor_data_offset + tensor->data_offset;
+    status = fat16_open_file(volume, filename, &file);
+    if (status != 0) return status;
+    if (offset > file.size || tensor->byte_size > file.size - offset) return -3;
+    status = fat16_file_seek(&file, offset);
+    if (status != 0) return status;
     for (output_index = 0U; output_index < 3U * channels; output_index++) {
         float result = 0.0f;
-        status = gpt2_gguf_project_qkv_row_fat16(volume, filename, model, tensor, channels,
-                                                  output_index, input, row_buffer,
-                                                  row_capacity, &result);
+        uint32_t read = 0U;
+        status = fat16_file_read(&file, row_buffer, row_bytes, &read);
+        if (status != 0) return status;
+        if (read != row_bytes) return -8;
+        status = gpt2_gguf_dot_quant_row_buffer(tensor, row_buffer, read,
+                                                input, channels, &result);
         if (status != 0) return status;
         if (output_index < channels) query[output_index] = result;
         else if (output_index < 2U * channels) key[output_index - channels] = result;
@@ -480,18 +557,37 @@ int gpt2_gguf_project_matrix_fat16(const fat16_volume_t* volume, const char* fil
                                    const float* input, uint8_t* row_buffer,
                                    uint32_t row_capacity, float* output,
                                    uint32_t output_capacity) {
+    fat16_file_t file;
     uint32_t row;
+    uint32_t block_bytes;
+    uint32_t row_bytes;
+    uint32_t offset;
     int status;
     if (!volume || !filename || !model || !tensor || !input || !row_buffer || !output) return -1;
     if (input_channels == 0U || output_channels == 0U ||
         tensor->dimensions != 2U || tensor->shape[0] != input_channels ||
         tensor->shape[1] != output_channels) return -9;
     if (output_capacity < output_channels * sizeof(float)) return -6;
+    if (tensor->type == GPT2_GGUF_TENSOR_Q3_K) block_bytes = GPT2_Q3_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q4_K) block_bytes = GPT2_Q4_K_BLOCK_BYTES;
+    else if (tensor->type == GPT2_GGUF_TENSOR_Q6_K) block_bytes = GPT2_Q6_K_BLOCK_BYTES;
+    else return -4;
+    if ((input_channels % GPT2_QK_K) != 0U ||
+        input_channels / GPT2_QK_K > 0xFFFFFFFFU / block_bytes) return -7;
+    row_bytes = (input_channels / GPT2_QK_K) * block_bytes;
+    if (row_bytes == 0U || row_capacity < row_bytes ||
+        model->index.info.tensor_data_offset > 0xFFFFFFFFU - tensor->data_offset) return -6;
+    offset = model->index.info.tensor_data_offset + tensor->data_offset;
+    status = fat16_open_file(volume, filename, &file);
+    if (status != 0) return status;
+    if (offset > file.size || tensor->byte_size > file.size - offset) return -3;
+    status = fat16_file_seek(&file, offset);
+    if (status != 0) return status;
     for (row = 0U; row < output_channels; row++) {
         uint32_t read = 0U;
-        status = gpt2_gguf_read_quant_row_fat16(volume, filename, model, tensor,
-                                                row, row_buffer, row_capacity, &read);
+        status = fat16_file_read(&file, row_buffer, row_bytes, &read);
         if (status != 0) return status;
+        if (read != row_bytes) return -8;
         status = gpt2_gguf_dot_quant_row_buffer(tensor, row_buffer, read,
                                                 input, input_channels, &output[row]);
         if (status != 0) return status;
@@ -516,10 +612,37 @@ int gpt2_gguf_forward_output_logits_fat16(const fat16_volume_t* volume,
         (output_tensor->type != GPT2_GGUF_TENSOR_Q3_K &&
          output_tensor->type != GPT2_GGUF_TENSOR_Q4_K &&
          output_tensor->type != GPT2_GGUF_TENSOR_Q6_K)) return -9;
+    fat16_file_t file;
+    uint32_t block_bytes;
+    uint32_t row_bytes;
+    uint32_t offset;
+    uint32_t row;
+    int status;
     if (logits_capacity < vocabulary * (uint32_t)sizeof(float)) return -6;
-    return gpt2_gguf_project_matrix_fat16(volume, filename, model, output_tensor,
-                                          channels, vocabulary, hidden, row_buffer,
-                                          row_capacity, logits, logits_capacity);
+    if (output_tensor->type == GPT2_GGUF_TENSOR_Q3_K) block_bytes = GPT2_Q3_K_BLOCK_BYTES;
+    else if (output_tensor->type == GPT2_GGUF_TENSOR_Q4_K) block_bytes = GPT2_Q4_K_BLOCK_BYTES;
+    else block_bytes = GPT2_Q6_K_BLOCK_BYTES;
+    if ((channels % GPT2_QK_K) != 0U ||
+        channels / GPT2_QK_K > 0xFFFFFFFFU / block_bytes) return -7;
+    row_bytes = (channels / GPT2_QK_K) * block_bytes;
+    if (row_bytes == 0U || row_capacity < row_bytes ||
+        model->index.info.tensor_data_offset > 0xFFFFFFFFU - output_tensor->data_offset) return -6;
+    offset = model->index.info.tensor_data_offset + output_tensor->data_offset;
+    status = fat16_open_file(volume, filename, &file);
+    if (status != 0) return status;
+    if (offset > file.size || output_tensor->byte_size > file.size - offset) return -3;
+    status = fat16_file_seek(&file, offset);
+    if (status != 0) return status;
+    for (row = 0U; row < vocabulary; row++) {
+        uint32_t read = 0U;
+        status = fat16_file_read(&file, row_buffer, row_bytes, &read);
+        if (status != 0) return status;
+        if (read != row_bytes) return -8;
+        status = gpt2_gguf_dot_quant_row_buffer(output_tensor, row_buffer, read,
+                                                hidden, channels, &logits[row]);
+        if (status != 0) return status;
+    }
+    return 0;
 }
 
 static int gpt2_gguf_kv_cache_offset(const gpt2_gguf_kv_cache_t* cache,
@@ -1106,6 +1229,7 @@ int gpt2_gguf_generation_token_fat16(
     gpt2_gguf_tensor_t attention_gamma, attention_beta, qkv, qkv_bias;
     gpt2_gguf_tensor_t attention_output, attention_output_bias;
     gpt2_gguf_tensor_t ffn_gamma, ffn_beta, ffn_up, ffn_down;
+    gpt2_gguf_tensor_t ffn_up_bias, ffn_down_bias;
     uint32_t channels;
     uint32_t hidden_channels;
     uint32_t layer_index;
@@ -1116,27 +1240,41 @@ int gpt2_gguf_generation_token_fat16(
         !workspace->position_embedding || !workspace->attention_gamma ||
         !workspace->attention_beta || !workspace->qkv_bias ||
         !workspace->attention_output_bias || !workspace->ffn_gamma ||
-        !workspace->ffn_beta || !workspace->final_gamma || !workspace->final_beta ||
+        !workspace->ffn_beta || !workspace->ffn_up_bias || !workspace->ffn_down_bias ||
+        !workspace->final_gamma || !workspace->final_beta ||
         !workspace->final_hidden) return -1;
     channels = generation->runtime.channels;
     if (channels == 0U || channels > 0x3FFFFFFFU || head_count == 0U ||
         channels % head_count != 0U || epsilon <= 0.0f ||
         token >= generation->vocabulary || position >= generation->max_positions ||
         cache->layers != generation->runtime.layer_count || cache->channels != channels ||
-        cache->max_positions < generation->max_positions || position != cache->count) return -9;
+        position >= cache->max_positions || position != cache->count) return -9;
     if (workspace->position_embedding_capacity < channels ||
         workspace->attention_gamma_capacity < channels ||
         workspace->attention_beta_capacity < channels ||
         workspace->qkv_bias_capacity < 3U * channels ||
         workspace->attention_output_bias_capacity < channels ||
         workspace->ffn_gamma_capacity < channels || workspace->ffn_beta_capacity < channels ||
+        workspace->ffn_down_bias_capacity < channels ||
         workspace->final_gamma_capacity < channels || workspace->final_beta_capacity < channels ||
         workspace->final_hidden_capacity < channels ||
         logits_capacity < generation->vocabulary * (uint32_t)sizeof(float)) return -6;
-    status = gpt2_gguf_read_dense_row_fat16(volume, filename, generation->runtime.model,
-                                             &generation->token_embedding, token, channels,
-                                             workspace->dense_scratch, workspace->dense_scratch_capacity,
-                                             workspace->final_hidden, workspace->final_hidden_capacity * (uint32_t)sizeof(float));
+    if (generation->token_embedding.type == GPT2_GGUF_TENSOR_F32 ||
+        generation->token_embedding.type == GPT2_GGUF_TENSOR_F16) {
+        status = gpt2_gguf_read_dense_row_fat16(volume, filename, generation->runtime.model,
+                                                 &generation->token_embedding, token, channels,
+                                                 workspace->dense_scratch, workspace->dense_scratch_capacity,
+                                                 workspace->final_hidden,
+                                                 workspace->final_hidden_capacity * (uint32_t)sizeof(float));
+    } else {
+        status = gpt2_gguf_read_quant_row_dequant_fat16(volume, filename,
+                                                         generation->runtime.model,
+                                                         &generation->token_embedding, token,
+                                                         workspace->dense_scratch,
+                                                         workspace->dense_scratch_capacity,
+                                                         workspace->final_hidden,
+                                                         workspace->final_hidden_capacity);
+    }
     if (status != 0) return status;
     status = gpt2_gguf_read_dense_row_fat16(volume, filename, generation->runtime.model,
                                              &generation->position_embedding, position, channels,
@@ -1157,10 +1295,13 @@ int gpt2_gguf_generation_token_fat16(
             gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_NORM_WEIGHT, &ffn_gamma) != 0 ||
             gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_NORM_BIAS, &ffn_beta) != 0 ||
             gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_UP_WEIGHT, &ffn_up) != 0 ||
-            gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT, &ffn_down) != 0) return -8;
+            gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT, &ffn_down) != 0 ||
+            gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_UP_BIAS, &ffn_up_bias) != 0 ||
+            gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_DOWN_BIAS, &ffn_down_bias) != 0) return -8;
         hidden_channels = (uint32_t)ffn_up.shape[1];
         if (hidden_channels == 0U || hidden_channels > 0xFFFFFFFFU / (uint32_t)sizeof(float)) return -9;
-        if (workspace->block.hidden_capacity < hidden_channels) return -6;
+        if (workspace->block.hidden_capacity < hidden_channels ||
+            workspace->ffn_up_bias_capacity < hidden_channels) return -6;
         status = gpt2_gguf_read_dense_row_fat16(volume, filename, generation->runtime.model,
                                                  &attention_gamma, 0U, channels,
                                                  workspace->dense_scratch, workspace->dense_scratch_capacity,
@@ -1194,12 +1335,25 @@ int gpt2_gguf_generation_token_fat16(
                                                  workspace->dense_scratch, workspace->dense_scratch_capacity,
                                                  workspace->ffn_beta, workspace->ffn_beta_capacity * (uint32_t)sizeof(float));
         if (status != 0) return status;
+        status = gpt2_gguf_read_dense_row_fat16(volume, filename, generation->runtime.model,
+                                                 &ffn_up_bias, 0U, hidden_channels,
+                                                 workspace->dense_scratch, workspace->dense_scratch_capacity,
+                                                 workspace->ffn_up_bias,
+                                                 workspace->ffn_up_bias_capacity * (uint32_t)sizeof(float));
+        if (status != 0) return status;
+        status = gpt2_gguf_read_dense_row_fat16(volume, filename, generation->runtime.model,
+                                                 &ffn_down_bias, 0U, channels,
+                                                 workspace->dense_scratch, workspace->dense_scratch_capacity,
+                                                 workspace->ffn_down_bias,
+                                                 workspace->ffn_down_bias_capacity * (uint32_t)sizeof(float));
+        if (status != 0) return status;
         status = gpt2_gguf_block_forward_fat16(
             cache, layer_index, position, workspace->final_hidden, workspace->final_hidden_capacity,
             channels, head_count, hidden_channels, workspace->attention_gamma,
             workspace->attention_beta, &qkv, workspace->qkv_bias, &attention_output,
             workspace->attention_output_bias, workspace->ffn_gamma, workspace->ffn_beta,
-            &ffn_up, &ffn_down, 0, 0, epsilon, volume, filename,
+            &ffn_up, &ffn_down, workspace->ffn_up_bias, workspace->ffn_down_bias,
+            epsilon, volume, filename,
             generation->runtime.model, &workspace->block);
         if (status != 0) return status;
     }

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -279,10 +279,15 @@ int gpt2_gguf_block_attention_forward_fat16(
                                       const float* bias, float* residual,
                                       uint32_t residual_capacity);
 
-/* Lit un fichier FAT16 8.3 dans le buffer fourni puis indexe son GGUF. */
+/* Lit un fichier FAT16 dans le buffer fourni puis indexe son GGUF complet. */
 int gpt2_gguf_load_fat16(const fat16_volume_t* volume, const char* filename,
                          uint8_t* buffer, uint32_t capacity,
                          gpt2_gguf_loaded_model_t* out);
+/* Charge seulement le catalogue GGUF dans un buffer caller-owned. La taille du
+ * fichier reste la borne logique des poids, lus ensuite par fenêtres FAT16. */
+int gpt2_gguf_load_fat16_header(const fat16_volume_t* volume, const char* filename,
+                                uint8_t* header, uint32_t header_capacity,
+                                gpt2_gguf_loaded_model_t* out);
 /* Lit une fenêtre relative aux données d’un tenseur déjà indexé. */
 int gpt2_gguf_read_tensor_fat16(const fat16_volume_t* volume, const char* filename,
                                 const gpt2_gguf_loaded_model_t* model,
@@ -329,6 +334,14 @@ int gpt2_gguf_read_quant_row_fat16(const fat16_volume_t* volume, const char* fil
                                    const gpt2_gguf_tensor_t* tensor,
                                    uint32_t row_index, uint8_t* buffer,
                                    uint32_t capacity, uint32_t* out_read);
+/* Lit puis déquantifie une ligne Q3_K/Q4_K/Q6_K vers des floats caller-owned. */
+int gpt2_gguf_read_quant_row_dequant_fat16(const fat16_volume_t* volume,
+                                           const char* filename,
+                                           const gpt2_gguf_loaded_model_t* model,
+                                           const gpt2_gguf_tensor_t* tensor,
+                                           uint32_t row_index, uint8_t* row_buffer,
+                                           uint32_t row_capacity, float* output,
+                                           uint32_t output_capacity);
 /* Calcule une ligne quantifiée déjà présente dans un buffer caller-owned. */
 int gpt2_gguf_dot_quant_row_buffer(const gpt2_gguf_tensor_t* tensor,
                                    const uint8_t* row_buffer, uint32_t row_capacity,

--- a/kernel/llm/gpt2_quant.c
+++ b/kernel/llm/gpt2_quant.c
@@ -166,3 +166,99 @@ float gpt2_q6_k_dot_f32(const float* input, const uint8_t* q6_blocks, uint32_t c
     }
     return result;
 }
+
+int gpt2_q3_k_dequantize(const uint8_t* q3_blocks, uint32_t count, float* output) {
+    uint32_t block;
+    if (!q3_blocks || !output || count == 0U || (count % GPT2_QK_K) != 0U) return -1;
+    for (block = 0U; block < count / GPT2_QK_K; block++) {
+        const uint8_t* raw = q3_blocks + block * GPT2_Q3_K_BLOCK_BYTES;
+        const float d = gpt2_f16_to_f32(gpt2_read_u16(raw + 108U));
+        int8_t scales[16];
+        uint32_t i;
+        uint32_t n;
+        for (i = 0U; i < 4U; i++) {
+            scales[i] = (int8_t)((raw[96U + i] & 0x0fU) | ((raw[104U + i] & 3U) << 4));
+            scales[4U + i] = (int8_t)((raw[100U + i] & 0x0fU) | (((raw[104U + i] >> 2) & 3U) << 4));
+            scales[8U + i] = (int8_t)(((raw[96U + i] >> 4) & 0x0fU) | (((raw[104U + i] >> 4) & 3U) << 4));
+            scales[12U + i] = (int8_t)(((raw[100U + i] >> 4) & 0x0fU) | (((raw[104U + i] >> 6) & 3U) << 4));
+        }
+        for (n = 0U; n < GPT2_QK_K; n += 128U) {
+            uint32_t j;
+            uint32_t qbase = 32U + n / 4U;
+            uint32_t mask_base = n == 0U ? 0U : 4U;
+            for (j = 0U; j < 4U; j++) {
+                uint32_t l;
+                uint32_t base = block * GPT2_QK_K + n + j * 32U;
+                uint32_t shift = j * 2U;
+                uint32_t mask = 1U << (mask_base + j);
+                float d0 = d * (float)(scales[2U * j] - 32);
+                float d1 = d * (float)(scales[2U * j + 1U] - 32);
+                for (l = 0U; l < 16U; l++) {
+                    int q0 = (int)((raw[qbase + l] >> shift) & 3U);
+                    int q1 = (int)((raw[qbase + l + 16U] >> shift) & 3U);
+                    if ((raw[l] & mask) == 0U) q0 -= 4;
+                    if ((raw[l + 16U] & mask) == 0U) q1 -= 4;
+                    output[base + l] = d0 * (float)q0;
+                    output[base + 16U + l] = d1 * (float)q1;
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+int gpt2_q4_k_dequantize(const uint8_t* q4_blocks, uint32_t count, float* output) {
+    uint32_t block;
+    if (!q4_blocks || !output || count == 0U || (count % GPT2_QK_K) != 0U) return -1;
+    for (block = 0U; block < count / GPT2_QK_K; block++) {
+        const uint8_t* raw = q4_blocks + block * GPT2_Q4_K_BLOCK_BYTES;
+        const float d = gpt2_f16_to_f32(gpt2_read_u16(raw));
+        const float minimum = gpt2_f16_to_f32(gpt2_read_u16(raw + 2U));
+        uint32_t segment;
+        for (segment = 0U; segment < GPT2_QK_K; segment += 64U) {
+            uint32_t l;
+            uint8_t scale0;
+            uint8_t scale1;
+            uint8_t min0;
+            uint8_t min1;
+            uint32_t base = block * GPT2_QK_K + segment;
+            gpt2_q4_k_scale_min(raw + 4U, segment / 32U, &scale0, &min0);
+            gpt2_q4_k_scale_min(raw + 4U, segment / 32U + 1U, &scale1, &min1);
+            for (l = 0U; l < 32U; l++) {
+                uint8_t packed = raw[16U + segment / 2U + l];
+                output[base + l] = d * (float)scale0 * (float)(packed & 0x0fU) - minimum * (float)min0;
+                output[base + 32U + l] = d * (float)scale1 * (float)(packed >> 4) - minimum * (float)min1;
+            }
+        }
+    }
+    return 0;
+}
+
+int gpt2_q6_k_dequantize(const uint8_t* q6_blocks, uint32_t count, float* output) {
+    uint32_t block;
+    if (!q6_blocks || !output || count == 0U || (count % GPT2_QK_K) != 0U) return -1;
+    for (block = 0U; block < count / GPT2_QK_K; block++) {
+        const uint8_t* raw = q6_blocks + block * GPT2_Q6_K_BLOCK_BYTES;
+        const float d = gpt2_f16_to_f32(gpt2_read_u16(raw + 208U));
+        uint32_t n;
+        for (n = 0U; n < GPT2_QK_K; n += 128U) {
+            uint32_t l;
+            uint32_t ql_base = n / 2U;
+            uint32_t qh_base = 128U + n / 4U;
+            uint32_t scale_base = 192U + n / 16U;
+            uint32_t base = block * GPT2_QK_K + n;
+            for (l = 0U; l < 32U; l++) {
+                const uint8_t qh = raw[qh_base + l];
+                int q1 = (int)((raw[ql_base + l] & 0x0fU) | ((qh & 3U) << 4)) - 32;
+                int q2 = (int)((raw[ql_base + l + 32U] & 0x0fU) | (((qh >> 2) & 3U) << 4)) - 32;
+                int q3 = (int)((raw[ql_base + l] >> 4) | (((qh >> 4) & 3U) << 4)) - 32;
+                int q4 = (int)((raw[ql_base + l + 32U] >> 4) | (((qh >> 6) & 3U) << 4)) - 32;
+                output[base + l] = d * (float)(int8_t)raw[scale_base] * (float)q1;
+                output[base + 32U + l] = d * (float)(int8_t)raw[scale_base + 2U] * (float)q2;
+                output[base + 64U + l] = d * (float)(int8_t)raw[scale_base + 4U] * (float)q3;
+                output[base + 96U + l] = d * (float)(int8_t)raw[scale_base + 6U] * (float)q4;
+            }
+        }
+    }
+    return 0;
+}

--- a/kernel/llm/gpt2_quant.h
+++ b/kernel/llm/gpt2_quant.h
@@ -26,5 +26,10 @@ float gpt2_q8_0_dot_f32(const float* input, const uint8_t* q8_blocks, uint32_t c
 float gpt2_q3_k_dot_f32(const float* input, const uint8_t* q3_blocks, uint32_t count);
 float gpt2_q4_k_dot_f32(const float* input, const uint8_t* q4_blocks, uint32_t count);
 float gpt2_q6_k_dot_f32(const float* input, const uint8_t* q6_blocks, uint32_t count);
+/* Déquantifie des super-blocs K vers un buffer float caller-owned. `count` doit
+ * être un multiple non nul de 256 ; 0 signifie succès. */
+int gpt2_q3_k_dequantize(const uint8_t* q3_blocks, uint32_t count, float* output);
+int gpt2_q4_k_dequantize(const uint8_t* q4_blocks, uint32_t count, float* output);
+int gpt2_q6_k_dequantize(const uint8_t* q6_blocks, uint32_t count, float* output);
 
 #endif

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -11,6 +11,7 @@
 #include "../mem/pmm.h"
 #include "../timer.h"
 #include "../llm/gpt2_infer.h"
+#include "../llm/gpt2_gguf_infer.h"
 #include "../llm/gpt2_model.h"
 #include "../llm/gpt2_tokenizer.h"
 #include "../service_registry.h"
@@ -404,6 +405,9 @@ void syscall_handler(cpu_state_t* cpu) {
             break;
         case SYS_GPT2_GENERATE:
             cpu->eax = (uint32_t)sys_gpt2_generate((const char*)cpu->ebx, (char*)cpu->ecx, cpu->edx);
+            break;
+        case SYS_GPT2_GGUF_GENERATE:
+            cpu->eax = (uint32_t)sys_gpt2_gguf_generate((const char*)cpu->ebx, (char*)cpu->ecx, cpu->edx);
             break;
         case SYS_IPC_SEND:
             cpu->eax = (uint32_t)sys_ipc_send((int)cpu->ebx,
@@ -944,13 +948,15 @@ int sys_vfs_overlay_rmdir(const char* path) {
  * modele s'execute dans le noyau freestanding et ne doit jamais consommer un
  * buffer utilisateur non borne.
  */
-int sys_gpt2_generate(const char* prompt, char* out, uint32_t max) {
+static int sys_gpt2_generate_impl(const char* prompt, char* out, uint32_t max,
+                                  uint8_t use_gguf) {
     char prompt_copy[128];
     uint32_t tokens[64];
     uint32_t token_count = 0;
     uint32_t written = 0;
     uint32_t rng_state;
     uint32_t prompt_tokens;
+    uint32_t generation_steps;
     uint32_t prev_generated = 0xFFFFFFFFu;
     const gpt2_model_t* model;
     int rc;
@@ -971,21 +977,30 @@ int sys_gpt2_generate(const char* prompt, char* out, uint32_t max) {
     rc = gpt2_tokenizer_encode(prompt_copy, tokens, 64, &token_count);
     if (rc != 0) return -2;
     model = gpt2_model_current();
-    if (!model->ready || token_count > model->config.max_seq_len) return -5;
+    if (use_gguf) {
+        if (!gpt2_gguf_infer_ready() || token_count > GPT2_GGUF_INFER_MAX_CONTEXT) return -5;
+    } else if (!model->ready || token_count > model->config.max_seq_len) return -5;
     prompt_tokens = token_count;
 
+    generation_steps = use_gguf ? 1U : GPT2_BAREMETAL_GENERATION_STEPS;
     rng_state = 0x9e3779b9U;
     for (uint32_t i = 0; prompt_copy[i] != '\0'; i++) {
         rng_state = rng_state * 16777619U + (uint8_t)prompt_copy[i];
     }
     if (rng_state == 0U) rng_state = 1U;
 
-    for (uint32_t step = 0; step < GPT2_BAREMETAL_GENERATION_STEPS && token_count < 64 && token_count < model->config.max_seq_len; step++) {
+    for (uint32_t step = 0; step < generation_steps && token_count < 64 &&
+         (use_gguf || token_count < model->config.max_seq_len); step++) {
         uint32_t next_token = 0;
         const char* piece;
         int saw_newline = 0;
         uint32_t generated_count = token_count - prompt_tokens;
-        rc = gpt2_generate_next_sampled(tokens, token_count, generated_count, &next_token, &rng_state);
+        if (use_gguf)
+            rc = gpt2_gguf_generate_next_sampled(tokens, token_count, generated_count,
+                                                  &next_token, &rng_state);
+        else
+            rc = gpt2_generate_next_sampled(tokens, token_count, generated_count,
+                                            &next_token, &rng_state);
         if (rc != 0) return -30 + rc;
         if (next_token == gpt2_tokenizer_eot()) break;
         if (next_token == prev_generated) break;
@@ -1005,6 +1020,14 @@ int sys_gpt2_generate(const char* prompt, char* out, uint32_t max) {
     }
     out[written] = '\0';
     return (int)written;
+}
+
+int sys_gpt2_generate(const char* prompt, char* out, uint32_t max) {
+    return sys_gpt2_generate_impl(prompt, out, max, 0U);
+}
+
+int sys_gpt2_gguf_generate(const char* prompt, char* out, uint32_t max) {
+    return sys_gpt2_generate_impl(prompt, out, max, 1U);
 }
 
 // Cette fonction est maintenant obsolète pour l'entrée clavier

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -87,6 +87,7 @@ int sys_rename(const char* oldpath, const char* newpath);
 int sys_copy(const char* src, const char* dst);
 int sys_append(const char* path, const char* buf, uint32_t n);
 int sys_gpt2_generate(const char* prompt, char* out, uint32_t max);
+int sys_gpt2_gguf_generate(const char* prompt, char* out, uint32_t max);
 int sys_ipc_send(int target_pid, const os_ipc_payload_t* payload);
 int sys_ipc_receive(os_ipc_message_t* out);
 int sys_service_register(const char* name);

--- a/scripts/make_gguf_fat16_image.py
+++ b/scripts/make_gguf_fat16_image.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Build a FAT16 AI-OS deployment disk carrying one GPT-2 GGUF as GPT2.GGU."""
+
+import argparse
+import math
+import shutil
+from pathlib import Path
+
+SECTOR = 512
+BASE_LBA = 64
+SECTORS_PER_CLUSTER = 8
+FAT_COUNT = 2
+ROOT_ENTRIES = 128
+RESERVED_SECTORS = 1
+FAT16_EOC = 0xFFFF
+FIXTURE_TEXT = b"FAT16 fixture OK\n"
+
+
+def put16(buffer, offset, value):
+    buffer[offset:offset + 2] = int(value).to_bytes(2, "little")
+
+
+def put32(buffer, offset, value):
+    buffer[offset:offset + 4] = int(value).to_bytes(4, "little")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--image", required=True, type=Path)
+    parser.add_argument("--reserve-clusters", type=int, default=1024)
+    args = parser.parse_args()
+
+    if not args.model.is_file():
+        raise SystemExit(f"modele introuvable: {args.model}")
+    if args.reserve_clusters < 0:
+        raise SystemExit("reserve-clusters doit etre positif")
+
+    model_size = args.model.stat().st_size
+    cluster_bytes = SECTOR * SECTORS_PER_CLUSTER
+    file_clusters = math.ceil(model_size / cluster_bytes)
+    cluster_count = file_clusters + args.reserve_clusters
+    if cluster_count < 4085 or cluster_count > 65524:
+        raise SystemExit("nombre de clusters incompatible FAT16")
+    fat_sectors = math.ceil((cluster_count + 2) * 2 / SECTOR)
+    root_sectors = math.ceil(ROOT_ENTRIES * 32 / SECTOR)
+    total_sectors = RESERVED_SECTORS + FAT_COUNT * fat_sectors + root_sectors + cluster_count * SECTORS_PER_CLUSTER
+    total_disk_sectors = BASE_LBA + total_sectors
+    data_lba = BASE_LBA + RESERVED_SECTORS + FAT_COUNT * fat_sectors + root_sectors
+
+    args.image.parent.mkdir(parents=True, exist_ok=True)
+    with args.image.open("wb") as image:
+        image.truncate(total_disk_sectors * SECTOR)
+        boot = bytearray(SECTOR)
+        boot[:3] = b"\xeb\x3c\x90"
+        boot[3:11] = b"AIOSGGUF"
+        put16(boot, 11, SECTOR)
+        boot[13] = SECTORS_PER_CLUSTER
+        put16(boot, 14, RESERVED_SECTORS)
+        boot[16] = FAT_COUNT
+        put16(boot, 17, ROOT_ENTRIES)
+        put16(boot, 19, 0)
+        boot[21] = 0xF8
+        put16(boot, 22, fat_sectors)
+        put16(boot, 24, 32)
+        put16(boot, 26, 64)
+        put32(boot, 28, BASE_LBA)
+        put32(boot, 32, total_sectors)
+        boot[36] = 0x80
+        boot[38] = 0x29
+        put32(boot, 39, 0xA1052026)
+        boot[43:54] = b"AIOS GGUF  "
+        boot[54:62] = b"FAT16   "
+        boot[510:512] = b"\x55\xaa"
+        image.seek(BASE_LBA * SECTOR)
+        image.write(boot)
+
+        fat = bytearray(fat_sectors * SECTOR)
+        put16(fat, 0, 0xFFF8)
+        put16(fat, 2, FAT16_EOC)
+        for cluster in range(2, file_clusters + 1):
+            put16(fat, cluster * 2, cluster + 1)
+        put16(fat, (file_clusters + 1) * 2, FAT16_EOC)
+        fixture_cluster = file_clusters + 2
+        put16(fat, fixture_cluster * 2, FAT16_EOC)
+        for copy in range(FAT_COUNT):
+            image.seek((BASE_LBA + RESERVED_SECTORS + copy * fat_sectors) * SECTOR)
+            image.write(fat)
+
+        root = bytearray(root_sectors * SECTOR)
+        root[:11] = b"GPT2    GGU"
+        root[11] = 0x20
+        put16(root, 26, 2)
+        put32(root, 28, model_size)
+        root[32:43] = b"FATOK   TXT"
+        root[32 + 11] = 0x20
+        put16(root, 32 + 26, fixture_cluster)
+        put32(root, 32 + 28, len(FIXTURE_TEXT))
+        image.seek((BASE_LBA + RESERVED_SECTORS + FAT_COUNT * fat_sectors) * SECTOR)
+        image.write(root)
+
+        image.seek(data_lba * SECTOR)
+        with args.model.open("rb") as source:
+            shutil.copyfileobj(source, image, length=1024 * 1024)
+        image.seek(data_lba * SECTOR + (fixture_cluster - 2) * cluster_bytes)
+        image.write(FIXTURE_TEXT)
+
+    print(f"GGUF FAT16: {args.image} ({total_disk_sectors * SECTOR} octets)")
+    print(f"GPT2.GGU: {model_size} octets, {file_clusters} clusters de {cluster_bytes} octets")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -97,6 +97,11 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_infer: $(UNIT_DIR)/kernel/test_gpt2_in
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/llm/gpt2_infer.c ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_gguf_infer: $(UNIT_DIR)/kernel/test_gpt2_gguf_infer.c ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c ../kernel/llm/gpt2_gguf_infer.c ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c ../kernel/llm/gpt2_gguf_infer.c ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES)
+	@echo "Compiled kernel test: $(notdir $@)"
+
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_gguf: $(UNIT_DIR)/kernel/test_gpt2_gguf.c ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES)

--- a/tests/scripts/ci_qemu_core_smoke.py
+++ b/tests/scripts/ci_qemu_core_smoke.py
@@ -124,7 +124,10 @@ def main():
         except OSError:
             pass
 
-    prepare_test_disk()
+    if os.environ.get("AIOS_PRESERVE_FAT16") != "1":
+        prepare_test_disk()
+    elif not os.path.isfile(TEST_DISK):
+        raise RuntimeError("missing preserved FAT16 deployment disk")
     proc = None
     monitor = None
     try:

--- a/tests/scripts/ci_qemu_gguf_local_smoke.py
+++ b/tests/scripts/ci_qemu_gguf_local_smoke.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Smoke QEMU optionnel : sélection shell puis première génération GPT-2 GGUF FAT16."""
+
+from __future__ import print_function
+import os
+import socket
+import subprocess
+import sys
+import time
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+KERNEL = os.environ.get("KERNEL", os.path.join(ROOT, "build", "ai_os.bin"))
+INITRD = os.environ.get("INITRD", os.path.join(ROOT, "my_initrd.tar"))
+DISK = os.environ.get("OVERLAY_DISK", os.path.join(ROOT, "build", "gpt2_gguf_fat16.img"))
+LOG = os.environ.get("LOG", os.path.join(ROOT, "test_logs", "ci-qemu-gguf-local.log"))
+ERR = os.environ.get("QEMU_ERR", os.path.join(ROOT, "test_logs", "ci-qemu-gguf-local.err"))
+MON = os.environ.get("QEMU_MON_SOCK", os.path.join(ROOT, "test_logs", "qemu-gguf-monitor.sock"))
+BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "90"))
+GENERATION_TIMEOUT = float(os.environ.get("GGUF_GENERATION_TIMEOUT", "180"))
+KEY_DELAY = float(os.environ.get("KEY_DELAY", "0.65"))
+
+
+def text():
+    try:
+        with open(LOG, "r", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
+def wait_for(proc, needle, timeout, start=0):
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        if proc.poll() is not None:
+            raise RuntimeError("QEMU stopped: %s" % text()[-2000:])
+        if needle in text()[start:]:
+            time.sleep(0.4)
+            return
+        time.sleep(0.15)
+    raise RuntimeError("timeout for %r: %s" % (needle, text()[-2000:]))
+
+
+def monitor():
+    end = time.monotonic() + 10.0
+    while time.monotonic() < end:
+        if os.path.exists(MON):
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                client.connect(MON)
+                client.settimeout(0.1)
+                try:
+                    client.recv(4096)
+                except socket.timeout:
+                    pass
+                return client
+            except OSError:
+                client.close()
+        time.sleep(0.1)
+    raise RuntimeError("QEMU monitor unavailable")
+
+
+def send(client, command):
+    aliases = {" ": "spc", "-": "minus", ".": "dot"}
+    for char in command:
+        client.sendall(("sendkey %s\n" % aliases.get(char, char.lower())).encode("ascii"))
+        time.sleep(KEY_DELAY)
+    time.sleep(KEY_DELAY)
+    client.sendall(b"sendkey ret\n")
+
+
+def main():
+    if not all(os.path.isfile(path) for path in (KERNEL, INITRD, DISK)):
+        raise RuntimeError("missing kernel, initrd or GGUF FAT16 disk")
+    os.makedirs(os.path.dirname(LOG), exist_ok=True)
+    for path in (LOG, ERR, MON):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    proc = None
+    client = None
+    try:
+        with open(ERR, "wb") as err:
+            proc = subprocess.Popen([
+                "qemu-system-i386", "-cpu", "pentium3", "-kernel", KERNEL,
+                "-initrd", INITRD, "-m", "1024M", "-display", "none", "-vga", "none",
+                "-serial", "file:" + LOG, "-monitor", "unix:%s,server,nowait" % MON,
+                "-machine", "type=pc,accel=tcg", "-no-reboot", "-no-shutdown",
+                "-drive", "file=%s,format=raw,if=ide,cache=writethrough" % DISK,
+            ], cwd=ROOT, stdout=err, stderr=err)
+            wait_for(proc, "GGUF: profil local FAT16 pret", BOOT_TIMEOUT)
+            wait_for(proc, "SYS_GETS: Debut", BOOT_TIMEOUT)
+            client = monitor()
+            start = len(text())
+            send(client, "ai-model use gpt2.gguf")
+            wait_for(proc, "Profil GPT-2 GGUF selectionne", BOOT_TIMEOUT, start)
+            start = len(text())
+            send(client, "ai bonjour")
+            wait_for(proc, "[GPT-2 GGUF local]", GENERATION_TIMEOUT, start)
+        print("QEMU GGUF local smoke passed.")
+        return 0
+    finally:
+        if client is not None:
+            client.close()
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=4)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        try:
+            os.remove(MON)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print("QEMU GGUF local smoke failed: %s" % error, file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -24,7 +24,7 @@ export OVERLAY_DISK PERSIST_DISK
 reset_overlay_disk() {
     local img="$1"
     mkdir -p "$(dirname "$img")"
-    dd if=/dev/zero of="$img" bs=512 count=64 status=none
+    dd if=/dev/zero of="$img" bs=512 count=64 conv=notrunc status=none
 }
 
 if [ ! -f "$KERNEL" ] || [ ! -f "$INITRD" ]; then

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -111,6 +111,9 @@ run_test() {
     if [ "$(basename "$test_file")" = "test_gpt2_gguf.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c $BASE_DIR/kernel/llm/gpt2_quant.c"
     fi
+    if [ "$(basename "$test_file")" = "test_gpt2_gguf_infer.c" ]; then
+        extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c $BASE_DIR/kernel/llm/gpt2_quant.c $BASE_DIR/kernel/llm/gpt2_gguf_infer.c $BASE_DIR/kernel/llm/gpt2_sample.c"
+    fi
     if [ "$(basename "$test_file")" = "test_gpt2_quant.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_quant.c"
     fi

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -13,6 +13,8 @@
 #define BLOCK_TOKEN_BYTES (BLOCK_CHANNELS * 4U * 4U)
 #define BLOCK_POSITION_BYTES (BLOCK_CHANNELS * 2U * 2U)
 #define BLOCK_NORM_BYTES (BLOCK_CHANNELS * 4U)
+#define BLOCK_FFN_UP_BIAS_BYTES (BLOCK_HIDDEN * 4U)
+#define BLOCK_FFN_DOWN_BIAS_BYTES (BLOCK_CHANNELS * 4U)
 #define BLOCK_OUTPUT_BYTES (4U * GPT2_Q4_K_BLOCK_BYTES)
 #define BLOCK_GLOBAL_BYTES (BLOCK_TOKEN_BYTES + BLOCK_POSITION_BYTES + 2U * BLOCK_NORM_BYTES + BLOCK_OUTPUT_BYTES)
 #define BLOCK_MODEL_BUFFER_BYTES 500000U
@@ -118,6 +120,33 @@ static void make_gguf_file(void) {
     while (p < end) disk[p++] = 0U;
     disk[tensor_data] = 0x11U;
     disk[tensor_data + GPT2_Q4_K_BLOCK_BYTES] = 0x77U;
+}
+
+static void test_indexes_gpt2_header_from_fat16(void) {
+    fat16_volume_t volume;
+    gpt2_gguf_loaded_model_t model;
+    gpt2_gguf_tensor_t tensor;
+    float decoded[GPT2_QK_K] = {0.0f};
+    uint8_t row[GPT2_Q4_K_BLOCK_BYTES] = {0U};
+    uint8_t header[160];
+    uint8_t short_header[120];
+    make_gguf_file();
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_load_fat16_header(&volume, "gpt2.ggu", header,
+                                                      sizeof(header), &model));
+    TEST_ASSERT_EQUAL(sizeof(header), model.bytes_loaded);
+    TEST_ASSERT_EQUAL(480U, model.index.blob_size);
+    TEST_ASSERT_EQUAL(1U, model.index.tensor_count);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_index_find(&model.index, "output.weight", &tensor));
+    TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_read_quant_row_dequant_fat16(&volume, "gpt2.ggu", &model,
+                                                                 &tensor, 0U, row, sizeof(row),
+                                                                 decoded, GPT2_QK_K));
+    TEST_ASSERT_EQUAL(-6, gpt2_gguf_read_quant_row_dequant_fat16(&volume, "gpt2.ggu", &model,
+                                                                  &tensor, 0U, row, sizeof(row),
+                                                                  decoded, GPT2_QK_K - 1U));
+    TEST_ASSERT_TRUE(gpt2_gguf_load_fat16_header(&volume, "gpt2.ggu", short_header,
+                                                 sizeof(short_header), &model) != 0);
 }
 
 static void test_loads_gpt2_from_fat16(void) {
@@ -594,11 +623,12 @@ static void make_block_gguf_file(void) {
     uint32_t fat;
     uint32_t total_tensor_bytes = BLOCK_GLOBAL_BYTES + 4U * BLOCK_NORM_BYTES +
                                   3U * BLOCK_CHANNELS * 4U + BLOCK_QKV_BYTES +
-                                  BLOCK_ATTN_BYTES + BLOCK_UP_BYTES + BLOCK_DOWN_BYTES;
+                                  BLOCK_ATTN_BYTES + BLOCK_UP_BYTES + BLOCK_DOWN_BYTES +
+                                  BLOCK_FFN_UP_BIAS_BYTES + BLOCK_FFN_DOWN_BIAS_BYTES;
     make_volume();
     put32(cursor, GPT2_GGUF_MAGIC); cursor += 4U;
     put32(cursor, GPT2_GGUF_VERSION); cursor += 4U;
-    put64_at(cursor, 15U); cursor += 8U;
+    put64_at(cursor, 17U); cursor += 8U;
     put64_at(cursor, 2U); cursor += 8U;
     put_text_at(&cursor, "general.architecture");
     put32(cursor, GPT2_GGUF_VALUE_STRING); cursor += 4U;
@@ -638,6 +668,12 @@ static void make_block_gguf_file(void) {
     put_tensor_at(&cursor, "blk.0.ffn_down.weight", BLOCK_HIDDEN,
                   BLOCK_CHANNELS, GPT2_GGUF_TENSOR_Q4_K,
                   BLOCK_GLOBAL_BYTES + 4U * BLOCK_NORM_BYTES + BLOCK_QKV_BYTES + 3U * BLOCK_CHANNELS * 4U + BLOCK_ATTN_BYTES + BLOCK_UP_BYTES);
+    put_vector_at(&cursor, "blk.0.ffn_up.bias", BLOCK_HIDDEN,
+                  GPT2_GGUF_TENSOR_F32,
+                  BLOCK_GLOBAL_BYTES + 4U * BLOCK_NORM_BYTES + BLOCK_QKV_BYTES + 3U * BLOCK_CHANNELS * 4U + BLOCK_ATTN_BYTES + BLOCK_UP_BYTES + BLOCK_DOWN_BYTES);
+    put_vector_at(&cursor, "blk.0.ffn_down.bias", BLOCK_CHANNELS,
+                  GPT2_GGUF_TENSOR_F32,
+                  BLOCK_GLOBAL_BYTES + 4U * BLOCK_NORM_BYTES + BLOCK_QKV_BYTES + 3U * BLOCK_CHANNELS * 4U + BLOCK_ATTN_BYTES + BLOCK_UP_BYTES + BLOCK_DOWN_BYTES + BLOCK_FFN_UP_BIAS_BYTES);
     tensor_data = (cursor + 31U) & ~31U;
     file_size = tensor_data - file_start + total_tensor_bytes;
     clusters = (file_size + 511U) / 512U;
@@ -730,6 +766,7 @@ static void test_generates_gguf_token_logits_from_fat16(void) {
     float position[BLOCK_CHANNELS] = {0.0f}, ag[BLOCK_CHANNELS] = {0.0f}, ab[BLOCK_CHANNELS] = {0.0f};
     float qkv_bias[3U * BLOCK_CHANNELS] = {0.0f}, aob[BLOCK_CHANNELS] = {0.0f};
     float fg[BLOCK_CHANNELS] = {0.0f}, fb[BLOCK_CHANNELS] = {0.0f};
+    float fub[BLOCK_HIDDEN] = {0.0f}, fdb[BLOCK_CHANNELS] = {0.0f};
     float final_gamma[BLOCK_CHANNELS] = {0.0f}, final_beta[BLOCK_CHANNELS] = {0.0f};
     float hidden[BLOCK_CHANNELS] = {0.0f}, norm[BLOCK_CHANNELS] = {0.0f};
     float query[BLOCK_CHANNELS] = {0.0f}, key[BLOCK_CHANNELS] = {0.0f}, value[BLOCK_CHANNELS] = {0.0f};
@@ -737,7 +774,7 @@ static void test_generates_gguf_token_logits_from_fat16(void) {
     float attention[BLOCK_CHANNELS] = {0.0f}, projected[BLOCK_CHANNELS] = {0.0f};
     float mlp_hidden[BLOCK_HIDDEN] = {0.0f}, mlp_output[BLOCK_CHANNELS] = {0.0f};
     float logits[4U] = {0.0f};
-    uint8_t dense_scratch[3U * BLOCK_CHANNELS * 4U] = {0U};
+    uint8_t dense_scratch[BLOCK_HIDDEN * 4U] = {0U};
     uint8_t row[4U * GPT2_Q4_K_BLOCK_BYTES] = {0U};
     char name[64];
     make_block_gguf_file();
@@ -755,6 +792,8 @@ static void test_generates_gguf_token_logits_from_fat16(void) {
     workspace.attention_output_bias=aob; workspace.attention_output_bias_capacity=BLOCK_CHANNELS;
     workspace.ffn_gamma=fg; workspace.ffn_gamma_capacity=BLOCK_CHANNELS;
     workspace.ffn_beta=fb; workspace.ffn_beta_capacity=BLOCK_CHANNELS;
+    workspace.ffn_up_bias=fub; workspace.ffn_up_bias_capacity=BLOCK_HIDDEN;
+    workspace.ffn_down_bias=fdb; workspace.ffn_down_bias_capacity=BLOCK_CHANNELS;
     workspace.final_gamma=final_gamma; workspace.final_gamma_capacity=BLOCK_CHANNELS;
     workspace.final_beta=final_beta; workspace.final_beta_capacity=BLOCK_CHANNELS;
     workspace.final_hidden=hidden; workspace.final_hidden_capacity=BLOCK_CHANNELS;
@@ -833,6 +872,13 @@ static void test_cursor_reads_successive_windows(void) {
     TEST_ASSERT_EQUAL('o', second[1]);
     TEST_ASSERT_EQUAL(0, fat16_file_read(&file, second, sizeof(second), &read));
     TEST_ASSERT_EQUAL(0, (int)read);
+    TEST_ASSERT_EQUAL(0, fat16_file_seek(&file, 2U));
+    TEST_ASSERT_EQUAL(0, fat16_file_read(&file, second, sizeof(second), &read));
+    TEST_ASSERT_EQUAL(3, (int)read);
+    TEST_ASSERT_EQUAL('l', second[0]);
+    TEST_ASSERT_EQUAL('l', second[1]);
+    TEST_ASSERT_EQUAL('o', second[2]);
+    TEST_ASSERT_EQUAL(OS_FAT16_BAD_PATH, fat16_file_seek(&file, 6U));
 }
 
 static void test_rejects_bad_bpb(void) {
@@ -958,6 +1004,7 @@ int main(void) {
     unity_init();
     RUN_TEST(test_mount_list_and_read);
     RUN_TEST(test_loads_gpt2_from_fat16);
+    RUN_TEST(test_indexes_gpt2_header_from_fat16);
     RUN_TEST(test_executes_q4_block_from_fat16);
     RUN_TEST(test_generates_gguf_token_logits_from_fat16);
     RUN_TEST(test_reads_bounded_file_range);

--- a/tests/unit/kernel/test_gpt2_gguf.c
+++ b/tests/unit/kernel/test_gpt2_gguf.c
@@ -97,18 +97,19 @@ static uint32_t make_role_tensors(void) {
         "blk.0.attn_qkv.weight", "blk.0.attn_qkv.bias",
         "blk.0.attn_output.weight", "blk.0.attn_output.bias",
         "blk.0.ffn_norm.weight", "blk.0.ffn_norm.bias",
-        "blk.0.ffn_up.weight", "blk.0.ffn_down.weight"
+        "blk.0.ffn_up.weight", "blk.0.ffn_down.weight",
+        "blk.0.ffn_up.bias", "blk.0.ffn_down.bias"
     };
     uint32_t i;
     uint32_t padded;
     reset_blob();
     put_u32(GPT2_GGUF_MAGIC);
     put_u32(GPT2_GGUF_VERSION);
-    put_u64(15U);
+    put_u64(17U);
     put_u64(2U);
     put_metadata_string("general.architecture", "gpt2");
     put_metadata_u32("general.alignment", 32U);
-    for (i = 0U; i < 15U; i++) {
+    for (i = 0U; i < 17U; i++) {
         put_tensor(names[i], 1U, GPT2_QK_K, 0U, GPT2_GGUF_TENSOR_Q4_K, (uint64_t)(i * 160U));
     }
     padded = 4096U;
@@ -149,7 +150,8 @@ static void test_prepares_generation_context_from_descriptors(void) {
         "blk.0.attn_qkv.weight", "blk.0.attn_qkv.bias",
         "blk.0.attn_output.weight", "blk.0.attn_output.bias",
         "blk.0.ffn_norm.weight", "blk.0.ffn_norm.bias",
-        "blk.0.ffn_up.weight", "blk.0.ffn_down.weight"
+        "blk.0.ffn_up.weight", "blk.0.ffn_down.weight",
+        "blk.0.ffn_up.bias", "blk.0.ffn_down.bias"
     };
     gpt2_gguf_loaded_model_t model = {0};
     gpt2_gguf_layer_t layers[1];
@@ -157,13 +159,13 @@ static void test_prepares_generation_context_from_descriptors(void) {
     char name[64];
     uint32_t i;
     model.index.info.is_valid = 1U;
-    model.index.tensor_count = 15U;
+    model.index.tensor_count = 17U;
     set_descriptor(&model.index.tensors[0], names[0], GPT2_QK_K, 4U, GPT2_GGUF_TENSOR_F32);
     set_descriptor(&model.index.tensors[1], names[1], GPT2_QK_K, 2U, GPT2_GGUF_TENSOR_F16);
     set_descriptor(&model.index.tensors[2], names[2], GPT2_QK_K, 1U, GPT2_GGUF_TENSOR_F32);
     set_descriptor(&model.index.tensors[3], names[3], GPT2_QK_K, 1U, GPT2_GGUF_TENSOR_F16);
     set_descriptor(&model.index.tensors[4], names[4], GPT2_QK_K, 4U, GPT2_GGUF_TENSOR_Q4_K);
-    for (i = 5U; i < 15U; i++) {
+    for (i = 5U; i < 17U; i++) {
         uint32_t width = GPT2_QK_K;
         uint32_t rows = 1U;
         uint32_t type = GPT2_GGUF_TENSOR_F32;
@@ -172,6 +174,7 @@ static void test_prepares_generation_context_from_descriptors(void) {
         else if (i == 9U) { rows = GPT2_QK_K; type = GPT2_GGUF_TENSOR_Q4_K; }
         else if (i == 13U) { rows = 4U * GPT2_QK_K; type = GPT2_GGUF_TENSOR_Q4_K; }
         else if (i == 14U) { width = 4U * GPT2_QK_K; rows = GPT2_QK_K; type = GPT2_GGUF_TENSOR_Q4_K; }
+        else if (i == 15U) width = 4U * GPT2_QK_K;
         set_descriptor(&model.index.tensors[i], names[i], width, rows, type);
     }
     TEST_ASSERT_EQUAL(0, gpt2_gguf_generation_prepare(&model, name, sizeof(name),
@@ -238,7 +241,7 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
     uint32_t size = make_role_tensors();
     TEST_ASSERT_EQUAL(0, gpt2_gguf_build_index(blob, size, &index));
     char name[40];
-    TEST_ASSERT_EQUAL(15, index.tensor_count);
+    TEST_ASSERT_EQUAL(17, index.tensor_count);
     TEST_ASSERT_EQUAL(0, gpt2_gguf_index_find(&index, "output.weight", &tensor));
     TEST_ASSERT_EQUAL(GPT2_GGUF_TENSOR_Q4_K, tensor.type);
     TEST_ASSERT_EQUAL(4 * 160, (int)tensor.data_offset);
@@ -258,14 +261,17 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
     TEST_ASSERT_EQUAL_STRING("blk.0.attn_norm.weight", name);
     TEST_ASSERT_EQUAL(0, gpt2_gguf_map_layer_role(&index, 0U, GPT2_GGUF_ROLE_LAYER_ATTN_QKV_WEIGHT, name, sizeof(name), &tensor));
     TEST_ASSERT_EQUAL_STRING("blk.0.attn_qkv.weight", name);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_map_layer_role(&index, 0U, GPT2_GGUF_ROLE_LAYER_FFN_UP_BIAS, name, sizeof(name), &tensor));
+    TEST_ASSERT_EQUAL_STRING("blk.0.ffn_up.bias", name);
     TEST_ASSERT_EQUAL(-8, gpt2_gguf_map_layer_role(&index, 1U, GPT2_GGUF_ROLE_LAYER_ATTN_NORM_WEIGHT, name, sizeof(name), &tensor));
     TEST_ASSERT_EQUAL(-2, gpt2_gguf_map_layer_role(&index, 0U, GPT2_GGUF_ROLE_LAYER_ATTN_QKV_WEIGHT, name, 8U, &tensor));
     {
         gpt2_gguf_layer_t layer;
         TEST_ASSERT_EQUAL(0, gpt2_gguf_map_layer(&index, 0U, name, sizeof(name), &layer));
-        TEST_ASSERT_EQUAL(0x3FF, (int)layer.present_mask);
+        TEST_ASSERT_EQUAL(0xFFF, (int)layer.present_mask);
         TEST_ASSERT_EQUAL(0, (int)layer.layer_index);
         TEST_ASSERT_EQUAL(0, gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_DOWN_WEIGHT, &tensor));
+        TEST_ASSERT_EQUAL(0, gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_LAYER_FFN_UP_BIAS, &tensor));
         TEST_ASSERT_EQUAL(-1, gpt2_gguf_layer_get(&layer, GPT2_GGUF_ROLE_OUTPUT_WEIGHT, &tensor));
         layer.tensors[0].dimensions = 1U; layer.tensors[0].shape[0] = GPT2_QK_K;
         layer.tensors[1].dimensions = 1U; layer.tensors[1].shape[0] = GPT2_QK_K;
@@ -277,6 +283,8 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
         layer.tensors[7].dimensions = 1U; layer.tensors[7].shape[0] = GPT2_QK_K;
         layer.tensors[8].dimensions = 2U; layer.tensors[8].shape[0] = GPT2_QK_K; layer.tensors[8].shape[1] = 4U * GPT2_QK_K;
         layer.tensors[9].dimensions = 2U; layer.tensors[9].shape[0] = 4U * GPT2_QK_K; layer.tensors[9].shape[1] = GPT2_QK_K;
+        layer.tensors[10].dimensions = 1U; layer.tensors[10].shape[0] = 4U * GPT2_QK_K; layer.tensors[10].type = GPT2_GGUF_TENSOR_F32;
+        layer.tensors[11].dimensions = 1U; layer.tensors[11].shape[0] = GPT2_QK_K; layer.tensors[11].type = GPT2_GGUF_TENSOR_F32;
         layer.tensors[0].byte_size = GPT2_Q4_K_BLOCK_BYTES;
         layer.tensors[1].byte_size = GPT2_Q4_K_BLOCK_BYTES;
         layer.tensors[2].byte_size = 3U * GPT2_QK_K * GPT2_Q4_K_BLOCK_BYTES;
@@ -287,6 +295,8 @@ static void test_builds_index_and_maps_gpt2_roles(void) {
         layer.tensors[7].byte_size = GPT2_Q4_K_BLOCK_BYTES;
         layer.tensors[8].byte_size = 4U * GPT2_QK_K * GPT2_Q4_K_BLOCK_BYTES;
         layer.tensors[9].byte_size = 4U * GPT2_QK_K * GPT2_Q4_K_BLOCK_BYTES;
+        layer.tensors[10].byte_size = 4U * GPT2_QK_K * 4U;
+        layer.tensors[11].byte_size = GPT2_QK_K * 4U;
         TEST_ASSERT_EQUAL(0, gpt2_gguf_validate_gpt2_layer(&layer, GPT2_QK_K));
         TEST_ASSERT_EQUAL(0, gpt2_gguf_validate_gpt2_layer_storage(&layer, GPT2_QK_K));
         layer.tensors[8].byte_size--;

--- a/tests/unit/kernel/test_gpt2_gguf_infer.c
+++ b/tests/unit/kernel/test_gpt2_gguf_infer.c
@@ -1,0 +1,20 @@
+#include "../../framework/unity.h"
+#include "../../../kernel/llm/gpt2_gguf_infer.h"
+
+static void test_rejects_generation_without_ready_fat16_profile(void) {
+    uint32_t token = 0U;
+    uint32_t next = 0U;
+    uint32_t rng = 1U;
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_infer_ready());
+    TEST_ASSERT_EQUAL(-1, gpt2_gguf_infer_init_fat16(0, "GPT2.GGU"));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_infer_ready());
+    TEST_ASSERT_EQUAL(-1, gpt2_gguf_generate_next_sampled(&token, 1U, 0U, &next, &rng));
+}
+
+int main(void) {
+    unity_init();
+    RUN_TEST(test_rejects_generation_without_ready_fat16_profile);
+    unity_print_results();
+    unity_cleanup();
+    return unity_stats.tests_failed == 0 ? 0 : 1;
+}

--- a/tests/unit/kernel/test_gpt2_quant.c
+++ b/tests/unit/kernel/test_gpt2_quant.c
@@ -59,6 +59,7 @@ static void test_q8_rejects_invalid_length(void) {
 
 static void test_q3_k_dot_one_super_block(void) {
     float activation[GPT2_QK_K];
+    float decoded[GPT2_QK_K];
     uint8_t block[GPT2_Q3_K_BLOCK_BYTES];
     uint32_t i;
     for (i = 0U; i < GPT2_QK_K; i++) activation[i] = 1.0f;
@@ -69,11 +70,15 @@ static void test_q3_k_dot_one_super_block(void) {
     block[108] = 0x00U;
     block[109] = 0x3cU;
     assert_close(gpt2_q3_k_dot_f32(activation, block, GPT2_QK_K), 256.0f, 0.0001f);
+    TEST_ASSERT_EQUAL(0, gpt2_q3_k_dequantize(block, GPT2_QK_K, decoded));
+    { float total = 0.0f; for (i = 0U; i < GPT2_QK_K; i++) total += decoded[i]; assert_close(total, 256.0f, 0.0001f); }
+    TEST_ASSERT_EQUAL(-1, gpt2_q3_k_dequantize(block, 128U, decoded));
     TEST_ASSERT_EQUAL(0, (int)gpt2_q3_k_dot_f32(activation, block, 128U));
 }
 
 static void test_q4_k_dot_one_super_block(void) {
     float activation[GPT2_QK_K];
+    float decoded[GPT2_QK_K];
     uint8_t block[GPT2_Q4_K_BLOCK_BYTES];
     uint32_t i;
     for (i = 0U; i < GPT2_QK_K; i++) activation[i] = 1.0f;
@@ -83,11 +88,15 @@ static void test_q4_k_dot_one_super_block(void) {
     for (i = 0U; i < 4U; i++) block[12U + i] = 1U;
     for (i = 0U; i < 128U; i++) block[16U + i] = 0x11U;
     assert_close(gpt2_q4_k_dot_f32(activation, block, GPT2_QK_K), 256.0f, 0.0001f);
+    TEST_ASSERT_EQUAL(0, gpt2_q4_k_dequantize(block, GPT2_QK_K, decoded));
+    { float total = 0.0f; for (i = 0U; i < GPT2_QK_K; i++) total += decoded[i]; assert_close(total, 256.0f, 0.0001f); }
+    TEST_ASSERT_EQUAL(-1, gpt2_q4_k_dequantize(block, 128U, decoded));
     TEST_ASSERT_EQUAL(0, (int)gpt2_q4_k_dot_f32(activation, block, 128U));
 }
 
 static void test_q6_k_dot_one_super_block(void) {
     float activation[GPT2_QK_K];
+    float decoded[GPT2_QK_K];
     uint8_t block[GPT2_Q6_K_BLOCK_BYTES];
     uint32_t i;
     for (i = 0U; i < GPT2_QK_K; i++) activation[i] = 1.0f;
@@ -96,6 +105,9 @@ static void test_q6_k_dot_one_super_block(void) {
     for (i = 192U; i < 208U; i++) block[i] = 1U;
     block[208] = 0x00U; block[209] = 0x3cU;
     assert_close(gpt2_q6_k_dot_f32(activation, block, GPT2_QK_K), 256.0f, 0.0001f);
+    TEST_ASSERT_EQUAL(0, gpt2_q6_k_dequantize(block, GPT2_QK_K, decoded));
+    { float total = 0.0f; for (i = 0U; i < GPT2_QK_K; i++) total += decoded[i]; assert_close(total, 256.0f, 0.0001f); }
+    TEST_ASSERT_EQUAL(-1, gpt2_q6_k_dequantize(block, 128U, decoded));
     TEST_ASSERT_EQUAL(0, (int)gpt2_q6_k_dot_f32(activation, block, 128U));
 }
 

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -500,6 +500,12 @@ int sys_gpt2_generate(const char* prompt, char* out, int max) {
     return result;
 }
 
+int sys_gpt2_gguf_generate(const char* prompt, char* out, int max) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_GPT2_GGUF_GENERATE), "b"(prompt), "c"(out), "d"(max));
+    return result;
+}
+
 int sys_ipc_send(int target_pid, const os_ipc_payload_t* payload) {
     int result;
     asm volatile("int $0x80" : "=a"(result) : "a"(SYS_IPC_SEND), "b"(target_pid), "c"(payload));
@@ -4457,7 +4463,7 @@ static void cmd_ai_model(shell_context_t* ctx, char args[][128], int arg_count) 
     if (strcmp(args[0], "list") == 0) {
         print_string("Modeles locaux declares :\n");
         print_string("  gpt2_124M.bin  [operationnel : checkpoint llm.c v3, CPU bare-metal]\n");
-        print_string("  qwen2.5-1.5b-instruct-q4_0.gguf  [profil futur : chargeur GGUF requis]\n");
+        print_string("  gpt2.gguf      [operationnel : GPT-2 GGUF FAT16, catalogue statique et cache KV]\n");
         return;
     }
     if (strcmp(args[0], "use") == 0 && arg_count == 2) {
@@ -4466,10 +4472,12 @@ static void cmd_ai_model(shell_context_t* ctx, char args[][128], int arg_count) 
             return;
         }
         strcpy(ctx->ai_model, args[1]);
-        if (strstr(args[1], "gpt2") != 0) {
-            print_success("Profil GPT-2 selectionne; validation par le chargeur au boot");
+        if (strstr(args[1], "gpt2") != 0 && strstr(args[1], ".gguf") != 0) {
+            print_success("Profil GPT-2 GGUF selectionne; modele FAT16 requis au boot");
+        } else if (strstr(args[1], "gpt2") != 0) {
+            print_success("Profil GPT-2 FP32 selectionne; validation par le chargeur au boot");
         } else {
-            print_warning("Profil memorise; seul GPT-2 .bin est actuellement executable");
+            print_warning("Profil memorise; seuls les profils GPT-2 locaux sont executables");
         }
         return;
     }
@@ -4741,8 +4749,8 @@ static void cmd_ai_runtime(shell_context_t* ctx, char args[][128], int arg_count
     print_string(ai_provider_name(ctx));
     print_string("\nModele declare     : ");
     print_string(ai_model_name(ctx));
-    print_string("\nLocal              : GPT-2 124M .bin + tokenizer .bin, generation top-k\n");
-    print_string("Limite locale      : 64 jetons de contexte, 4 jetons generes, cache KV actif\n");
+    print_string("\nLocal              : GPT-2 FP32 initrd ou GPT-2 GGUF FAT16, generation top-k\n");
+    print_string("Limite locale      : 64 jetons de contexte, cache KV actif; GGUF lit les poids par fenetres\n");
     print_string("Session LLM noyau  : ");
     print_string(ai_session_phase_name(session_status));
     print_string((session_status & 1U) ? " (NE2000 pret)\n" : " (NE2000 absent)\n");
@@ -4817,15 +4825,18 @@ void call_ai_assistant(shell_context_t* ctx, const char* query) {
     print_string("\n");
     if (strstr(ai_model_name(ctx), "gpt2") != 0) {
         char generated[384];
-        int generated_len = sys_gpt2_generate(query, generated, sizeof(generated));
+        int use_gguf = strstr(ai_model_name(ctx), ".gguf") != 0;
+        int generated_len = use_gguf
+            ? sys_gpt2_gguf_generate(query, generated, sizeof(generated))
+            : sys_gpt2_generate(query, generated, sizeof(generated));
         if (generated_len >= 0) {
-            print_colored("[GPT-2 local] ", COLOR_GREEN);
+            print_colored(use_gguf ? "[GPT-2 GGUF local] " : "[GPT-2 local] ", COLOR_GREEN);
             if (generated_len == 0) print_string("(fin de sequence)");
             else print_string(generated);
             print_string("\n");
             return;
         }
-        print_colored("[GPT-2 local] indisponible (code ", COLOR_YELLOW);
+        print_colored(use_gguf ? "[GPT-2 GGUF local] indisponible (code " : "[GPT-2 local] indisponible (code ", COLOR_YELLOW);
         print_int(generated_len);
         print_colored("); repli de compatibilite.\n", COLOR_YELLOW);
     }


### PR DESCRIPTION
## AOS-1569…1576 — runtime GGUF local

Cette livraison rend le profil `gpt2.gguf` exécutable depuis le shell, sans allocation dynamique et sans charger les 93 MiB de poids en RAM.

### Contenu
- indexage GGUF depuis une fenêtre d’en-tête FAT16 bornée à 2 MiB ;
- backend statique GPT-2 12×768, cache KV 64 positions, top-k déterministe et syscall 109 ;
- support des embeddings Q3_K et des tenseurs Q3_K/Q4_K/Q6_K, avec biais MLP réels ;
- projections QKV, MLP et logits via curseur FAT16 séquentiel ;
- sélection shell `ai-model use gpt2.gguf` et génération locale d’un token bornée ;
- `make gguf-disk` pour l’image `GPT2.GGU` et `make qemu-gguf-smoke` de bout en bout ;
- correction du smoke pour préserver un disque FAT16 explicitement fourni.

### Validation locale
- `make test-all` : **452/452** verts ;
- `make qemu-smoke` : core, extras, persistance, spawn/yield/wait et exec verts ;
- `make qemu-gguf-smoke` : boot, sélection du profil et retour local GGUF verts ;
- `git diff --check` et recherche d’allocateurs dynamiques : propres.

Documentation : `docs/aos1569_1576_gguf_local_shell.md`.