### PR TITLE
perf: stream GGUF logits into top-k

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AI-OS est un **prototype de hobby OS i386 32-bit** démarrant par Multiboot. Ce 
 | Découverte Foundation | Registre volatile de 8 services et 8 abonnements ; retrait, transfert par propriétaire, notifications et purge immédiate à la terminaison ; pas de capabilities |
 | Fichiers | Archive initrd TAR en lecture seule, overlay AIOV V2 sur ATA PIO (64 nœuds, V1 compatible), volume FAT16 et primitives FAT32 d’écriture/chaînage/rollback hors intégration VFS complète |
 | IA locale | GPT-2 124M `llm.c v3`, BPE UTF-8, cache KV, SSE2 et top-k sur workspace statique borné, sans réseau au boot ni allocation dynamique dans le moteur d’inférence |
-| GGUF | Runtime GPT-2 GGUF v3 local : catalogue FAT16 borné à 2 MiB, cache de secteur caller-owned, embeddings Q3_K, matrices Q3_K/Q4_K/Q6_K, bloc avec biais MLP, cache KV statique, top-k et shell `ai-model use gpt2.gguf`, sans allocation dynamique |
+| GGUF | Runtime GPT-2 GGUF v3 local : catalogue FAT16 borné à 2 MiB, cache de secteur caller-owned, embeddings Q3_K, matrices Q3_K/Q4_K/Q6_K, bloc avec biais MLP, cache KV statique, top-k en flux sans buffer de logits complet et shell `ai-model use gpt2.gguf`, sans allocation dynamique |
 | Réseau | Pilote NE2000 ISA, `SYS_NET_STATUS`, codecs ARP/IPv4/UDP/DHCP/DNS/TCP/TLS record, renouvellement, réacquisition et backoff DHCP caller-owned différés hors IRQ0, conservation fournisseur et reprise HTTP/SSE contrôlées, reprise SSE fine `Last-Event-ID`, registre TCP statique, orchestrateur noyau DHCP/DNS/ARP/SYN→TLS→HTTP/SSE socket et FIN+ACK transactionnel ; client OpenAI Chat Completions activable depuis le shell, campagne externe réelle en attente d’une clé API valide |
 
 Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `sort`, `head`, `tail`, `fat16-list`, `fat16-cat`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `service-publish`, `service-grant`, `service-find`, `service-status <nom>`, `service-watch`, `vfs-backend-probe <fichier>`, `vfs-backend-write-probe <fichier> <texte>`, `vfs-backend-remove-probe <fichier>`, `vfs-backend-rename-probe <src> <dst>`, `vfs-grant <pid>`, `vfs-backend-grant <pid>`, `vfs-backend-grant-read <pid>`, `vfs-backend-grant-mutate <pid>`, `vfs-backend-revoke <pid>`, `vfs-backend-status <pid>`, `vfs-backend-list`, `vfs-read <chemin>`, `vfs-stat <chemin>`, `vfs-list <repertoire/>`, `vfs-list-page <repertoire/> <depart>`, `vfs-mkdir`, `vfs-rmdir`, `vfs-stats`, `vfs-mount-add <prefixe/> <initrd|overlay>`, `vfs-mount-remove <prefixe/>`, `vfs-write <chemin> <texte>`, `vfs-remove <chemin>`, `vfs-rename <src> <dst>`, `jobs`, `top`, `ai`, `ai-provider`, `ai-model`, `ai-runtime`, `ai-credential`, `net-status` et `net-status json`. La liste complète, y compris la supervision de tâches, est dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
@@ -45,7 +45,7 @@ make run
 | Cible | Rôle |
 |---|---|
 | `make all` | Noyau, initrd et image overlay IDE (AIOV + FAT16 à partir du LBA 64) |
-| `make test-all` | Suite complète Unity/robustesse ; l’état courant validé est de 453 tests exécutés avec succès |
+| `make test-all` | Suite complète Unity/robustesse ; l’état courant validé est de 454 tests exécutés avec succès |
 | `make qemu-smoke` | Scénarios QEMU classiques : overlay, persistance, spawn/yield et exec |
 | `make gguf-disk` | Construit un disque FAT16 de déploiement contenant le modèle sous l’alias `GPT2.GGU` |
 | `make qemu-gguf-smoke` | Démarre le disque GGUF, sélectionne `gpt2.gguf`, valide un token local et affiche sa latence |
@@ -97,7 +97,7 @@ Le profil `ai-provider openai` est activable de façon contrôlée : la session 
 
 ## Tests et artefacts
 
