### PR TITLE
feat: add FAT16 LFN read lookup

### DIFF
--- a/docs/aos1641_1648_gguf_latency_closure.md
+++ b/docs/aos1641_1648_gguf_latency_closure.md
@@ -1,0 +1,41 @@
+# AOS-1641 à AOS-1648 — clôture mesurée de l’axe de latence GGUF
+
+## Objet
+
+Ce lot clôt l’exploration des optimisations locales du runtime GPT-2 GGUF Q3_K lu depuis FAT16. La règle de décision est conservée : une optimisation ne peut être retenue que si son gain est **reproductible au-delà de la variabilité observée de QEMU TCG**, approximativement trois à cinq secondes pour le premier token et une à deux secondes pour la continuation. Le runtime reste entièrement freestanding, i386 et sans allocation dynamique.
+
+## État retenu
+
+| Composant | État retenu | Justification |
+|---|---|---|
+| Transferts ATA PIO | `rep insw` / `rep outsw` | Gain mesuré et chemin matériel inchangé. |
+| FAT16 | Fenêtre caller-owned de 8 Kio sur 16 secteurs, conservée entre clusters ; cache FAT isolé | Réduit fortement les lectures physiques et conserve les contrats d’erreur. |
+| Q3_K | Décodage sans branche | Équivalence fonctionnelle et réduction déterministe du contrôle conditionnel. |
+| Cache KV et session locale | Résidents, bornés à 64 positions | Évite le recalcul du contexte sans allocation dynamique. |
+
+Les deux essais complémentaires suivants ont été exécutés sur le vrai disque `GPT2.GGU`, ont franchi les tests unitaires applicables, puis ont été retirés car aucune amélioration robuste n’a été observée.
+
+| Essai retiré | Empreinte additionnelle | Mesure QEMU TCG | Décision |
+|---|---:|---:|---|
+| Cache paresseux des huit vecteurs constants de chaque couche | Environ 474 Kio statiques | 50,08 s puis 21,88 s | Rejeté : pas de gain, budget mémoire inutile. |
+| Spécialisation Q3_K de la ligne top-k pour éviter le dispatch par super-bloc | Aucune | 49,94 s puis 21,43 s | Rejeté : variation contradictoire et inférieure au seuil de confiance. |
+
+Après retrait des deux essais, le smoke propre a produit **48,59 s** pour le premier token et **23,08 s** pour `ai-continue`. Cette mesure est cohérente avec la variabilité déjà documentée : elle ne constitue pas une régression ni une promesse de performance matérielle.
+
+> Le forward d’un token GPT-2 124M contient environ 84 934 656 multiplications dans les douze couches et 38 597 376 dans la projection de vocabulaire, soit environ 123 532 032 multiplications. Les micro-optimisations de normalisation, de copies de petits vecteurs ou de dispatch n’ont donc pas une marge crédible de plusieurs secondes sous QEMU TCG.
+
+## Validation de clôture
+
+La suite complète a été relancée après tous les retraits. Elle valide **457 tests sur 457** avec succès. Le dépôt a été vérifié propre et synchronisé avec `origin/master`. Le smoke GGUF réel valide toujours l’initialisation du modèle FAT16, le premier token de `ai` et l’avancement coopératif par `ai-continue`.
+
+## Limites et suite
+
+Cette clôture ne prétend pas épuiser les optimisations possibles sur matériel réel. Une mesure sur une cible i386 physique, ou un profiler capable d’isoler ATA, décodage Q3_K et calcul scalaire hors bruit d’émulation, serait nécessaire avant de réouvrir cet axe. La priorité de livraison bascule donc vers les fonctionnalités encore explicitement ouvertes, en commençant par la recherche FAT16 par nom long pour les opérations de lecture.
+
+## Références internes
+
+- [État réel du projet](ETAT_REEL.md)
+- [Backlog de livraison](todo.md)
+- [Mesures de la fenêtre FAT16 inter-clusters](aos1625_1632_fat16_intercluster_window.md)
+- [Décodage Q3_K sans branche et variabilité QEMU](aos1633_1640_q3k_branchless_decode.md)
+- [Contrat LFN FAT16 existant](aos1193_fat16_lfn.md)

