### PR TITLE
fix: run real GGUF Q3_K forward from FAT16

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AI-OS est un **prototype de hobby OS i386 32-bit** démarrant par Multiboot. Ce 
 | Découverte Foundation | Registre volatile de 8 services et 8 abonnements ; retrait, transfert par propriétaire, notifications et purge immédiate à la terminaison ; pas de capabilities |
 | Fichiers | Archive initrd TAR en lecture seule, overlay AIOV V2 sur ATA PIO (64 nœuds, V1 compatible), volume FAT16 et primitives FAT32 d’écriture/chaînage/rollback hors intégration VFS complète |
 | IA locale | GPT-2 124M `llm.c v3`, BPE UTF-8, cache KV, SSE2 et top-k sur workspace statique borné, sans réseau au boot ni allocation dynamique dans le moteur d’inférence |
-| GGUF | Runtime GPT-2 GGUF v3 local : catalogue FAT16 borné à 2 MiB, cache de secteur caller-owned, embeddings Q3_K, matrices Q3_K/Q4_K/Q6_K, bloc avec biais MLP, cache KV statique, top-k en flux sans buffer de logits complet, session coopérative `ai` / `ai-continue` et shell `ai-model use gpt2.gguf`, sans allocation dynamique |
+| GGUF | Runtime GPT-2 GGUF v3 local : catalogue FAT16 borné à 2 MiB, embeddings Q3_K, matrices Q3_K/Q4_K/Q6_K, bloc MLP réel à largeur 4C, cache KV statique, top-k en flux sans buffer de logits complet, session coopérative `ai` / `ai-continue` et shell `ai-model use gpt2.gguf`, sans allocation dynamique ; très lent sous QEMU TCG |
 | Réseau | Pilote NE2000 ISA, `SYS_NET_STATUS`, codecs ARP/IPv4/UDP/DHCP/DNS/TCP/TLS record, renouvellement, réacquisition et backoff DHCP caller-owned différés hors IRQ0, conservation fournisseur et reprise HTTP/SSE contrôlées, reprise SSE fine `Last-Event-ID`, registre TCP statique, orchestrateur noyau DHCP/DNS/ARP/SYN→TLS→HTTP/SSE socket et FIN+ACK transactionnel ; client OpenAI Chat Completions activable depuis le shell, campagne externe réelle en attente d’une clé API valide |
 
 Les commandes du shell comprennent notamment `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `cp`, `mv`, `write`, `append`, `touch`, `stat`, `grep`, `wc`, `sort`, `head`, `tail`, `fat16-list`, `fat16-cat`, `spawn`, `yield`, `ipc-send`, `ipc-recv`, `service-publish`, `service-grant`, `service-find`, `service-status <nom>`, `service-watch`, `vfs-backend-probe <fichier>`, `vfs-backend-write-probe <fichier> <texte>`, `vfs-backend-remove-probe <fichier>`, `vfs-backend-rename-probe <src> <dst>`, `vfs-grant <pid>`, `vfs-backend-grant <pid>`, `vfs-backend-grant-read <pid>`, `vfs-backend-grant-mutate <pid>`, `vfs-backend-revoke <pid>`, `vfs-backend-status <pid>`, `vfs-backend-list`, `vfs-read <chemin>`, `vfs-stat <chemin>`, `vfs-list <repertoire/>`, `vfs-list-page <repertoire/> <depart>`, `vfs-mkdir`, `vfs-rmdir`, `vfs-stats`, `vfs-mount-add <prefixe/> <initrd|overlay>`, `vfs-mount-remove <prefixe/>`, `vfs-write <chemin> <texte>`, `vfs-remove <chemin>`, `vfs-rename <src> <dst>`, `jobs`, `top`, `ai`, `ai-continue`, `ai-provider`, `ai-model`, `ai-runtime`, `ai-credential`, `net-status` et `net-status json`. La liste complète, y compris la supervision de tâches, est dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md).
@@ -45,10 +45,10 @@ make run
 | Cible | Rôle |
 |---|---|
 | `make all` | Noyau, initrd et image overlay IDE (AIOV + FAT16 à partir du LBA 64) |
-| `make test-all` | Suite complète Unity/robustesse ; l’état courant validé est de 455 tests exécutés avec succès |
+| `make test-all` | Suite complète Unity/robustesse ; l’état courant validé est de 456 tests exécutés avec succès |
 | `make qemu-smoke` | Scénarios QEMU classiques : overlay, persistance, spawn/yield et exec |
 | `make gguf-disk` | Construit un disque FAT16 de déploiement contenant le modèle sous l’alias `GPT2.GGU` |
-| `make qemu-gguf-smoke` | Démarre le disque GGUF, sélectionne `gpt2.gguf`, valide un token local et affiche sa latence |
+| `make qemu-gguf-smoke` | Démarre le disque GGUF, sélectionne `gpt2.gguf`, valide le premier token local réel puis `ai-continue` et affiche les deux latences |
 | `make integration-qemu` | Contrats QEMU AOS-022, AOS-024, AOS-025, NE2000, IPC, VFS avec montages dynamiques, mutations médiées, révocation, notifications, cycle de vie et transfert Foundation |
 | `make qemu-irq0-preemption` | Lance `spin` puis exige un shell toujours réactif |
 | `make qemu-ai-provider` | Vérifie le diagnostic réseau et le blocage OpenAI |
@@ -91,13 +91,13 @@ QEMU nécessite **1 Gio** de RAM quand le checkpoint FP32 est dans l’initrd. D
 
 ## GGUF, OpenAI et réseau : limites assumées
 
-AI-OS valide la structure GGUF v3 et exécute désormais le profil GPT-2 GGUF quantifié depuis FAT16. `make gguf-disk` conserve les poids hors initrd sous `GPT2.GGU`; le boot indexe seulement le catalogue et `ai-model use gpt2.gguf` sélectionne le syscall local dédié. Les lectures de QKV, MLP et logits sont séquentielles sur FAT16 et le workspace reste entièrement statique.
+AI-OS valide la structure GGUF v3 et exécute désormais le profil GPT-2 GGUF quantifié depuis FAT16, y compris la projection descendante MLP à largeur `4C` et les lectures profondes de la chaîne FAT16. `make gguf-disk` conserve les poids hors initrd sous `GPT2.GGU`; le boot indexe seulement le catalogue et `ai-model use gpt2.gguf` sélectionne le syscall local dédié. Les lectures de QKV, MLP et logits sont séquentielles sur FAT16 et le workspace reste entièrement statique.
 
 Le profil `ai-provider openai` est activable de façon contrôlée : la session noyau relie DHCP, DNS, socket TCP statique, TLS, HTTP/SSE et extraction de réponse. `net-status` / `net-status json` publient la présence réelle d’une NIC NE2000 ISA ; l’appel externe reste désactivé tant qu’un bearer n’est pas configuré par `ai-credential`. Les secrets OpenAI ne doivent jamais être inclus dans l’image, les logs série ou le dépôt.
 
 ## Tests et artefacts
 
-`make test-all` a validé **455 tests exécutés avec succès** dans l’état courant, dont FAT16/FAT32, curseur, saut et cache de secteur FAT16, projection GGUF top-k en flux, session GGUF locale persistante, console VGA, PCI, SHA-256/HMAC, codecs Ethernet/ARP/IPv4/UDP/DHCP/DNS/TCP, NE2000, orchestrateur noyau LLM TLS/HTTP/SSE sur socket, GPT-2/GGUF, IPC, VFS, services, shell et RAMFS. `make qemu-gguf-smoke` complète les smokes QEMU en validant le disque GPT2.GGU, la génération locale sélectionnée dans le shell et sa durée mesurée. Les détails de périmètre et les limites restantes sont maintenus dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md) et [docs/todo.md](docs/todo.md).
+`make test-all` a validé **456 tests exécutés avec succès** dans l’état courant, dont FAT16/FAT32, curseur, saut et cache de secteur FAT16, une lecture FAT16 profonde multi-secteurs, projection GGUF top-k en flux, session GGUF locale persistante, console VGA, PCI, SHA-256/HMAC, codecs Ethernet/ARP/IPv4/UDP/DHCP/DNS/TCP, NE2000, orchestrateur noyau LLM TLS/HTTP/SSE sur socket, GPT-2/GGUF, IPC, VFS, services, shell et RAMFS. `make qemu-gguf-smoke` complète les smokes QEMU en validant le disque GPT2.GGU, le premier token sélectionné dans le shell et `ai-continue`, avec deux durées mesurées. Sur QEMU TCG, ces durées sont de plusieurs minutes pour le modèle Q3_K réel ; elles ne préjugent pas de la performance matérielle. Les détails de périmètre et les limites restantes sont maintenus dans [docs/ETAT_REEL.md](docs/ETAT_REEL.md) et [docs/todo.md](docs/todo.md).
 
 Une ISO BIOS/GRUB peut être produite avec l’initrd. Lorsque les poids GPT-2 sont fournis, ils sont bien incorporés à l’ISO pour un fonctionnement local sur une machine vierge ; ils restent ignorés par Git.
 
@@ -107,7 +107,7 @@ Le backlog courant est [US/ai_os_us.md](US/ai_os_us.md). La vision MOHHOS est co
 
 - [x] GPT-2 local, cache KV, SSE2 et top-k borné
 - [x] Tokenizer BPE UTF-8 avec couverture de lettres Unicode ciblée
-- [x] Sonde GGUF v3, kernels Q3_K/Q4_K/Q6_K, mapping de couches, runtime FAT16 local et session persistante `ai-continue`
+- [x] Sonde GGUF v3, kernels Q3_K/Q4_K/Q6_K, mapping de couches, forward Q3_K réel depuis FAT16 et session persistante `ai-continue`
 - [x] Tests QEMU versionnés
 - [x] Overlay ATA PIO V2, 64 nœuds et restauration V1
 - [x] Préemption IRQ0 sûre entre tâches Ring 3

--- a/docs/aos1601_1608_gguf_real_runtime.md
+++ b/docs/aos1601_1608_gguf_real_runtime.md
@@ -1,0 +1,68 @@
+# AOS-1601 à AOS-1608 — exécution GGUF réelle, lecture FAT16 profonde et smoke de continuation
+
+> **Statut : livré et mesuré.** Ce macro-lot corrige les deux bornes qui empêchaient le forward GPT-2 GGUF Q3_K réel d’atteindre sa projection de vocabulaire, puis transforme le smoke QEMU en validation effective d’un premier jeton local et d’une continuation `ai-continue`.
+
+## Constat initial
+
+Les lots précédents validaient les kernels quantifiés et le chemin shell avec des fixtures courtes. Sur le modèle Q3_K de déploiement, le premier forward pouvait cependant s’arrêter avant le token avec un code de capacité, puis le shell basculait vers le programme de compatibilité. Le marqueur textuel historique du smoke reconnaissait également ce repli comme une réponse locale, ce qui ne démontrait pas l’inférence réelle.
+
+| Sujet | Cause identifiée | Correction |
+|---|---|---|
+| Projection MLP `ffn_down` | Le buffer de ligne était limité à trois blocs Q6_K, soit 630 octets. Une ligne `ffn_down` de largeur `4 × 768` nécessite jusqu’à 2 520 octets au format Q6_K. | Le buffer statique est dimensionné à partir de la largeur cachée maximale `4C` et du pire bloc Q6_K. |
+| Lecture profonde FAT16 | Les gardes des lecteurs augmentaient pour chaque secteur après avoir compté les clusters sautés. Une lecture légitime à la fin d’un grand fichier pouvait ainsi devenir `OS_FAT16_CORRUPT`. | La garde progresse uniquement lors du franchissement d’un cluster, pour `fat16_read_file_range` et `fat16_file_read`. |
+| Smoke local | Le smoke acceptait le préfixe commun au diagnostic « indisponible ». | Le scénario rejette explicitement le repli, lance `ai-continue` et mesure séparément les deux tours. |
+
+> **Invariant de sûreté :** la garde reste bornée par le nombre de clusters ; seule son unité de comptage est corrigée. Une chaîne cyclique ou une valeur FAT invalide est toujours rejetée.
+
+## Buffer de ligne du profil GPT-2
+
+Le runtime statique utilise `GPT2_GGUF_INFER_MAX_CHANNELS = 768` et une largeur MLP maximale de `4C = 3 072`. Les lignes quantifiées sont lues dans un buffer caller-owned interne avant déquantification et produit scalaire. Le dimensionnement précédent couvrait une projection à 768 canaux, mais pas la matrice descendante MLP dont l’entrée est de 3 072 canaux.
+
+| Quantification | Octets par bloc de 256 valeurs | Blocs pour 3 072 valeurs | Buffer minimal |
+|---|---:|---:|---:|
+| Q3_K | 110 | 12 | 1 320 octets |
+| Q4_K | 144 | 12 | 1 728 octets |
+| Q6_K | 210 | 12 | 2 520 octets |
+
+La nouvelle borne choisit Q6_K, le format le plus large supporté. Le stockage reste un tableau statique ; aucune allocation dynamique n’est ajoutée.
+
+## Garde de chaîne FAT16
+
+Un fichier FAT16 est suivi par clusters, mais une lecture peut consommer plusieurs secteurs à l’intérieur du même cluster. La garde doit donc mesurer les **transitions de clusters**, et non les itérations de secteurs. Cette distinction est essentielle pour le fichier `GPT2.GGU`, qui est volumineux et utilise des clusters de 4 Kio.
+
+Le vecteur `test_reads_deep_multisector_cluster_without_false_corruption` construit un volume FAT16 valide de plus de 4 085 clusters, lit 3 000 octets depuis une position profonde d’un fichier à clusters de 4 Kio, puis répète la lecture avec un curseur. Il vérifie les deux implémentations et verrouille la régression qui faisait échouer les lectures profondes après quelques secteurs.
+
+## Smoke QEMU de génération réelle
+
+Le script `ci_qemu_gguf_local_smoke.py` suit maintenant ce parcours : démarrage avec `GPT2.GGU`, sélection de `gpt2.gguf`, `ai bonjour`, puis `ai-continue`. Il rejette un diagnostic `indisponible` ou `session indisponible`, et publie deux mesures distinctes. La limite par défaut de génération est de 600 secondes pour tenir compte de QEMU TCG.
+
+| Mesure observée sous QEMU TCG | Durée |
+|---|---:|
+| Premier token après `ai bonjour` | 529,67 s |
+| Continuation après `ai-continue` | 175,05 s |
+
+Ces durées valident le chemin réel complet, y compris le cache KV et la session persistante, mais ne constituent **ni une promesse de performance matérielle, ni un objectif atteint**. Elles montrent que le forward quantifié, notamment les 50 257 projections de sortie et l’émulation i386 TCG, reste le goulot dominant. Le sous-objectif historique inférieur à une seconde reste non satisfait.
+
+## Validation
+
+| Vérification | Résultat |
+|---|---|
+| Test FAT16 ciblé | 15/15 verts, y compris la lecture profonde par plage et curseur. |
+| Build freestanding i386 | Réussi après le redimensionnement du buffer. |
+| Smoke GGUF avec délai étendu | Premier token réel et continuation réels, sans repli shell. |
+| Allocation dynamique | Aucune allocation introduite ; les modifications n’ajoutent ni `kmalloc`, ni `malloc`, ni `calloc`, ni `realloc`. |
+
+La suite complète a validé **456 tests sur 456**, grâce au nouveau vecteur FAT16 et sans échec ni test ignoré.
+
+## Limites et suite
+
+La livraison priorise la correction fonctionnelle et l’honnêteté de mesure. Le prochain axe est l’accélération ciblée de la projection de sortie Q3_K et des kernels de produit scalaire sous i386, idéalement avec une stratégie qui évite de relire ou de déquantifier 50 257 lignes pour chaque tour. Toute optimisation devra conserver l’échantillonnage top-k complet, l’équivalence RNG, l’absence d’allocation dynamique et une mesure QEMU explicite.
+
+## Références
+
+[1]: ../kernel/llm/gpt2_gguf_infer.c "Borne statique de ligne du runtime GPT-2 GGUF"
+[2]: ../kernel/fs/fat16.c "Lecteurs FAT16 et garde de progression de chaîne"
+[3]: ../tests/unit/kernel/test_fat16.c "Vecteur FAT16 profond multi-secteurs"
+[4]: ../tests/scripts/ci_qemu_gguf_local_smoke.py "Smoke QEMU de génération et continuation GGUF"
+
+Les corrections sont implémentées dans le runtime [1] et le lecteur FAT16 [2], puis couvertes par le vecteur de régression [3] et le smoke réel [4].

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -57,7 +57,7 @@
 - [x] `exec` bloquant : parent `TASK_WAITING`, enfant reveille via `SYS_EXIT` (plus de `int $0x30` noyau)
 - [x] AOS-020…026 : sonde GGUF, BPE UTF-8, contrats QEMU, overlay V2, IRQ0, stub OpenAI, FAT16 lecture seule
 - [x] Kernels GGUF Q3_K/Q4_K/Q6_K, index, mapping, génération shell et échantillonnage local FAT16
-- [ ] Réduire la latence locale GGUF ; le forward bout-en-bout, le cache KV, les lectures séquentielles FAT16 et la session locale coopérative sont désormais livrés
+- [ ] Réduire la latence locale GGUF ; le forward Q3_K réel, le cache KV, les lectures séquentielles FAT16 profondes et la session locale coopérative sont désormais validés, mais restent très lents sous QEMU TCG
 - [x] Écriture FAT16 8.3, création de fichiers FAT32, écriture/chaînage FAT32, extension de racine et primitives LFN FAT32 — [aos_fat_volume.md](aos_fat_volume.md) ; intégration VFS complète, Unicode hors ASCII et suppression/renommage LFN restent à faire ; pas ext2
 - [x] Pilote NE2000 ISA et codecs ARP/IPv4/UDP/DHCP/DNS/TCP/TLS record (lots 113–154)
 - [x] Validation page-par-page des pointeurs socket utilisateur dans le VMM
@@ -90,10 +90,11 @@
 - [x] AOS-1577…1584 : cache de curseur FAT16, pré-calcul Q4_K/Q6_K et smoke local chronométré — [aos1577_1584_gguf_fat16_latency.md](aos1577_1584_gguf_fat16_latency.md)
 - [x] AOS-1585…1592 : projection GGUF top-k en flux, suppression du buffer de logits et équivalence RNG — [aos1585_1592_gguf_stream_topk.md](aos1585_1592_gguf_stream_topk.md)
 - [x] AOS-1593…1600 : session GPT-2 GGUF locale persistante, continuation coopérative `ai-continue`, ABI 110 et refus sans session — [aos1593_1600_gguf_local_session.md](aos1593_1600_gguf_local_session.md)
+- [x] AOS-1601…1608 : forward GGUF Q3_K réel, buffer MLP 4C, garde FAT16 profonde corrigée et smoke `ai`/`ai-continue` sans repli — [aos1601_1608_gguf_real_runtime.md](aos1601_1608_gguf_real_runtime.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)
-- [x] Tests complets du système corrigé (`make test-all` : 455 tests exécutés avec succès ; `make qemu-smoke`, `make qemu-gguf-smoke` et `make integration-qemu`)
+- [x] Tests complets du système corrigé (`make test-all` : 456 tests exécutés avec succès ; `make qemu-smoke`, `make qemu-gguf-smoke` et `make integration-qemu`)
 - [x] Validation du fonctionnement en mode utilisateur (QEMU GTK + `sendkey`)
 - [x] Commit et push des corrections sur GitHub
 - [x] Documentation des corrections apportées ([ETAT_REEL.md](ETAT_REEL.md))

--- a/kernel/fs/fat16.c
+++ b/kernel/fs/fat16.c
@@ -459,7 +459,7 @@ int fat16_read_file_range(const fat16_volume_t* v, const char* name,
             uint32_t lba;
             uint32_t take = FAT16_SECTOR_SIZE - sector_offset;
             if (cluster < 2U || cluster >= FAT16_EOC_MIN ||
-                cluster - 2U >= v->cluster_count || guard++ > v->cluster_count) return OS_FAT16_CORRUPT;
+                cluster - 2U >= v->cluster_count || guard > v->cluster_count) return OS_FAT16_CORRUPT;
             lba = v->data_lba + (uint32_t)(cluster - 2U) * v->sectors_per_cluster + sector_in_cluster;
             if (read_at(v, lba, sector2) != 0) return OS_FAT16_CORRUPT;
             if (take > max - copied) take = max - copied;
@@ -468,7 +468,8 @@ int fat16_read_file_range(const fat16_volume_t* v, const char* name,
             copied += take;
             intra += take;
             if (intra >= cluster_bytes && copied < max && offset + copied < size) {
-                if (read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
+                if (guard++ >= v->cluster_count ||
+                    read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
                 intra = 0U;
             }
         }
@@ -556,7 +557,7 @@ int fat16_file_read(fat16_file_t* file, uint8_t* buffer, uint32_t max,
         uint32_t take = FAT16_SECTOR_SIZE - sector_offset;
         uint32_t lba;
         if (file->cluster < 2U || file->cluster >= FAT16_EOC_MIN ||
-            file->cluster - 2U >= v->cluster_count || file->guard++ > v->cluster_count) return OS_FAT16_CORRUPT;
+            file->cluster - 2U >= v->cluster_count || file->guard > v->cluster_count) return OS_FAT16_CORRUPT;
         lba = v->data_lba + (uint32_t)(file->cluster - 2U) * v->sectors_per_cluster + sector_in_cluster;
         if (!file->cache_valid || file->cached_lba != lba) {
             if (read_at(v, lba, file->sector_cache) != 0) return OS_FAT16_CORRUPT;
@@ -570,7 +571,8 @@ int fat16_file_read(fat16_file_t* file, uint8_t* buffer, uint32_t max,
         file->position += take;
         file->cluster_offset += take;
         if (file->cluster_offset >= cluster_bytes && file->position < file->size) {
-            if (read_fat_entry(v, file->cluster, &file->cluster) != 0) return OS_FAT16_CORRUPT;
+            if (file->guard++ >= v->cluster_count ||
+                read_fat_entry(v, file->cluster, &file->cluster) != 0) return OS_FAT16_CORRUPT;
             file->cluster_offset = 0U;
         }
     }

--- a/kernel/llm/gpt2_gguf_infer.c
+++ b/kernel/llm/gpt2_gguf_infer.c
@@ -4,7 +4,9 @@
 
 #define GPT2_GGUF_INFER_HIDDEN (4U * GPT2_GGUF_INFER_MAX_CHANNELS)
 #define GPT2_GGUF_INFER_DENSE_BYTES (GPT2_GGUF_INFER_HIDDEN * (uint32_t)sizeof(float))
-#define GPT2_GGUF_INFER_ROW_BYTES (3U * GPT2_Q6_K_BLOCK_BYTES)
+/* ffn_down lit une ligne de largeur 4C : dimensionner pour le pire cas Q6_K. */
+#define GPT2_GGUF_INFER_ROW_BYTES \
+    ((GPT2_GGUF_INFER_HIDDEN / GPT2_QK_K) * GPT2_Q6_K_BLOCK_BYTES)
 #define GPT2_GGUF_INFER_FILENAME_MAX 13U
 
 static uint8_t gguf_header[GPT2_GGUF_INFER_HEADER_BYTES];

--- a/tests/scripts/ci_qemu_gguf_local_smoke.py
+++ b/tests/scripts/ci_qemu_gguf_local_smoke.py
@@ -16,7 +16,7 @@ LOG = os.environ.get("LOG", os.path.join(ROOT, "test_logs", "ci-qemu-gguf-local.
 ERR = os.environ.get("QEMU_ERR", os.path.join(ROOT, "test_logs", "ci-qemu-gguf-local.err"))
 MON = os.environ.get("QEMU_MON_SOCK", os.path.join(ROOT, "test_logs", "qemu-gguf-monitor.sock"))
 BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "90"))
-GENERATION_TIMEOUT = float(os.environ.get("GGUF_GENERATION_TIMEOUT", "180"))
+GENERATION_TIMEOUT = float(os.environ.get("GGUF_GENERATION_TIMEOUT", "600"))
 KEY_DELAY = float(os.environ.get("KEY_DELAY", "0.65"))
 
 
@@ -98,7 +98,18 @@ def main():
             started = time.monotonic()
             send(client, "ai bonjour")
             wait_for(proc, "[GPT-2 GGUF local]", GENERATION_TIMEOUT, start)
-        print("QEMU GGUF local smoke passed in %.2fs." % (time.monotonic() - started))
+            if "[GPT-2 GGUF local] indisponible" in text()[start:]:
+                raise RuntimeError("GGUF local rejected generation: %s" % text()[start:][-1000:])
+            first_token_elapsed = time.monotonic() - started
+            start = len(text())
+            continued = time.monotonic()
+            send(client, "ai-continue")
+            wait_for(proc, "[GPT-2 GGUF local suite]", GENERATION_TIMEOUT, start)
+            if "session indisponible" in text()[start:]:
+                raise RuntimeError("GGUF continuation rejected: %s" % text()[start:][-1000:])
+            continue_elapsed = time.monotonic() - continued
+        print("QEMU GGUF local smoke passed: premier token %.2fs, continuation %.2fs." %
+              (first_token_elapsed, continue_elapsed))
         return 0
     finally:
         if client is not None:

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -3,7 +3,7 @@
 #include "../../../kernel/llm/gpt2_gguf_loader.h"
 #include "../../../kernel/llm/gpt2_quant.h"
 
-#define TEST_SECTORS 4224U
+#define TEST_SECTORS 32768U
 #define BLOCK_CHANNELS GPT2_QK_K
 #define BLOCK_HIDDEN (4U * GPT2_QK_K)
 #define BLOCK_QKV_BYTES (3U * BLOCK_CHANNELS * GPT2_Q4_K_BLOCK_BYTES)
@@ -1044,6 +1044,43 @@ static void test_creates_lfn_file(void) {
     TEST_ASSERT_EQUAL('\0', entries[1].name[14]);
     TEST_ASSERT_EQUAL(3U, entries[1].size);
 }
+static void test_reads_deep_multisector_cluster_without_false_corruption(void) {
+    fat16_volume_t volume;
+    fat16_file_t file;
+    uint8_t range[3000];
+    uint8_t cursor[3000];
+    uint32_t root = (1U + 2U * 17U) * 512U;
+    uint32_t data = (root / 512U + 2U) * 512U;
+    uint32_t clusters = (TEST_SECTORS - (data / 512U)) / 8U;
+    uint32_t offset = (clusters - 3U) * 8U * 512U + 100U;
+    uint32_t read = 0U;
+    uint32_t i;
+    uint32_t fat;
+    make_volume();
+    disk[13] = 8U;
+    for (fat = 1U; fat <= 2U; fat++) {
+        uint32_t base = (1U + (fat - 1U) * 17U) * 512U;
+        for (i = 2U; i < clusters + 1U; i++) put16(base + i * 2U, (uint16_t)(i + 1U));
+        put16(base + clusters * 2U, 0xFFF8U);
+    }
+    disk[root + 32U] = 'D'; disk[root + 33U] = 'E'; disk[root + 34U] = 'E'; disk[root + 35U] = 'P';
+    disk[root + 36U] = ' '; disk[root + 37U] = ' '; disk[root + 38U] = ' '; disk[root + 39U] = ' ';
+    disk[root + 40U] = 'B'; disk[root + 41U] = 'I'; disk[root + 42U] = 'N'; disk[root + 43U] = 0x20U;
+    put16(root + 32U + 26U, 2U);
+    put32(root + 32U + 28U, clusters * 8U * 512U);
+    for (i = 0U; i < sizeof(range); i++) disk[data + offset + i] = (uint8_t)(i ^ 0x5AU);
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, fat16_read_file_range(&volume, "deep.bin", offset,
+                                                range, sizeof(range), &read));
+    TEST_ASSERT_EQUAL(sizeof(range), read);
+    for (i = 0U; i < sizeof(range); i++) TEST_ASSERT_EQUAL((uint8_t)(i ^ 0x5AU), range[i]);
+    TEST_ASSERT_EQUAL(0, fat16_open_file(&volume, "deep.bin", &file));
+    TEST_ASSERT_EQUAL(0, fat16_file_seek(&file, offset));
+    TEST_ASSERT_EQUAL(0, fat16_file_read(&file, cursor, sizeof(cursor), &read));
+    TEST_ASSERT_EQUAL(sizeof(cursor), read);
+    for (i = 0U; i < sizeof(cursor); i++) TEST_ASSERT_EQUAL((uint8_t)(i ^ 0x5AU), cursor[i]);
+}
+
 static void test_rejects_bad_name_and_small_buffer(void) {
     fat16_volume_t volume;
     char content[4];
@@ -1065,6 +1102,7 @@ int main(void) {
     RUN_TEST(test_cursor_reads_successive_windows);
     RUN_TEST(test_cursor_caches_shared_sector);
     RUN_TEST(test_rejects_bad_bpb);
+    RUN_TEST(test_reads_deep_multisector_cluster_without_false_corruption);
     RUN_TEST(test_rejects_bad_name_and_small_buffer);
     RUN_TEST(test_writes_only_with_explicit_writer);
     RUN_TEST(test_creates_persistent_file);


### PR DESCRIPTION
## Résumé

Ce lot rend le forward GPT-2 GGUF Q3_K réellement exécutable sur le disque FAT16 de déploiement et durcit sa validation de bout en bout.

- dimensionne le buffer de ligne statique pour `ffn_down` à largeur 4C (jusqu’à Q6_K) ;
- corrige la garde FAT16 pour compter les transitions de clusters, non les secteurs ;
- ajoute un vecteur FAT16 profond multi-secteurs ;
- exige un token GGUF réel et une continuation `ai-continue` dans le smoke QEMU ;
- documente les limites de latence QEMU TCG, sans allocation dynamique.

## Validation locale

- `make test-all` : **456/456** ;
- `make all` : build freestanding i386 réussi ;
- `make qemu-smoke` : réussi ;
- `GGUF_GENERATION_TIMEOUT=600 make qemu-gguf-smoke` : premier token réel **529,67 s**, continuation réelle **175,05 s** sous QEMU TCG ;
- `git diff --check` et audit ciblé sans `kmalloc`/`malloc`/`calloc`/`realloc` : réussis.

La durée QEMU TCG est une mesure fonctionnelle et non une promesse de performance matérielle.