-`make test-all` a validé **453 tests exécutés avec succès** dans l’état courant, dont FAT16/FAT32, curseur, saut et cache de secteur FAT16, console VGA, PCI, SHA-256/HMAC, codecs Ethernet/ARP/IPv4/UDP/DHCP/DNS/TCP, NE2000, orchestrateur noyau LLM TLS/HTTP/SSE sur socket, GPT-2/GGUF, IPC, VFS, services, shell et RAMFS. `make qemu-gguf-smoke` complète les smokes QEMU en validant le disque GPT2.GGU, la génération locale sélectionnée dans le shell et sa durée mesurée. Les détails de périmètre et les limites restantes sont maintenus dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md) et [docs/todo.md](docs/todo.md).
+`make test-all` a validé **454 tests exécutés avec succès** dans l’état courant, dont FAT16/FAT32, curseur, saut et cache de secteur FAT16, projection GGUF top-k en flux, console VGA, PCI, SHA-256/HMAC, codecs Ethernet/ARP/IPv4/UDP/DHCP/DNS/TCP, NE2000, orchestrateur noyau LLM TLS/HTTP/SSE sur socket, GPT-2/GGUF, IPC, VFS, services, shell et RAMFS. `make qemu-gguf-smoke` complète les smokes QEMU en validant le disque GPT2.GGU, la génération locale sélectionnée dans le shell et sa durée mesurée. Les détails de périmètre et les limites restantes sont maintenus dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md) et [docs/todo.md](docs/todo.md).
 
 Une ISO BIOS/GRUB peut être produite avec l’initrd. Lorsque les poids GPT-2 sont fournis, ils sont bien incorporés à l’ISO pour un fonctionnement local sur une machine vierge ; ils restent ignorés par Git.
 

--- a/docs/aos1585_1592_gguf_stream_topk.md
+++ b/docs/aos1585_1592_gguf_stream_topk.md
@@ -1,0 +1,36 @@
+# AOS-1585…1592 — Projection GGUF top-k en flux
+
+**Statut : livré et mesuré.** Le runtime GPT-2 GGUF local n’écrit plus un tableau complet de logits avant l’échantillonnage. La tête quantifiée FAT16 offre chaque logit directement à un accumulateur top-k caller-owned de huit candidats, qui applique la même pénalité de répétition, le même bannissement du dernier token généré et le même tirage déterministe que le chemin historique.
+
+> **Invariant d’équivalence.** À logits, historique généré et état RNG identiques, le token choisi par la projection en flux est identique à celui choisi après matérialisation complète du vocabulaire.
+
+## Livraison
+
+| Composant | Modification | Effet |
+|---|---|---|
+| `gpt2_sample` | État top-k explicite avec initialisation, offre de logit et finalisation RNG | La politique d’échantillonnage est partagée par les deux chemins. |
+| Loader GGUF | Projection de tête `gpt2_gguf_forward_output_top_k_fat16` | Chaque ligne quantifiée est lue, projetée puis insérée immédiatement parmi les huit candidats. |
+| Pas de génération | Implémentation commune vers logits ou top-k en flux | Les embeddings, blocs, normalisation et cache KV restent strictement communs. |
+| Backend persistant | Suppression du tableau statique de 50 257 floats ; conservation du dernier top-k compact associé au cache KV | Environ 201 KiB de mémoire statique de logits ne sont plus requis par le runtime local. |
+| Cache KV | Invalidations explicites lorsqu’un historique généré rend une réutilisation de top-k ambiguë | Aucun candidat associé à un préfixe incompatible n’est réutilisé. |
+
+## Contrat d’échantillonnage
+
+L’accumulateur stocke huit paires `(token, score)` ordonnées. Lorsqu’un logit est proposé, il applique d’abord le bannissement du dernier token généré, puis la pénalité de fréquence sur les tokens déjà générés. La finalisation effectue ensuite la température et le tirage du même générateur linéaire que le chemin précédent.
+
+| Ressource | Avant | Après |
+|---|---:|---:|
+| Logits persistants du backend GGUF | 50 257 floats | Aucun |
+| Accumulateur de sortie | implicite dans l’échantillonneur après projection | 8 IDs + 8 scores, caller-owned |
+| Lectures de tête FAT16 | séquentielles | inchangées et séquentielles |
+| Politique top-k, température et RNG | historique | identique |
+
+## Validation
+
+Le vecteur `test_streams_output_top_k_equivalently_from_fat16` utilise la fixture GGUF quantifiée existante, projette d’abord les logits complets puis la variante en flux et vérifie l’identité du token et de l’état RNG avec un historique non vide. Les tests historiques de bannissement, pénalité et déterminisme restent verts après factorisation de l’échantillonneur.
+
+Le smoke `make qemu-gguf-smoke` confirme le boot, la sélection `ai-model use gpt2.gguf` et le retour local sur le modèle Q3_K réel. La mesure observée pour `ai bonjour` est **16,42 s** sous QEMU TCG dans cette exécution, après une mesure de **17,03 s** pour le lot de cache sectoriel. Cette variation inclut l’émulation complète ; elle ne constitue pas une promesse de latence matérielle.
+
+## Limites
+
+La projection de chaque ligne de la tête reste nécessaire pour préserver l’échantillonnage sur tout le vocabulaire. Cette livraison réduit donc la mémoire d’état et les écritures de logits, mais elle ne transforme pas le coût algorithmique de la projection Q6_K. Les prochaines pistes restent la vectorisation SSE2 des kernels, une politique de cache de pages de poids statique et une génération coopérative sans blocage prolongé du shell.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -88,10 +88,11 @@
 - [x] AOS-1561…1568 : exécution GPT-2 GGUF token-vers-logits sur FAT16, cache KV et workspace caller-owned — [aos1561_1568_gguf_token_logits.md](aos1561_1568_gguf_token_logits.md)
 - [x] AOS-1569…1576 : runtime GPT-2 GGUF local, disque FAT16 de déploiement, shell, top-k et lectures séquentielles — [aos1569_1576_gguf_local_shell.md](aos1569_1576_gguf_local_shell.md)
 - [x] AOS-1577…1584 : cache de curseur FAT16, pré-calcul Q4_K/Q6_K et smoke local chronométré — [aos1577_1584_gguf_fat16_latency.md](aos1577_1584_gguf_fat16_latency.md)