--- a/docs/aos1649_1656_fat16_lfn_read_lookup.md
+++ b/docs/aos1649_1656_fat16_lfn_read_lookup.md
@@ -1,0 +1,47 @@
+# AOS-1649 à AOS-1656 — recherche FAT16 par nom long pour la lecture
+
+## Objet
+
+Ce macro-lot rend les opérations FAT16 de lecture capables de sélectionner un fichier par son **alias 8.3** ou par son **nom long LFN ASCII validé**. Il complète le lot de création et de listage LFN sans modifier l’ABI publique `fat16_*`, sans allocation dynamique et sans dupliquer la logique de parcours de clusters.
+
+## Contrat de recherche
+
+La nouvelle recherche interne `fat16_find_root_entry` parcourt la racine FAT16 une seule fois. Elle conserve un état LFN borné dans un tableau automatique de taille `OS_NAME_MAX`, exactement comme le listage déjà existant. Une séquence ne peut produire une correspondance longue que lorsque toutes les conditions suivantes sont respectées.
+
+| Condition | Effet |
+|---|---|
+| Nom demandé non vide, borné et ASCII imprimable | Autorise la recherche LFN ; les séparateurs de chemin et les octets non ASCII sont refusés. |
+| Alias 8.3 valide | Conserve le repli historique, sans sensibilité à la casse ASCII. |
+| Entrées LFN ordonnées, séquence initiale marquée et checksum cohérent | Reconstruit le nom long dans le buffer local. |
+| Entrée courte suivante avec checksum correspondant | Lie le LFN à son entrée FAT16 effective. |
+| Séquence supprimée, volume ou entrée de volume | Invalide l’état LFN et n’est jamais sélectionnée. |
+
+> La recherche retourne toujours l’entrée courte FAT16 associée. Les lecteurs réemploient donc les champs existants `first_cluster`, `size` et `attributes` sans nouvelle structure, ni copie persistante, ni changement du format disque.
+
+## Intégration
+
+`fat16_read_file`, `fat16_read_file_range` et `fat16_open_file` appellent désormais cette primitive commune. Le curseur `fat16_file_read` ne change pas : après l’ouverture par LFN, il conserve son cache de secteur, sa fenêtre FAT16 caller-owned et ses gardes de chaîne FAT habituels.
+
+| API | Prise en charge après le lot |
+|---|---|
+| `fat16_read_file` | Alias 8.3 et LFN ASCII validé. |
+| `fat16_read_file_range` | Alias 8.3 et LFN ASCII validé, y compris un offset non nul. |
+| `fat16_open_file` | Alias 8.3 et LFN ASCII validé. |
+| `fat16_file_read` | Inchangé ; fonctionne sur le curseur ouvert par LFN. |
+| `fat16_list_root` | Inchangé ; demeure la source de restitution des LFN validés. |
+
+## Validation
+
+Le scénario Unity de création `Session-2026-A` exerce désormais les quatre usages de lecture du même volume en mémoire. Il vérifie la lecture totale avec un nom long en casse différente, la lecture bornée à offset, l’ouverture puis la lecture cursorisée, ainsi que le refus d’un LFN absent. Les seize scénarios FAT16 restent verts, y compris les chemins GGUF, les fenêtres multi-secteurs, les chaînes profondes et l’écriture persistante.
+
+La suite complète doit être exécutée avant publication afin de confirmer l’absence de régression dans les autres lecteurs FAT16, le VFS et le runtime GGUF.
+
+## Limites
+
+Le format reste volontairement limité aux LFN ASCII de `OS_NAME_MAX - 1` caractères. L’UTF-8 complet, les caractères non BMP, la normalisation et les opérations de suppression ou renommage LFN restent hors de ce macro-lot. Le contrat n’introduit aucune allocation implicite.
+
+## Références internes
+
+- [Fondations LFN FAT16](aos1193_fat16_lfn.md)
+- [Contrats FAT16 publics](../kernel/fs/fat16.h)
+- [Clôture de la latence GGUF](aos1641_1648_gguf_latency_closure.md)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -57,7 +57,7 @@
 - [x] `exec` bloquant : parent `TASK_WAITING`, enfant reveille via `SYS_EXIT` (plus de `int $0x30` noyau)
 - [x] AOS-020…026 : sonde GGUF, BPE UTF-8, contrats QEMU, overlay V2, IRQ0, stub OpenAI, FAT16 lecture seule
 - [x] Kernels GGUF Q3_K/Q4_K/Q6_K, index, mapping, génération shell et échantillonnage local FAT16
