### PR TITLE
perf: cache sequential GGUF FAT16 reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AI-OS est un **prototype de hobby OS i386 32-bit** démarrant par Multiboot. Ce 
 | Découverte Foundation | Registre volatile de 8 services et 8 abonnements ; retrait, transfert par propriétaire, notifications et purge immédiate à la terminaison ; pas de capabilities |
 | Fichiers | Archive initrd TAR en lecture seule, overlay AIOV V2 sur ATA PIO (64 nœuds, V1 compatible), volume FAT16 et primitives FAT32 d’écriture/chaînage/rollback hors intégration VFS complète |
 | IA locale | GPT-2 124M `llm.c v3`, BPE UTF-8, cache KV, SSE2 et top-k sur workspace statique borné, sans réseau au boot ni allocation dynamique dans le moteur d’inférence |
-| GGUF | Runtime GPT-2 GGUF v3 local : catalogue FAT16 borné à 2 MiB, embeddings Q3_K, matrices Q3_K/Q4_K/Q6_K, bloc avec biais MLP, cache KV statique, top-k et shell `ai-model use gpt2.gguf`, sans allocation dynamique |
+| GGUF | Runtime GPT-2 GGUF v3 local : catalogue FAT16 borné à 2 MiB, cache de secteur caller-owned, embeddings Q3_K, matrices Q3_K/Q4_K/Q6_K, bloc avec biais MLP, cache KV statique, top-k et shell `ai-model use gpt2.gguf`, sans allocation dynamique |
 | Réseau | Pilote NE2000 ISA, `SYS_NET_STATUS`, codecs ARP/IPv4/UDP/DHCP/DNS/TCP/TLS record, renouvellement, réacquisition et backoff DHCP caller-owned différés hors IRQ0, conservation fournisseur et reprise HTTP/SSE contrôlées, reprise SSE fine `Last-Event-ID`, registre TCP statique, orchestrateur noyau DHCP/DNS/ARP/SYN→TLS→HTTP/SSE socket et FIN+ACK transactionnel ; client OpenAI Chat Completions activable depuis le shell, campagne externe réelle en attente d’une clé API valide |
 
 Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `sort`, `head`, `tail`, `fat16-list`, `fat16-cat`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `service-publish`, `service-grant`, `service-find`, `service-status <nom>`, `service-watch`, `vfs-backend-probe <fichier>`, `vfs-backend-write-probe <fichier> <texte>`, `vfs-backend-remove-probe <fichier>`, `vfs-backend-rename-probe <src> <dst>`, `vfs-grant <pid>`, `vfs-backend-grant <pid>`, `vfs-backend-grant-read <pid>`, `vfs-backend-grant-mutate <pid>`, `vfs-backend-revoke <pid>`, `vfs-backend-status <pid>`, `vfs-backend-list`, `vfs-read <chemin>`, `vfs-stat <chemin>`, `vfs-list <repertoire/>`, `vfs-list-page <repertoire/> <depart>`, `vfs-mkdir`, `vfs-rmdir`, `vfs-stats`, `vfs-mount-add <prefixe/> <initrd|overlay>`, `vfs-mount-remove <prefixe/>`, `vfs-write <chemin> <texte>`, `vfs-remove <chemin>`, `vfs-rename <src> <dst>`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime`, `ai-credential`, `net-status` et `net-status json`. La liste complète, y compris la supervision de tâches, est dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
@@ -45,10 +45,10 @@ make run
 | Cible | Rôle |
 |---|---|
 | `make all` | Noyau, initrd et image overlay IDE (AIOV + FAT16 à partir du LBA 64) |
-| `make test-all` | Suite complète Unity/robustesse ; l’état courant validé est de 452 tests exécutés avec succès |
+| `make test-all` | Suite complète Unity/robustesse ; l’état courant validé est de 453 tests exécutés avec succès |
 | `make qemu-smoke` | Scénarios QEMU classiques : overlay, persistance, spawn/yield et exec |
 | `make gguf-disk` | Construit un disque FAT16 de déploiement contenant le modèle sous l’alias `GPT2.GGU` |
-| `make qemu-gguf-smoke` | Démarre le disque GGUF, sélectionne `gpt2.gguf` dans le shell et valide un token local |
+| `make qemu-gguf-smoke` | Démarre le disque GGUF, sélectionne `gpt2.gguf`, valide un token local et affiche sa latence |
 | `make integration-qemu` | Contrats QEMU AOS-022, AOS-024, AOS-025, NE2000, IPC, VFS avec montages dynamiques, mutations médiées, révocation, notifications, cycle de vie et transfert Foundation |
 | `make qemu-irq0-preemption` | Lance `spin` puis exige un shell toujours réactif |
 | `make qemu-ai-provider` | Vérifie le diagnostic réseau et le blocage OpenAI |
@@ -97,7 +97,7 @@ Le profil `ai-provider openai` est activable de façon contrôlée : la session 
 
 ## Tests et artefacts
 
-`make test-all` a validé **452 tests exécutés avec succès** dans l’état courant, dont FAT16/FAT32, curseur et saut FAT16, console VGA, PCI, SHA-256/HMAC, codecs Ethernet/ARP/IPv4/UDP/DHCP/DNS/TCP, NE2000, orchestrateur noyau LLM TLS/HTTP/SSE sur socket, GPT-2/GGUF, IPC, VFS, services, shell et RAMFS. `make qemu-gguf-smoke` complète les smokes QEMU en validant le disque GPT2.GGU et la génération locale sélectionnée dans le shell. Les détails de périmètre et les limites restantes sont maintenus dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md) et [docs/todo.md](docs/todo.md).
+`make test-all` a validé **453 tests exécutés avec succès** dans l’état courant, dont FAT16/FAT32, curseur, saut et cache de secteur FAT16, console VGA, PCI, SHA-256/HMAC, codecs Ethernet/ARP/IPv4/UDP/DHCP/DNS/TCP, NE2000, orchestrateur noyau LLM TLS/HTTP/SSE sur socket, GPT-2/GGUF, IPC, VFS, services, shell et RAMFS. `make qemu-gguf-smoke` complète les smokes QEMU en validant le disque GPT2.GGU, la génération locale sélectionnée dans le shell et sa durée mesurée. Les détails de périmètre et les limites restantes sont maintenus dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md) et [docs/todo.md](docs/todo.md).
 
 Une ISO BIOS/GRUB peut être produite avec l’initrd. Lorsque les poids GPT-2 sont fournis, ils sont bien incorporés à l’ISO pour un fonctionnement local sur une machine vierge ; ils restent ignorés par Git.
 

--- a/docs/aos1577_1584_gguf_fat16_latency.md
+++ b/docs/aos1577_1584_gguf_fat16_latency.md
@@ -1,0 +1,45 @@
+# AOS-1577…1584 — Latence GGUF : cache de curseur FAT16 et kernels quantifiés
+
+**Statut : livré et mesuré.** Ce lot diminue le coût de lecture du runtime GPT-2 GGUF local sans charger les poids en mémoire, sans allocation dynamique et sans modifier l’ABI du shell. Il traite le chevauchement physique entre deux lignes quantifiées successives et réduit les opérations arithmétiques répétées dans les kernels Q4_K et Q6_K.
+
+> **Constat initial.** Une ligne quantifiée de 768 canaux occupe 324, 432 ou 630 octets selon Q3_K, Q4_K ou Q6_K. Deux lectures de lignes successives peuvent donc partager un secteur FAT16 de 512 octets ; sans cache, ce secteur était relu au périphérique.
+
+## Livraison
+
+| Composant | Modification | Garantie |
+|---|---|---|
+| `fat16_file_t` | Cache d’un secteur de 512 octets et LBA associé, possédés par le curseur | L’état est caller-owned ; aucun cache global, heap ou allocation implicite n’est ajouté. |
+| `fat16_file_read` | Réutilisation du secteur caché lorsque le LBA demandé est identique | La sémantique des lectures partielles et des limites de fichier est préservée. |
+| `fat16_file_seek` | Invalidation explicite du cache lors du repositionnement | Un saut ne peut pas réutiliser un secteur associé à une position antérieure. |
+| Kernel Q4_K | Facteurs d’échelle et minima pré-calculés par segment de 64 valeurs | L’ordre des opérations utiles et le résultat des vecteurs Unity sont conservés. |
+| Kernel Q6_K | Facteurs `d × scale` pré-calculés par segment de 128 valeurs | Les produits de la tête de logits et des matrices Q6_K évitent des multiplications répétées. |
+| Smoke QEMU GGUF | Publication du temps mur entre l’envoi de `ai bonjour` et le marqueur de réponse locale | La régression peut être mesurée par la cible versionnée `make qemu-gguf-smoke`. |
+
+## Contrat mémoire
+
+Le cache ajoute exactement **512 octets** et quelques métadonnées au curseur FAT16. Chaque lecteur de tenseur quantifié continue d’ouvrir un curseur local, de se positionner sur le tenseur, puis de consommer ses lignes séquentiellement. Les poids du modèle restent exclusivement sur le volume FAT16.
+
+| Ressource | Avant | Après | Allocation dynamique |
+|---|---:|---:|---|
+| Catalogue GGUF | 2 MiB statiques | 2 MiB statiques | Aucune |
+| Workspace et cache KV | inchangés | inchangés | Aucune |
+| Curseur FAT16 | métadonnées de position | métadonnées + 512 octets | Aucune |
+| Poids GGUF | FAT16 par fenêtres | FAT16 par fenêtres | Aucune |
+
+## Mesure QEMU TCG
+
+La mesure utilise le disque de déploiement Q3_K réel, sélectionne `gpt2.gguf`, soumet `ai bonjour` et attend le marqueur `[GPT-2 GGUF local]`. Les runs QEMU TCG présentent une variabilité limitée liée à l’émulation ; la référence initiale a été **19,13 s** et le run avec cache de curseur a observé **17,03 s**, soit un gain indicatif d’environ **11 %**. Le run combinant aussi le pré-calcul des échelles a mesuré **17,32 s**, ce qui reste dans la variabilité d’émulation mais confirme l’absence de régression fonctionnelle.
+
+| Commande | Validation |
+|---|---|
+| `make test-all` | La suite inclut le cache FAT16 et les kernels quantifiés. |
+| `make qemu-gguf-smoke` | Affiche la durée du premier token local sur le modèle réel. |
+| `make qemu-smoke` | Conserve les scénarios système standard. |
+
+## Vecteurs ajoutés
+
+Le test `test_cursor_caches_shared_sector` compte les lectures de secteur de la fixture. Après une première fenêtre de trois octets du fichier `FATOK.TXT`, une seconde fenêtre de deux octets appartenant au même secteur ne déclenche pas de lecture périphérique supplémentaire. Les vecteurs Q4_K et Q6_K existants continuent de valider les produits quantifiés après le pré-calcul des facteurs.
+
+## Limites et suite
+
+Le cache est volontairement limité à un seul secteur par curseur : il cible le chevauchement certain des lectures séquentielles sans déplacer le coût mémoire vers un cache de modèle non borné. La latence QEMU reste dominée par le forward complet et la tête de 50 257 logits. La suite peut étudier un cache de pages statique explicitement dimensionné, des kernels vectorisés i386 SSE2 et une génération coopérative, tout en préservant le caractère sans heap du runtime.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -87,10 +87,11 @@
 - [x] AOS-1553…1560 : préparation statique de génération GPT-2 GGUF, rôles globaux, couches contiguës et dimensions déduites — [aos1553_1560_gguf_generation_prepare.md](aos1553_1560_gguf_generation_prepare.md)
 - [x] AOS-1561…1568 : exécution GPT-2 GGUF token-vers-logits sur FAT16, cache KV et workspace caller-owned — [aos1561_1568_gguf_token_logits.md](aos1561_1568_gguf_token_logits.md)
 - [x] AOS-1569…1576 : runtime GPT-2 GGUF local, disque FAT16 de déploiement, shell, top-k et lectures séquentielles — [aos1569_1576_gguf_local_shell.md](aos1569_1576_gguf_local_shell.md)
+- [x] AOS-1577…1584 : cache de curseur FAT16, pré-calcul Q4_K/Q6_K et smoke local chronométré — [aos1577_1584_gguf_fat16_latency.md](aos1577_1584_gguf_fat16_latency.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)
-- [x] Tests complets du système corrigé (`make test-all` : 452 tests exécutés avec succès ; `make qemu-smoke`, `make qemu-gguf-smoke` et `make integration-qemu`)
+- [x] Tests complets du système corrigé (`make test-all` : 453 tests exécutés avec succès ; `make qemu-smoke`, `make qemu-gguf-smoke` et `make integration-qemu`)
 - [x] Validation du fonctionnement en mode utilisateur (QEMU GTK + `sendkey`)
 - [x] Commit et push des corrections sur GitHub
 - [x] Documentation des corrections apportées ([ETAT_REEL.md](ETAT_REEL.md))

--- a/kernel/fs/fat16.c
+++ b/kernel/fs/fat16.c
@@ -499,6 +499,8 @@ int fat16_open_file(const fat16_volume_t* v, const char* name, fat16_file_t* out
         out->position = 0U;
         out->cluster_offset = 0U;
         out->guard = 0U;
+        out->cached_lba = 0U;
+        out->cache_valid = 0U;
         out->open = 1U;
         return 0;
     }
@@ -518,6 +520,7 @@ int fat16_file_seek(fat16_file_t* file, uint32_t offset) {
     file->position = 0U;
     file->cluster_offset = 0U;
     file->guard = 0U;
+    file->cache_valid = 0U;
     if (offset == file->size) {
         file->position = offset;
         return 0;
@@ -555,10 +558,14 @@ int fat16_file_read(fat16_file_t* file, uint8_t* buffer, uint32_t max,
         if (file->cluster < 2U || file->cluster >= FAT16_EOC_MIN ||
             file->cluster - 2U >= v->cluster_count || file->guard++ > v->cluster_count) return OS_FAT16_CORRUPT;
         lba = v->data_lba + (uint32_t)(file->cluster - 2U) * v->sectors_per_cluster + sector_in_cluster;
-        if (read_at(v, lba, sector2) != 0) return OS_FAT16_CORRUPT;
+        if (!file->cache_valid || file->cached_lba != lba) {
+            if (read_at(v, lba, file->sector_cache) != 0) return OS_FAT16_CORRUPT;
+            file->cached_lba = lba;
+            file->cache_valid = 1U;
+        }
         if (take > max - copied) take = max - copied;
         if (take > file->size - file->position) take = file->size - file->position;
-        for (uint32_t i = 0U; i < take; i++) buffer[copied + i] = sector2[sector_offset + i];
+        for (uint32_t i = 0U; i < take; i++) buffer[copied + i] = file->sector_cache[sector_offset + i];
         copied += take;
         file->position += take;
         file->cluster_offset += take;

--- a/kernel/fs/fat16.h
+++ b/kernel/fs/fat16.h
@@ -33,6 +33,9 @@ typedef struct {
     uint32_t position;
     uint32_t cluster_offset;
     uint32_t guard;
+    uint32_t cached_lba;
+    uint8_t sector_cache[512];
+    uint8_t cache_valid;
     uint8_t open;
 } fat16_file_t;
 

--- a/kernel/llm/gpt2_quant.c
+++ b/kernel/llm/gpt2_quant.c
@@ -123,13 +123,21 @@ float gpt2_q4_k_dot_f32(const float* input, const uint8_t* q4_blocks, uint32_t c
             uint8_t scale1;
             uint8_t min0;
             uint8_t min1;
+            float scale_value0;
+            float scale_value1;
+            float min_value0;
+            float min_value1;
             gpt2_q4_k_scale_min(raw + 4U, segment / 32U, &scale0, &min0);
             gpt2_q4_k_scale_min(raw + 4U, segment / 32U + 1U, &scale1, &min1);
+            scale_value0 = d * (float)scale0;
+            scale_value1 = d * (float)scale1;
+            min_value0 = minimum * (float)min0;
+            min_value1 = minimum * (float)min1;
             for (l = 0U; l < 32U; l++) {
                 uint8_t packed = raw[16U + segment / 2U + l];
-                result += (d * (float)scale0 * (float)(packed & 0x0fU) - minimum * (float)min0) *
+                result += (scale_value0 * (float)(packed & 0x0fU) - min_value0) *
                           input[block * GPT2_QK_K + segment + l];
-                result += (d * (float)scale1 * (float)(packed >> 4) - minimum * (float)min1) *
+                result += (scale_value1 * (float)(packed >> 4) - min_value1) *
                           input[block * GPT2_QK_K + segment + 32U + l];
             }
         }
@@ -151,16 +159,20 @@ float gpt2_q6_k_dot_f32(const float* input, const uint8_t* q6_blocks, uint32_t c
             uint32_t ql_base = n / 2U;
             uint32_t qh_base = 128U + n / 4U;
             uint32_t scale_base = 192U + n / 16U;
+            float scale1 = d * (float)(int8_t)raw[scale_base];
+            float scale2 = d * (float)(int8_t)raw[scale_base + 2U];
+            float scale3 = d * (float)(int8_t)raw[scale_base + 4U];
+            float scale4 = d * (float)(int8_t)raw[scale_base + 6U];
             for (l = 0U; l < 32U; l++) {
                 const uint8_t qh = raw[qh_base + l];
                 int q1 = (int)((raw[ql_base + l] & 0x0fU) | ((qh & 3U) << 4)) - 32;
                 int q2 = (int)((raw[ql_base + l + 32U] & 0x0fU) | (((qh >> 2) & 3U) << 4)) - 32;
                 int q3 = (int)((raw[ql_base + l] >> 4) | (((qh >> 4) & 3U) << 4)) - 32;
                 int q4 = (int)((raw[ql_base + l + 32U] >> 4) | (((qh >> 6) & 3U) << 4)) - 32;
-                result += d * (float)(int8_t)raw[scale_base] * (float)q1 * input[block * GPT2_QK_K + n + l];
-                result += d * (float)(int8_t)raw[scale_base + 2U] * (float)q2 * input[block * GPT2_QK_K + n + 32U + l];
-                result += d * (float)(int8_t)raw[scale_base + 4U] * (float)q3 * input[block * GPT2_QK_K + n + 64U + l];
-                result += d * (float)(int8_t)raw[scale_base + 6U] * (float)q4 * input[block * GPT2_QK_K + n + 96U + l];
+                result += scale1 * (float)q1 * input[block * GPT2_QK_K + n + l];
+                result += scale2 * (float)q2 * input[block * GPT2_QK_K + n + 32U + l];
+                result += scale3 * (float)q3 * input[block * GPT2_QK_K + n + 64U + l];
+                result += scale4 * (float)q4 * input[block * GPT2_QK_K + n + 96U + l];
             }
         }
     }

--- a/tests/scripts/ci_qemu_gguf_local_smoke.py
+++ b/tests/scripts/ci_qemu_gguf_local_smoke.py
@@ -95,9 +95,10 @@ def main():
             send(client, "ai-model use gpt2.gguf")
             wait_for(proc, "Profil GPT-2 GGUF selectionne", BOOT_TIMEOUT, start)
             start = len(text())
+            started = time.monotonic()
             send(client, "ai bonjour")
             wait_for(proc, "[GPT-2 GGUF local]", GENERATION_TIMEOUT, start)
-        print("QEMU GGUF local smoke passed.")
+        print("QEMU GGUF local smoke passed in %.2fs." % (time.monotonic() - started))
         return 0
     finally:
         if client is not None:

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -20,6 +20,7 @@
 #define BLOCK_MODEL_BUFFER_BYTES 500000U
 static uint8_t disk[TEST_SECTORS * 512U];
 static uint8_t block_model_buffer[BLOCK_MODEL_BUFFER_BYTES];
+static uint32_t read_sector_calls;
 
 static uint16_t le16(uint32_t off) {
     return (uint16_t)disk[off] | ((uint16_t)disk[off + 1U] << 8);
@@ -38,6 +39,7 @@ static void put32(uint32_t off, uint32_t value) {
 static int read_sector(uint32_t lba, void* out) {
     uint32_t i;
     if (!out || lba >= TEST_SECTORS) return -1;
+    read_sector_calls++;
     for (i = 0U; i < 512U; i++) ((uint8_t*)out)[i] = disk[lba * 512U + i];
     return 0;
 }
@@ -53,6 +55,7 @@ static void make_volume(void) {
     uint32_t root = (1U + 2U * 17U) * 512U;
     uint32_t data = (root / 512U + 2U) * 512U;
     uint32_t i;
+    read_sector_calls = 0U;
     for (i = 0U; i < sizeof(disk); i++) disk[i] = 0U;
     put16(11U, 512U);
     disk[13] = 1U;
@@ -881,6 +884,23 @@ static void test_cursor_reads_successive_windows(void) {
     TEST_ASSERT_EQUAL(OS_FAT16_BAD_PATH, fat16_file_seek(&file, 6U));
 }
 
+static void test_cursor_caches_shared_sector(void) {
+    fat16_volume_t volume;
+    fat16_file_t file;
+    uint8_t buffer[3] = {0U, 0U, 0U};
+    uint32_t read = 0U;
+    uint32_t after_first;
+    make_volume();
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, fat16_open_file(&volume, "fatok.txt", &file));
+    TEST_ASSERT_EQUAL(0, fat16_file_read(&file, buffer, 3U, &read));
+    TEST_ASSERT_EQUAL(3, (int)read);
+    after_first = read_sector_calls;
+    TEST_ASSERT_EQUAL(0, fat16_file_read(&file, buffer, 2U, &read));
+    TEST_ASSERT_EQUAL(2, (int)read);
+    TEST_ASSERT_EQUAL((int)after_first, (int)read_sector_calls);
+}
+
 static void test_rejects_bad_bpb(void) {
     fat16_volume_t volume;
     make_volume();
@@ -1009,6 +1029,7 @@ int main(void) {
     RUN_TEST(test_generates_gguf_token_logits_from_fat16);
     RUN_TEST(test_reads_bounded_file_range);
     RUN_TEST(test_cursor_reads_successive_windows);
+    RUN_TEST(test_cursor_caches_shared_sector);
     RUN_TEST(test_rejects_bad_bpb);
     RUN_TEST(test_rejects_bad_name_and_small_buffer);
     RUN_TEST(test_writes_only_with_explicit_writer);


### PR DESCRIPTION
## AOS-1577…1584 — latence GGUF FAT16

Cette PR réduit les relectures FAT16 du runtime GGUF local sans allocation dynamique.

### Contenu
- cache sectoriel de 512 octets strictement caller-owned dans `fat16_file_t` ;
- invalidation du cache lors d’un `fat16_file_seek` ;
- pré-calcul des facteurs d’échelle Q4_K et Q6_K par sous-bloc ;
- vecteur Unity qui prouve qu’un secteur partagé par deux fenêtres successives n’est lu qu’une fois ;
- smoke `qemu-gguf-smoke` chronométré et note technique de mesures.

### Mesure locale
Le premier token `ai bonjour` sur le modèle Q3_K réel a été observé à **19,13 s** avant le cache et **17,03 s** après activation du cache sectoriel, soit environ **11 %** de gain indicatif sous QEMU TCG.

### Validation locale
- `make test-all` : **453/453** verts ;
- `make qemu-smoke` : core, extras, persistance, spawn/yield/wait et exec verts ;
- `make qemu-gguf-smoke` : sélection du profil et génération locale verte ;
- `git diff --check` et recherche d’allocateurs dynamiques : propres.

Documentation : `docs/aos1577_1584_gguf_fat16_latency.md`.