+- [x] AOS-1585…1592 : projection GGUF top-k en flux, suppression du buffer de logits et équivalence RNG — [aos1585_1592_gguf_stream_topk.md](aos1585_1592_gguf_stream_topk.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)
-- [x] Tests complets du système corrigé (`make test-all` : 453 tests exécutés avec succès ; `make qemu-smoke`, `make qemu-gguf-smoke` et `make integration-qemu`)
+- [x] Tests complets du système corrigé (`make test-all` : 454 tests exécutés avec succès ; `make qemu-smoke`, `make qemu-gguf-smoke` et `make integration-qemu`)
 - [x] Validation du fonctionnement en mode utilisateur (QEMU GTK + `sendkey`)
 - [x] Commit et push des corrections sur GitHub
 - [x] Documentation des corrections apportées ([ETAT_REEL.md](ETAT_REEL.md))

--- a/kernel/llm/gpt2_gguf_infer.c
+++ b/kernel/llm/gpt2_gguf_infer.c
@@ -45,7 +45,8 @@ static float gguf_attention[GPT2_GGUF_INFER_MAX_CHANNELS];
 static float gguf_projected[GPT2_GGUF_INFER_MAX_CHANNELS];
 static float gguf_hidden[GPT2_GGUF_INFER_HIDDEN];
 static float gguf_mlp_output[GPT2_GGUF_INFER_MAX_CHANNELS];
-static float gguf_logits[GPT2_GGUF_INFER_MAX_VOCAB];
+static gpt2_sample_top_k_state_t gguf_last_top_k;
+static uint8_t gguf_last_top_k_ready;
 static uint8_t gguf_ready;
 static const char* gguf_status = "GGUF: profil local non initialise";
 