-- [ ] Réduire la latence locale GGUF ; le forward Q3_K réel sans branche, le cache KV, les lectures FAT16 inter-clusters et la session locale coopérative sont validés ; la projection de vocabulaire/top-k demeure le prochain axe de performance
+- [x] Réduire la latence locale GGUF ; le forward Q3_K réel sans branche, le cache KV, les lectures FAT16 inter-clusters et la session locale coopérative sont validés. Les essais supplémentaires de cache paresseux de constantes et de spécialisation Q3_K top-k n’ayant pas dépassé la variabilité QEMU TCG, l’axe est clôturé avec mesures et critères dans [aos1641_1648_gguf_latency_closure.md](aos1641_1648_gguf_latency_closure.md).
 - [x] Écriture FAT16 8.3, création de fichiers FAT32, écriture/chaînage FAT32, extension de racine et primitives LFN FAT32 — [aos_fat_volume.md](aos_fat_volume.md) ; intégration VFS complète, Unicode hors ASCII et suppression/renommage LFN restent à faire ; pas ext2
 - [x] Pilote NE2000 ISA et codecs ARP/IPv4/UDP/DHCP/DNS/TCP/TLS record (lots 113–154)
 - [x] Validation page-par-page des pointeurs socket utilisateur dans le VMM
@@ -95,6 +95,8 @@
 - [x] AOS-1617…1624 : fenêtre FAT16 caller-owned de 4 Kio, lecture ATA multi-secteurs et accélération QEMU du forward/continuation GGUF — [aos1617_1624_fat16_read_window.md](aos1617_1624_fat16_read_window.md)
 - [x] AOS-1625…1632 : fenêtre FAT16 inter-clusters de 8 Kio, cache FAT isolé, invalidation après écriture et gain QEMU supplémentaire — [aos1625_1632_fat16_intercluster_window.md](aos1625_1632_fat16_intercluster_window.md)
 - [x] AOS-1633…1640 : décodage Q3_K sans branche, équivalence quantifiée et gain QEMU de projection — [aos1633_1640_q3k_branchless_decode.md](aos1633_1640_q3k_branchless_decode.md)