@@ -118,6 +119,7 @@ static void gpt2_gguf_workspace_bind(void) {
 int gpt2_gguf_infer_init_fat16(const fat16_volume_t* volume, const char* filename) {
     int status;
     gguf_ready = 0U;
+    gguf_last_top_k_ready = 0U;
     gguf_status = "GGUF: profil local non initialise";
     if (!volume || gpt2_gguf_copy_filename(filename) != 0) {
         gguf_status = "GGUF: nom FAT16 invalide";
@@ -177,6 +179,7 @@ int gpt2_gguf_generate_next_sampled(const uint32_t* tokens, uint32_t token_count
                                     uint32_t* rng_state) {
     uint32_t generated = generated_count;
     uint32_t i;
+    gpt2_sample_top_k_state_t top_k;
     int status;
     if (!tokens || !next_token || !gguf_ready || !gguf_volume) {
         gguf_status = "GGUF: profil local indisponible";
@@ -193,26 +196,36 @@ int gpt2_gguf_generate_next_sampled(const uint32_t* tokens, uint32_t token_count
             return -3;
         }
     }
-    if (!gpt2_gguf_cache_matches(tokens, token_count)) gpt2_gguf_kv_cache_reset(&gguf_cache);
+    if (!gpt2_gguf_cache_matches(tokens, token_count) ||
+        (gguf_cache.count == token_count && generated != 0U)) {
+        gpt2_gguf_kv_cache_reset(&gguf_cache);
+        gguf_last_top_k_ready = 0U;
+    }
     while (gguf_cache.count < token_count) {
         uint32_t position = gguf_cache.count;
-        status = gpt2_gguf_generation_token_fat16(&gguf_generation, &gguf_cache,
-                                                   tokens[position], position,
-                                                   GPT2_GGUF_INFER_HEADS, 0.00001f,
-                                                   gguf_volume, gguf_filename,
-                                                   &gguf_workspace, gguf_logits,
-                                                   sizeof(gguf_logits));
+        gpt2_sample_top_k_init(&top_k,
+                                generated ? tokens + token_count - generated : 0,
+                                generated);
+        status = gpt2_gguf_generation_token_top_k_fat16(&gguf_generation, &gguf_cache,
+                                                         tokens[position], position,
+                                                         GPT2_GGUF_INFER_HEADS, 0.00001f,
+                                                         gguf_volume, gguf_filename,
+                                                         &gguf_workspace, &top_k);
         if (status != 0) {
             gguf_status = "GGUF: echec de lecture ou forward FAT16";
             return -20 + status;
         }
         gguf_cache_tokens[position] = tokens[position];
+        gguf_last_top_k = top_k;
+        gguf_last_top_k_ready = 1U;
+    }
+    if (!gguf_last_top_k_ready) {
+        gguf_status = "GGUF: logits top-k indisponibles";
+        return -4;
     }
     if (generated > token_count) generated = token_count;
-    *next_token = gpt2_sample_top_k(gguf_logits, gguf_generation.vocabulary,
-                                    generated ? tokens + token_count - generated : 0,
-                                    generated, rng_state);
-    gguf_status = "GGUF: jeton echantillonne localement (cache KV FAT16 actif)";
+    *next_token = gpt2_sample_top_k_finish(&gguf_last_top_k, rng_state);
+    gguf_status = "GGUF: jeton top-k en flux (cache KV FAT16 actif)";
     return 0;
 }
 

--- a/kernel/llm/gpt2_gguf_loader.c
+++ b/kernel/llm/gpt2_gguf_loader.c
@@ -645,6 +645,55 @@ int gpt2_gguf_forward_output_logits_fat16(const fat16_volume_t* volume,
     return 0;
 }
 
+int gpt2_gguf_forward_output_top_k_fat16(const fat16_volume_t* volume,
+                                         const char* filename,
+                                         const gpt2_gguf_loaded_model_t* model,
+                                         const gpt2_gguf_tensor_t* output_tensor,
+                                         uint32_t channels, uint32_t vocabulary,
+                                         const float* hidden, uint8_t* row_buffer,
+                                         uint32_t row_capacity,
+                                         gpt2_sample_top_k_state_t* top_k) {
+    fat16_file_t file;
+    uint32_t block_bytes;
+    uint32_t row_bytes;
+    uint32_t offset;
+    uint32_t row;
+    int status;
+    if (!volume || !filename || !model || !output_tensor || !hidden ||
+        !row_buffer || !top_k || channels == 0U || vocabulary == 0U) return -1;
+    if (output_tensor->dimensions != 2U || output_tensor->shape[0] != channels ||
+        output_tensor->shape[1] != vocabulary ||
+        (output_tensor->type != GPT2_GGUF_TENSOR_Q3_K &&
+         output_tensor->type != GPT2_GGUF_TENSOR_Q4_K &&
+         output_tensor->type != GPT2_GGUF_TENSOR_Q6_K)) return -9;
+    if (output_tensor->type == GPT2_GGUF_TENSOR_Q3_K) block_bytes = GPT2_Q3_K_BLOCK_BYTES;
+    else if (output_tensor->type == GPT2_GGUF_TENSOR_Q4_K) block_bytes = GPT2_Q4_K_BLOCK_BYTES;
+    else block_bytes = GPT2_Q6_K_BLOCK_BYTES;
+    if ((channels % GPT2_QK_K) != 0U ||
+        channels / GPT2_QK_K > 0xFFFFFFFFU / block_bytes) return -7;
+    row_bytes = (channels / GPT2_QK_K) * block_bytes;
+    if (row_bytes == 0U || row_capacity < row_bytes ||
+        model->index.info.tensor_data_offset > 0xFFFFFFFFU - output_tensor->data_offset) return -6;
+    offset = model->index.info.tensor_data_offset + output_tensor->data_offset;
+    status = fat16_open_file(volume, filename, &file);
+    if (status != 0) return status;
+    if (offset > file.size || output_tensor->byte_size > file.size - offset) return -3;
+    status = fat16_file_seek(&file, offset);
+    if (status != 0) return status;
+    for (row = 0U; row < vocabulary; row++) {
+        float logit = 0.0f;
+        uint32_t read = 0U;
+        status = fat16_file_read(&file, row_buffer, row_bytes, &read);
+        if (status != 0) return status;
+        if (read != row_bytes) return -8;
+        status = gpt2_gguf_dot_quant_row_buffer(output_tensor, row_buffer, read,
+                                                hidden, channels, &logit);
+        if (status != 0) return status;
+        gpt2_sample_top_k_offer(top_k, row, logit);
+    }
+    return 0;
+}
+
 static int gpt2_gguf_kv_cache_offset(const gpt2_gguf_kv_cache_t* cache,
                                      uint32_t layer, uint32_t position,
                                      uint32_t* out_offset) {
@@ -1217,14 +1266,15 @@ int gpt2_gguf_block_forward_fat16(
     return gpt2_gguf_add_residual(residual, residual_capacity, workspace->mlp_output, channels);
 }
 
-int gpt2_gguf_generation_token_fat16(
+static int gpt2_gguf_generation_token_impl(
                                       const gpt2_gguf_generation_t* generation,
                                       gpt2_gguf_kv_cache_t* cache,
                                       uint32_t token, uint32_t position,
                                       uint32_t head_count, float epsilon,
                                       const fat16_volume_t* volume, const char* filename,
                                       gpt2_gguf_generation_workspace_t* workspace,
-                                      float* logits, uint32_t logits_capacity) {
+                                      float* logits, uint32_t logits_capacity,
+                                      gpt2_sample_top_k_state_t* top_k) {
     gpt2_gguf_layer_t layer;
     gpt2_gguf_tensor_t attention_gamma, attention_beta, qkv, qkv_bias;
     gpt2_gguf_tensor_t attention_output, attention_output_bias;
@@ -1236,7 +1286,8 @@ int gpt2_gguf_generation_token_fat16(
     uint32_t i;
     int status;
     if (!generation || !generation->ready || !generation->runtime.ready || !cache ||
-        !volume || !filename || !workspace || !logits || !workspace->dense_scratch ||
+        !volume || !filename || !workspace || (!logits && !top_k) ||
+        (logits && top_k) || !workspace->dense_scratch ||
         !workspace->position_embedding || !workspace->attention_gamma ||
         !workspace->attention_beta || !workspace->qkv_bias ||
         !workspace->attention_output_bias || !workspace->ffn_gamma ||
@@ -1258,7 +1309,7 @@ int gpt2_gguf_generation_token_fat16(
         workspace->ffn_down_bias_capacity < channels ||
         workspace->final_gamma_capacity < channels || workspace->final_beta_capacity < channels ||
         workspace->final_hidden_capacity < channels ||
-        logits_capacity < generation->vocabulary * (uint32_t)sizeof(float)) return -6;
+        (logits && logits_capacity < generation->vocabulary * (uint32_t)sizeof(float))) return -6;
     if (generation->token_embedding.type == GPT2_GGUF_TENSOR_F32 ||
         generation->token_embedding.type == GPT2_GGUF_TENSOR_F16) {
         status = gpt2_gguf_read_dense_row_fat16(volume, filename, generation->runtime.model,
@@ -1371,10 +1422,39 @@ int gpt2_gguf_generation_token_fat16(
                                   workspace->final_beta, epsilon, workspace->block.norm,
                                   workspace->block.norm_capacity);
     if (status != 0) return status;
+    if (top_k) return gpt2_gguf_forward_output_top_k_fat16(
+        volume, filename, generation->runtime.model, &generation->output_weight,
+        channels, generation->vocabulary, workspace->block.norm,
+        workspace->block.row_buffer, workspace->block.row_capacity, top_k);
     return gpt2_gguf_forward_output_logits_fat16(
         volume, filename, generation->runtime.model, &generation->output_weight,
         channels, generation->vocabulary, workspace->block.norm,
         workspace->block.row_buffer, workspace->block.row_capacity, logits, logits_capacity);
+}
+
+int gpt2_gguf_generation_token_fat16(
+                                      const gpt2_gguf_generation_t* generation,
+                                      gpt2_gguf_kv_cache_t* cache,
+                                      uint32_t token, uint32_t position,
+                                      uint32_t head_count, float epsilon,
+                                      const fat16_volume_t* volume, const char* filename,
+                                      gpt2_gguf_generation_workspace_t* workspace,
+                                      float* logits, uint32_t logits_capacity) {
+    return gpt2_gguf_generation_token_impl(generation, cache, token, position, head_count,
+                                            epsilon, volume, filename, workspace, logits,
+                                            logits_capacity, 0);
+}
+
+int gpt2_gguf_generation_token_top_k_fat16(
+                                      const gpt2_gguf_generation_t* generation,
+                                      gpt2_gguf_kv_cache_t* cache,
+                                      uint32_t token, uint32_t position,
+                                      uint32_t head_count, float epsilon,
+                                      const fat16_volume_t* volume, const char* filename,
+                                      gpt2_gguf_generation_workspace_t* workspace,
+                                      gpt2_sample_top_k_state_t* top_k) {
+    return gpt2_gguf_generation_token_impl(generation, cache, token, position, head_count,
+                                            epsilon, volume, filename, workspace, 0, 0U, top_k);
 }
 
 int gpt2_gguf_block_attention_forward_fat16(

--- a/kernel/llm/gpt2_gguf_loader.h
+++ b/kernel/llm/gpt2_gguf_loader.h
@@ -3,6 +3,7 @@
 
 #include "gpt2_gguf.h"
 #include "gpt2_quant.h"
+#include "gpt2_sample.h"
 #include "../fs/fat16.h"
 
 typedef struct {
@@ -258,6 +259,15 @@ int gpt2_gguf_generation_token_fat16(
                                       const fat16_volume_t* volume, const char* filename,
                                       gpt2_gguf_generation_workspace_t* workspace,
                                       float* logits, uint32_t logits_capacity);
+/* Exécute le même token complet mais accumule directement les candidats top-k. */
+int gpt2_gguf_generation_token_top_k_fat16(
+                                      const gpt2_gguf_generation_t* generation,
+                                      gpt2_gguf_kv_cache_t* cache,
+                                      uint32_t token, uint32_t position,
+                                      uint32_t head_count, float epsilon,
+                                      const fat16_volume_t* volume, const char* filename,
+                                      gpt2_gguf_generation_workspace_t* workspace,
+                                      gpt2_sample_top_k_state_t* top_k);
 
 int gpt2_gguf_block_attention_forward_fat16(
                                       const gpt2_gguf_kv_cache_t* cache,
@@ -378,5 +388,14 @@ int gpt2_gguf_forward_output_logits_fat16(const fat16_volume_t* volume,
                                           const float* hidden, uint8_t* row_buffer,
                                           uint32_t row_capacity, float* logits,
                                           uint32_t logits_capacity);
+/* Projette toute la tête quantifiée en alimentant un top-k caller-owned. */
+int gpt2_gguf_forward_output_top_k_fat16(const fat16_volume_t* volume,
+                                         const char* filename,
+                                         const gpt2_gguf_loaded_model_t* model,
+                                         const gpt2_gguf_tensor_t* output_tensor,
+                                         uint32_t channels, uint32_t vocabulary,
+                                         const float* hidden, uint8_t* row_buffer,
+                                         uint32_t row_capacity,
+                                         gpt2_sample_top_k_state_t* top_k);
 
 #endif

--- a/kernel/llm/gpt2_sample.c
+++ b/kernel/llm/gpt2_sample.c
@@ -11,61 +11,75 @@ static float gpt2_fast_exp(float value) {
     return convert.f;
 }
 
+void gpt2_sample_top_k_init(gpt2_sample_top_k_state_t* state,
+                            const uint32_t* generated, uint32_t generated_count) {
+    if (!state) return;
+    state->generated = generated;
+    state->generated_count = generated_count;
+    state->count = 0U;
+}
+
+void gpt2_sample_top_k_offer(gpt2_sample_top_k_state_t* state,
+                             uint32_t token, float logit) {
+    uint32_t banned;
+    uint32_t repeats = 0U;
+    uint32_t pos;
+    float value = logit;
+    if (!state) return;
+    banned = (state->generated && state->generated_count > 0U)
+        ? state->generated[state->generated_count - 1U] : 0xFFFFFFFFu;
+    if (token == banned) return;
+    if (state->generated) {
+        for (uint32_t i = 0U; i < state->generated_count; i++) {
+            if (state->generated[i] == token) repeats++;
+        }
+    }
+    if (repeats > 0U) value -= GPT2_REPEAT_PENALTY * (float)repeats;
+    pos = state->count < GPT2_SAMPLE_TOP_K ? state->count++ : GPT2_SAMPLE_TOP_K;
+    while (pos > 0U && value > state->values[pos - 1U]) {
+        if (pos < GPT2_SAMPLE_TOP_K) {
+            state->values[pos] = state->values[pos - 1U];
+            state->ids[pos] = state->ids[pos - 1U];
+        }
+        pos--;
+    }
+    if (pos < GPT2_SAMPLE_TOP_K) {
+        state->values[pos] = value;
+        state->ids[pos] = token;
+    }
+}
+
+uint32_t gpt2_sample_top_k_finish(const gpt2_sample_top_k_state_t* state,
+                                  uint32_t* rng_state) {
+    float weights[GPT2_SAMPLE_TOP_K];
+    uint32_t random_state = rng_state && *rng_state ? *rng_state : 0x9e3779b9U;
+    uint32_t banned;
+    float total = 0.0f;
+    float target;
+    if (!state) return 0U;
+    banned = (state->generated && state->generated_count > 0U)
+        ? state->generated[state->generated_count - 1U] : 0xFFFFFFFFu;
+    if (state->count == 0U) return banned == 0xFFFFFFFFu ? 0U : banned;
+    for (uint32_t i = 0U; i < state->count; i++) {
+        weights[i] = gpt2_fast_exp((state->values[i] - state->values[0]) / GPT2_SAMPLE_TEMPERATURE);
+        total += weights[i];
+    }
+    random_state = random_state * 1664525U + 1013904223U;
+    if (rng_state) *rng_state = random_state;
+    target = ((float)(random_state & 0x00ffffffU) / 16777216.0f) * total;
+    for (uint32_t i = 0U; i < state->count; i++) {
+        if (target <= weights[i]) return state->ids[i];
+        target -= weights[i];
+    }
+    return state->ids[state->count - 1U];
+}
+
 uint32_t gpt2_sample_top_k(const float* logits, uint32_t vocab,
                            const uint32_t* generated, uint32_t generated_count,
                            uint32_t* rng_state) {
-    uint32_t ids[GPT2_SAMPLE_TOP_K];
-    float values[GPT2_SAMPLE_TOP_K];
-    float weights[GPT2_SAMPLE_TOP_K];
-    uint32_t count = 0;
-    uint32_t state = rng_state && *rng_state ? *rng_state : 0x9e3779b9U;
-    uint32_t banned = (generated && generated_count > 0U)
-        ? generated[generated_count - 1U] : 0xFFFFFFFFu;
-
+    gpt2_sample_top_k_state_t state;
     if (!logits || vocab == 0U) return 0U;
-
-    for (uint32_t i = 0; i < vocab; i++) {
-        float value;
-        uint32_t repeats = 0;
-        uint32_t pos;
-
-        if (i == banned) continue;
-        value = logits[i];
-        if (generated) {
-            for (uint32_t j = 0; j < generated_count; j++) {
-                if (generated[j] == i) repeats++;
-            }
-        }
-        if (repeats > 0U) value -= GPT2_REPEAT_PENALTY * (float)repeats;
-        pos = count < GPT2_SAMPLE_TOP_K ? count++ : GPT2_SAMPLE_TOP_K;
-        while (pos > 0U && value > values[pos - 1U]) {
-            if (pos < GPT2_SAMPLE_TOP_K) {
-                values[pos] = values[pos - 1U];
-                ids[pos] = ids[pos - 1U];
-            }
-            pos--;
-        }
-        if (pos < GPT2_SAMPLE_TOP_K) {
-            values[pos] = value;
-            ids[pos] = i;
-        }
-    }
-    if (count == 0U) return banned == 0xFFFFFFFFu ? 0U : banned;
-
-    {
-        float total = 0.0f;
-        float target;
-        for (uint32_t i = 0; i < count; i++) {
-            weights[i] = gpt2_fast_exp((values[i] - values[0]) / GPT2_SAMPLE_TEMPERATURE);
-            total += weights[i];
-        }
-        state = state * 1664525U + 1013904223U;
-        if (rng_state) *rng_state = state;
-        target = ((float)(state & 0x00ffffffU) / 16777216.0f) * total;
-        for (uint32_t i = 0; i < count; i++) {
-            if (target <= weights[i]) return ids[i];
-            target -= weights[i];
-        }
-        return ids[count - 1U];
-    }
+    gpt2_sample_top_k_init(&state, generated, generated_count);
+    for (uint32_t i = 0U; i < vocab; i++) gpt2_sample_top_k_offer(&state, i, logits[i]);
+    return gpt2_sample_top_k_finish(&state, rng_state);
 }

--- a/kernel/llm/gpt2_sample.h
+++ b/kernel/llm/gpt2_sample.h
@@ -5,11 +5,25 @@
 
 #define GPT2_SAMPLE_TOP_K 8U
 
+typedef struct {
+    uint32_t ids[GPT2_SAMPLE_TOP_K];
+    float values[GPT2_SAMPLE_TOP_K];
+    const uint32_t* generated;
+    uint32_t generated_count;
+    uint32_t count;
+} gpt2_sample_top_k_state_t;
+
 /*
  * Near-greedy top-k (temperature 0.6). Frequency penalty and the previous-token
  * ban apply only to tokens already emitted, never to the prompt. That stops
  * GPT-2's " The The The" loop without derailing the continuation.
  */
+void gpt2_sample_top_k_init(gpt2_sample_top_k_state_t* state,
+                            const uint32_t* generated, uint32_t generated_count);
+void gpt2_sample_top_k_offer(gpt2_sample_top_k_state_t* state,
+                             uint32_t token, float logit);
+uint32_t gpt2_sample_top_k_finish(const gpt2_sample_top_k_state_t* state,
+                                  uint32_t* rng_state);
 uint32_t gpt2_sample_top_k(const float* logits, uint32_t vocab,
                            const uint32_t* generated, uint32_t generated_count,
                            uint32_t* rng_state);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -102,14 +102,14 @@ $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_gguf_infer: $(UNIT_DIR)/kernel/test_gp
 	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c ../kernel/llm/gpt2_gguf_infer.c ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_gguf: $(UNIT_DIR)/kernel/test_gpt2_gguf.c ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_gpt2_gguf: $(UNIT_DIR)/kernel/test_gpt2_gguf.c ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
-$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_fat16: $(UNIT_DIR)/kernel/test_fat16.c ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
+$(BUILD_DIR)/$(UNIT_DIR)/kernel/test_fat16: $(UNIT_DIR)/kernel/test_fat16.c ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c $(FRAMEWORK_SOURCES)
+	$(CC) $(CFLAGS_KERNEL) -o $@ $< ../kernel/fs/fat16.c ../kernel/llm/gpt2_gguf.c ../kernel/llm/gpt2_gguf_loader.c ../kernel/llm/gpt2_quant.c ../kernel/llm/gpt2_sample.c $(FRAMEWORK_SOURCES)
 	@echo "Compiled kernel test: $(notdir $@)"
 
 $(BUILD_DIR)/$(UNIT_DIR)/kernel/test_vga_console: $(UNIT_DIR)/kernel/test_vga_console.c ../kernel/vga_console.c $(FRAMEWORK_SOURCES) $(FRAMEWORK_HEADERS)

--- a/tests/scripts/run_all_tests.sh
+++ b/tests/scripts/run_all_tests.sh
@@ -109,7 +109,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_infer.c $BASE_DIR/kernel/llm/gpt2_sample.c"
     fi
     if [ "$(basename "$test_file")" = "test_gpt2_gguf.c" ]; then
-        extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c $BASE_DIR/kernel/llm/gpt2_quant.c"
+        extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c $BASE_DIR/kernel/llm/gpt2_quant.c $BASE_DIR/kernel/llm/gpt2_sample.c"
     fi
     if [ "$(basename "$test_file")" = "test_gpt2_gguf_infer.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c $BASE_DIR/kernel/llm/gpt2_quant.c $BASE_DIR/kernel/llm/gpt2_gguf_infer.c $BASE_DIR/kernel/llm/gpt2_sample.c"
@@ -118,7 +118,7 @@ run_test() {
         extra_src="$extra_src $BASE_DIR/kernel/llm/gpt2_quant.c"
     fi
     if [ "$(basename "$test_file")" = "test_fat16.c" ]; then
-        extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c $BASE_DIR/kernel/llm/gpt2_quant.c"
+        extra_src="$extra_src $BASE_DIR/kernel/fs/fat16.c $BASE_DIR/kernel/llm/gpt2_gguf.c $BASE_DIR/kernel/llm/gpt2_gguf_loader.c $BASE_DIR/kernel/llm/gpt2_quant.c $BASE_DIR/kernel/llm/gpt2_sample.c"
     fi
     if [ "$(basename "$test_file")" = "test_vga_console.c" ]; then
         extra_src="$extra_src $BASE_DIR/kernel/vga_console.c"

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -826,6 +826,39 @@ static void test_generates_gguf_token_logits_from_fat16(void) {
                                                             logits, sizeof(logits)));
 }
 
+static void test_streams_output_top_k_equivalently_from_fat16(void) {
+    fat16_volume_t volume;
+    gpt2_gguf_loaded_model_t model;
+    gpt2_gguf_layer_t layers[1];
+    gpt2_gguf_generation_t generation;
+    float hidden[BLOCK_CHANNELS] = {0.0f};
+    float logits[4U] = {0.0f};
+    uint8_t row[4U * GPT2_Q4_K_BLOCK_BYTES] = {0U};
+    uint32_t generated[1] = {1U};
+    uint32_t rng_logits = 0x12345678U;
+    uint32_t rng_streamed = 0x12345678U;
+    uint32_t token_logits;
+    uint32_t token_streamed;
+    gpt2_sample_top_k_state_t top_k;
+    char name[64];
+    make_block_gguf_file();
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_load_fat16(&volume, "block.ggu", block_model_buffer,
+                                               sizeof(block_model_buffer), &model));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_generation_prepare(&model, name, sizeof(name), layers, 1U, &generation));
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_forward_output_logits_fat16(
+        &volume, "block.ggu", &model, &generation.output_weight, BLOCK_CHANNELS, 4U,
+        hidden, row, sizeof(row), logits, sizeof(logits)));
+    gpt2_sample_top_k_init(&top_k, generated, 1U);
+    TEST_ASSERT_EQUAL(0, gpt2_gguf_forward_output_top_k_fat16(
+        &volume, "block.ggu", &model, &generation.output_weight, BLOCK_CHANNELS, 4U,
+        hidden, row, sizeof(row), &top_k));
+    token_logits = gpt2_sample_top_k(logits, 4U, generated, 1U, &rng_logits);
+    token_streamed = gpt2_sample_top_k_finish(&top_k, &rng_streamed);
+    TEST_ASSERT_EQUAL((int)token_logits, (int)token_streamed);
+    TEST_ASSERT_EQUAL((int)rng_logits, (int)rng_streamed);
+}
+
 static void test_mount_list_and_read(void) {
     fat16_volume_t volume;
     os_fat16_dirent_t entries[4];
@@ -1027,6 +1060,7 @@ int main(void) {
     RUN_TEST(test_indexes_gpt2_header_from_fat16);
     RUN_TEST(test_executes_q4_block_from_fat16);
     RUN_TEST(test_generates_gguf_token_logits_from_fat16);
+    RUN_TEST(test_streams_output_top_k_equivalently_from_fat16);
     RUN_TEST(test_reads_bounded_file_range);
     RUN_TEST(test_cursor_reads_successive_windows);
     RUN_TEST(test_cursor_caches_shared_sector);


### PR DESCRIPTION
## AOS-1585…1592 — projection GGUF top-k en flux

Cette PR supprime le buffer persistant de 50 257 logits du backend GGUF local et alimente l’échantillonneur pendant le parcours séquentiel FAT16.

### Contenu
- accumulateur top-k compact partagé par le sampler historique et le runtime GGUF ;
- projection de tête Q3_K/Q4_K/Q6_K vers l’accumulateur, sans tableau de vocabulaire ;
- pas de génération commun vers logits ou top-k en flux ;
- conservation sûre du dernier top-k avec le cache KV ;
- suppression du tableau statique de logits du backend ;
- équivalence Unity token + RNG avec historique non vide ;
- Makefile et runner CI alignés sur la dépendance `gpt2_sample.c`.

### Mesure locale
Le smoke QEMU réel `ai bonjour` a observé **16,42 s** pour le premier token, après **17,03 s** sur le lot de cache sectoriel. Cette valeur inclut la variabilité QEMU TCG.

### Validation locale
- `make test-all` : **454/454** verts ;
- `make qemu-smoke` : core, extras, persistance, spawn/yield/wait et exec verts ;
- `make qemu-gguf-smoke` : génération locale Q3_K verte ;
- `git diff --check` et recherche d’allocateurs dynamiques : propres.

Documentation : `docs/aos1585_1592_gguf_stream_topk.md`.