+- [x] AOS-1641…1648 : clôture mesurée de l’axe de latence GGUF, essais non concluants retirés et bascule vers les fonctionnalités FAT16/LFN — [aos1641_1648_gguf_latency_closure.md](aos1641_1648_gguf_latency_closure.md)
+- [x] AOS-1649…1656 : recherche FAT16 par LFN ASCII validé pour lecture totale, lecture à offset et curseur, sans allocation dynamique — [aos1649_1656_fat16_lfn_read_lookup.md](aos1649_1656_fat16_lfn_read_lookup.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/fs/fat16.c
+++ b/kernel/fs/fat16.c
@@ -437,43 +437,112 @@ int fat16_list_root(const fat16_volume_t* v, os_fat16_dirent_t* out, uint32_t ca
     return (int)count;
 }
 
-int fat16_read_file(const fat16_volume_t* v, const char* name, char* buffer, uint32_t max) {
+static int fat16_lfn_query_valid(const char* name) {
+    uint32_t i;
+    if (!name) return 0;
+    for (i = 0U; i < OS_NAME_MAX; i++) {
+        uint8_t c = (uint8_t)name[i];
+        if (c == 0U) return i != 0U;
+        if (c < 0x20U || c >= 0x80U || c == (uint8_t)'/' || c == (uint8_t)'\\') return 0;
+    }
+    return 0;
+}
+
+static int fat16_name_equals_folded(const char* left, const char* right) {
+    uint32_t i;
+    if (!left || !right) return 0;
+    for (i = 0U; i < OS_NAME_MAX; i++) {
+        char a = left[i];
+        char b = right[i];
+        if (upper_ascii(a) != upper_ascii(b)) return 0;
+        if (a == '\0' || b == '\0') return a == b;
+    }
+    return 0;
+}
+
+/* Recherche une entrée de racine à la fois par alias 8.3 et par LFN ASCII
+ * validé. Le résultat reste l’entrée courte FAT16 : aucun état ni allocation
+ * supplémentaire n’est nécessaire aux lecteurs et curseurs existants. */
+static int fat16_find_root_entry(const fat16_volume_t* v, const char* name,
+                                 uint8_t* out) {
     uint8_t short_name[11];
+    uint8_t entry[FAT16_ENTRY_SIZE];
+    char lfn[OS_NAME_MAX];
+    uint32_t i;
+    uint32_t lfn_length = 0U;
+    uint8_t lfn_sum = 0U;
+    uint8_t lfn_expected = 0U;
+    uint8_t lfn_valid = 0U;
+    int short_valid;
+    if (!fat16_is_mounted(v)) return OS_FAT16_NOT_MOUNTED;
+    if (!out || !fat16_lfn_query_valid(name)) return OS_FAT16_BAD_PATH;
+    short_valid = make_short_name(name, short_name) == 0;
+    for (i = 0U; i < v->root_entries; i++) {
+        uint8_t ordinal;
+        if (read_root_entry(v, i, entry) != 0) return OS_FAT16_CORRUPT;
+        if (entry[0] == 0x00U) break;
+        if (entry[0] == 0xE5U) { lfn_valid = 0U; continue; }
+        if (entry[11] == 0x0FU) {
+            ordinal = entry[0] & 0x1FU;
+            if ((entry[0] & 0x40U) != 0U) {
+                lfn_length = (uint32_t)ordinal * 13U;
+                if (lfn_length >= OS_NAME_MAX) { lfn_valid = 0U; continue; }
+                for (uint32_t j = 0U; j < OS_NAME_MAX; j++) lfn[j] = '\0';
+                lfn_sum = entry[13];
+                lfn_expected = ordinal;
+                lfn_valid = 1U;
+            }
+            if (!lfn_valid || ordinal == 0U || ordinal != lfn_expected ||
+                entry[13] != lfn_sum) { lfn_valid = 0U; continue; }
+            fat16_lfn_get(entry, 1U, (uint32_t)(ordinal - 1U) * 13U, lfn, OS_NAME_MAX);
+            fat16_lfn_get(entry, 14U, (uint32_t)(ordinal - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
+            fat16_lfn_get(entry, 28U, (uint32_t)(ordinal - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            lfn_expected--;
+            continue;
+        }
+        if ((entry[11] & 0x08U) != 0U) { lfn_valid = 0U; continue; }
+        if ((short_valid && entry_matches(entry, short_name)) ||
+            (lfn_valid && lfn_expected == 0U && fat16_lfn_checksum(entry) == lfn_sum &&
+             fat16_name_equals_folded(name, lfn))) {
+            for (uint32_t j = 0U; j < FAT16_ENTRY_SIZE; j++) out[j] = entry[j];
+            return 0;
+        }
+        lfn_valid = 0U;
+    }
+    return OS_FAT16_NOT_FOUND;
+}
+
+int fat16_read_file(const fat16_volume_t* v, const char* name, char* buffer, uint32_t max) {
     uint8_t entry[FAT16_ENTRY_SIZE];
     uint32_t i;
     uint32_t size;
     uint32_t copied = 0U;
     uint16_t cluster;
     uint32_t guard = 0U;
+    int status;
     if (!fat16_is_mounted(v)) return OS_FAT16_NOT_MOUNTED;
     if (!buffer || max == 0U) return OS_FAT16_BUFFER_SMALL;
-    if (make_short_name(name, short_name) != 0) return OS_FAT16_BAD_PATH;
-    for (i = 0U; i < v->root_entries; i++) {
-        if (read_root_entry(v, i, entry) != 0) return OS_FAT16_CORRUPT;
-        if (entry[0] == 0x00U) break;
-        if (entry[0] == 0xE5U || entry[11] == 0x0FU || (entry[11] & 0x08U)) continue;
-        if (!entry_matches(entry, short_name)) continue;
-        if (entry[11] & 0x10U) return OS_FAT16_BAD_PATH;
-        size = le32(entry + 28U);
-        if (size > max) return OS_FAT16_BUFFER_SMALL;
-        cluster = le16(entry + 26U);
-        while (copied < size) {
-            uint32_t s;
-            uint32_t take;
-            if (cluster < 2U || cluster >= FAT16_EOC_MIN || cluster - 2U >= v->cluster_count || guard++ > v->cluster_count) return OS_FAT16_CORRUPT;
-            for (s = 0U; s < v->sectors_per_cluster && copied < size; s++) {
-                uint32_t lba = v->data_lba + (uint32_t)(cluster - 2U) * v->sectors_per_cluster + s;
-                if (read_at(v, lba, sector2) != 0) return OS_FAT16_CORRUPT;
-                take = size - copied;
-                if (take > FAT16_SECTOR_SIZE) take = FAT16_SECTOR_SIZE;
-                for (i = 0U; i < take; i++) buffer[copied + i] = (char)sector2[i];
-                copied += take;
-            }
-            if (copied < size && read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
+    status = fat16_find_root_entry(v, name, entry);
+    if (status != 0) return status;
+    if (entry[11] & 0x10U) return OS_FAT16_BAD_PATH;
+    size = le32(entry + 28U);
+    if (size > max) return OS_FAT16_BUFFER_SMALL;
+    cluster = le16(entry + 26U);
+    while (copied < size) {
+        uint32_t s;
+        uint32_t take;
+        if (cluster < 2U || cluster >= FAT16_EOC_MIN || cluster - 2U >= v->cluster_count || guard++ > v->cluster_count) return OS_FAT16_CORRUPT;
+        for (s = 0U; s < v->sectors_per_cluster && copied < size; s++) {
+            uint32_t lba = v->data_lba + (uint32_t)(cluster - 2U) * v->sectors_per_cluster + s;
+            if (read_at(v, lba, sector2) != 0) return OS_FAT16_CORRUPT;
+            take = size - copied;
+            if (take > FAT16_SECTOR_SIZE) take = FAT16_SECTOR_SIZE;
+            for (i = 0U; i < take; i++) buffer[copied + i] = (char)sector2[i];
+            copied += take;
         }
-        return (int)copied;
+        if (copied < size && read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
     }
-    return OS_FAT16_NOT_FOUND;
+    return (int)copied;
 }
 
 const char* fat16_status(void) {
@@ -484,7 +553,6 @@ const char* fat16_status(void) {
 int fat16_read_file_range(const fat16_volume_t* v, const char* name,
                           uint32_t offset, uint8_t* buffer, uint32_t max,
                           uint32_t* out_read) {
-    uint8_t short_name[11];
     uint8_t entry[FAT16_ENTRY_SIZE];
     uint32_t i;
     uint32_t size;
@@ -494,81 +562,69 @@ int fat16_read_file_range(const fat16_volume_t* v, const char* name,
     uint32_t copied = 0U;
     uint16_t cluster;
     uint32_t guard = 0U;
+    int status;
     if (out_read) *out_read = 0U;
     if (!fat16_is_mounted(v)) return OS_FAT16_NOT_MOUNTED;
     if (!buffer || max == 0U || !out_read) return OS_FAT16_BUFFER_SMALL;
-    if (make_short_name(name, short_name) != 0) return OS_FAT16_BAD_PATH;
-    for (i = 0U; i < v->root_entries; i++) {
-        if (read_root_entry(v, i, entry) != 0) return OS_FAT16_CORRUPT;
-        if (entry[0] == 0x00U) break;
-        if (entry[0] == 0xE5U || entry[11] == 0x0FU || (entry[11] & 0x08U)) continue;
-        if (!entry_matches(entry, short_name)) continue;
-        if (entry[11] & 0x10U) return OS_FAT16_BAD_PATH;
-        size = le32(entry + 28U);
-        if (offset > size) return OS_FAT16_BAD_PATH;
-        cluster = le16(entry + 26U);
-        cluster_bytes = (uint32_t)v->sectors_per_cluster * FAT16_SECTOR_SIZE;
-        if (cluster_bytes == 0U) return OS_FAT16_CORRUPT;
-        skip_clusters = offset / cluster_bytes;
-        intra = offset % cluster_bytes;
-        while (skip_clusters-- > 0U) {
-            if (cluster < 2U || cluster >= FAT16_EOC_MIN ||
-                cluster - 2U >= v->cluster_count || guard++ > v->cluster_count ||
-                read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
-        }
-        while (copied < max && offset + copied < size) {
-            uint32_t sector_in_cluster = intra / FAT16_SECTOR_SIZE;
-            uint32_t sector_offset = intra % FAT16_SECTOR_SIZE;
-            uint32_t lba;
-            uint32_t take = FAT16_SECTOR_SIZE - sector_offset;
-            if (cluster < 2U || cluster >= FAT16_EOC_MIN ||
-                cluster - 2U >= v->cluster_count || guard > v->cluster_count) return OS_FAT16_CORRUPT;
-            lba = v->data_lba + (uint32_t)(cluster - 2U) * v->sectors_per_cluster + sector_in_cluster;
-            if (read_at(v, lba, sector2) != 0) return OS_FAT16_CORRUPT;
-            if (take > max - copied) take = max - copied;
-            if (take > size - offset - copied) take = size - offset - copied;
-            for (i = 0U; i < take; i++) buffer[copied + i] = sector2[sector_offset + i];
-            copied += take;
-            intra += take;
-            if (intra >= cluster_bytes && copied < max && offset + copied < size) {
-                if (guard++ >= v->cluster_count ||
-                    read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
-                intra = 0U;
-            }
-        }
-        *out_read = copied;
-        return 0;
+    status = fat16_find_root_entry(v, name, entry);
+    if (status != 0) return status;
+    if (entry[11] & 0x10U) return OS_FAT16_BAD_PATH;
+    size = le32(entry + 28U);
+    if (offset > size) return OS_FAT16_BAD_PATH;
+    cluster = le16(entry + 26U);
+    cluster_bytes = (uint32_t)v->sectors_per_cluster * FAT16_SECTOR_SIZE;
+    if (cluster_bytes == 0U) return OS_FAT16_CORRUPT;
+    skip_clusters = offset / cluster_bytes;
+    intra = offset % cluster_bytes;
+    while (skip_clusters-- > 0U) {
+        if (cluster < 2U || cluster >= FAT16_EOC_MIN ||
+            cluster - 2U >= v->cluster_count || guard++ > v->cluster_count ||
+            read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
     }
-    return OS_FAT16_NOT_FOUND;
+    while (copied < max && offset + copied < size) {
+        uint32_t sector_in_cluster = intra / FAT16_SECTOR_SIZE;
+        uint32_t sector_offset = intra % FAT16_SECTOR_SIZE;
+        uint32_t lba;
+        uint32_t take = FAT16_SECTOR_SIZE - sector_offset;
+        if (cluster < 2U || cluster >= FAT16_EOC_MIN ||
+            cluster - 2U >= v->cluster_count || guard > v->cluster_count) return OS_FAT16_CORRUPT;
+        lba = v->data_lba + (uint32_t)(cluster - 2U) * v->sectors_per_cluster + sector_in_cluster;
+        if (read_at(v, lba, sector2) != 0) return OS_FAT16_CORRUPT;
+        if (take > max - copied) take = max - copied;
+        if (take > size - offset - copied) take = size - offset - copied;
+        for (i = 0U; i < take; i++) buffer[copied + i] = sector2[sector_offset + i];
+        copied += take;
+        intra += take;
+        if (intra >= cluster_bytes && copied < max && offset + copied < size) {
+            if (guard++ >= v->cluster_count ||
+                read_fat_entry(v, cluster, &cluster) != 0) return OS_FAT16_CORRUPT;
+            intra = 0U;
+        }
+    }
+    *out_read = copied;
+    return 0;
 }
 
 
 int fat16_open_file(const fat16_volume_t* v, const char* name, fat16_file_t* out) {
-    uint8_t short_name[11];
     uint8_t entry[FAT16_ENTRY_SIZE];
-    uint32_t i;
+    int status;
     if (!fat16_is_mounted(v) || !out) return OS_FAT16_NOT_MOUNTED;
-    if (make_short_name(name, short_name) != 0) return OS_FAT16_BAD_PATH;
     out->open = 0U;
-    for (i = 0U; i < v->root_entries; i++) {
-        if (read_root_entry(v, i, entry) != 0) return OS_FAT16_CORRUPT;
-        if (entry[0] == 0x00U) break;
-        if (entry[0] == 0xE5U || entry[11] == 0x0FU || (entry[11] & 0x08U)) continue;
-        if (!entry_matches(entry, short_name)) continue;
-        if (entry[11] & 0x10U) return OS_FAT16_BAD_PATH;
-        out->volume = v;
-        out->first_cluster = le16(entry + 26U);
-        out->cluster = out->first_cluster;
-        out->size = le32(entry + 28U);
-        out->position = 0U;
-        out->cluster_offset = 0U;
-        out->guard = 0U;
-        out->cached_lba = 0U;
-        out->cache_valid = 0U;
-        out->open = 1U;
-        return 0;
-    }
-    return OS_FAT16_NOT_FOUND;
+    status = fat16_find_root_entry(v, name, entry);
+    if (status != 0) return status;
+    if (entry[11] & 0x10U) return OS_FAT16_BAD_PATH;
+    out->volume = v;
+    out->first_cluster = le16(entry + 26U);
+    out->cluster = out->first_cluster;
+    out->size = le32(entry + 28U);
+    out->position = 0U;
+    out->cluster_offset = 0U;
+    out->guard = 0U;
+    out->cached_lba = 0U;
+    out->cache_valid = 0U;
+    out->open = 1U;
+    return 0;
 }
 
 int fat16_file_seek(fat16_file_t* file, uint32_t offset) {

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -1022,6 +1022,10 @@ static void test_creates_lfn_file(void) {
     uint8_t data[3] = {'L', 'F', 'N'};
     uint16_t first = 0U;
     os_fat16_dirent_t entries[4];
+    char readback[4] = {0};
+    uint8_t range[2] = {0};
+    uint32_t read = 0U;
+    fat16_file_t file;
     uint32_t root = 35U * 512U;
     make_volume();
     TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
@@ -1049,6 +1053,19 @@ static void test_creates_lfn_file(void) {
     TEST_ASSERT_EQUAL('o', entries[1].name[5]);
     TEST_ASSERT_EQUAL('n', entries[1].name[6]);
     TEST_ASSERT_EQUAL('-', entries[1].name[7]);
+    TEST_ASSERT_EQUAL(3, fat16_read_file(&volume, "session-2026-a", readback, sizeof(readback)));
+    TEST_ASSERT_EQUAL_STRING("LFN", readback);
+    TEST_ASSERT_EQUAL(0, fat16_read_file_range(&volume, "SESSION-2026-A", 1U, range,
+                                               sizeof(range), &read));
+    TEST_ASSERT_EQUAL(2U, read);
+    TEST_ASSERT_EQUAL('F', range[0]);
+    TEST_ASSERT_EQUAL('N', range[1]);
+    TEST_ASSERT_EQUAL(0, fat16_open_file(&volume, "Session-2026-A", &file));
+    TEST_ASSERT_EQUAL(0, fat16_file_read(&file, range, sizeof(range), &read));
+    TEST_ASSERT_EQUAL(2U, read);
+    TEST_ASSERT_EQUAL('L', range[0]);
+    TEST_ASSERT_EQUAL('F', range[1]);
+    TEST_ASSERT_EQUAL(OS_FAT16_NOT_FOUND, fat16_open_file(&volume, "Unknown-long-name", &file));
     TEST_ASSERT_EQUAL('2', entries[1].name[8]);
     TEST_ASSERT_EQUAL('0', entries[1].name[9]);
     TEST_ASSERT_EQUAL('2', entries[1].name[10]);


### PR DESCRIPTION
## Résumé

- clôture mesurée de l’axe de latence GGUF ; les essais sous le bruit QEMU sont documentés et retirés
- ajoute une recherche FAT16 racine commune acceptant alias 8.3 ou LFN ASCII validé
- étend `fat16_read_file`, `fat16_read_file_range` et `fat16_open_file` sans allocation dynamique
- conserve le curseur, les fenêtres FAT16, les gardes de chaîne et l’ABI existante
- ajoute les vérifications LFN de lecture totale, à offset, ouverture/cursor et absence

## Validation

- `make -s test-all` : **457/457** tests réussis
- `git diff --check` : succès
- test FAT16 ciblé : **16/16** succès

## Notes

Documentation française ajoutée dans `docs/aos1641_1648_gguf_latency_closure.md` et `docs/aos1649_1656_fat16_lfn_read_lookup.md`.