### PR TITLE
feat: add FAT32 LFN unlink

### DIFF
--- a/docs/aos1657_1664_fat32_lfn_unlink.md
+++ b/docs/aos1657_1664_fat32_lfn_unlink.md
@@ -1,0 +1,36 @@
+# AOS-1657 à AOS-1664 — suppression FAT32 par alias et LFN
+
+## Objet
+
+Ce macro-lot ajoute `fat32_unlink_file`, une suppression bornée de fichier FAT32 qui accepte soit l’alias 8.3, soit un **nom long LFN ASCII validé**. Elle complète la création et le listage LFN déjà disponibles, sans allocation dynamique et sans extension de l’état résident.
+
+## Recherche et intégrité
+
+La recherche traverse la chaîne du répertoire racine au moyen de `fat32_dir_slot`. Les fragments LFN ne sont associés à une entrée courte que si les ordinaux sont complets, dans l’ordre attendu, et si le checksum de l’alias correspond. Les séquences supprimées, invalides et les labels de volume sont ignorés.
+
+| Nom demandé | Comportement |
+|---|---|
+| Alias 8.3 valide | Correspondance historique préservée. |
+| LFN ASCII valide | Correspondance insensible à la casse après validation intégrale de la séquence. |
+| Nom absent | `OS_FAT16_NOT_FOUND`. |
+| Nom vide, séparateur ou octet hors ASCII | `OS_FAT16_BAD_PATH`. |
+
+## Suppression
+
+Après identification, toutes les entrées LFN de la séquence et l’entrée courte associée sont marquées supprimées (`0xE5`). La première unité de la chaîne de données est ensuite transmise au libérateur FAT32 existant, qui parcourt et remet à zéro les entrées FAT dans une boucle bornée par `cluster_count`.
+
+> Les données ne sont pas écrasées : comme le prévoit FAT, les clusters sont rendus disponibles à la réallocation. L’API reste freestanding et ne dépend d’aucun `malloc`, `kmalloc`, cache de noms ni buffer persistant supplémentaire.
+
+## Validation
+
+Le vecteur FAT32 existant crée `Persistent-LLM-Session` sur l’alias `SESSION.BIN`, puis vérifie la suppression via le nom long en casse différente. Il contrôle le marquage des quatre entrées de répertoire concernées, la libération de l’entrée FAT du premier cluster, l’absence au listage et le refus d’une seconde suppression.
+
+## Limites
+
+Le renommage LFN, l’UTF-8 au-delà de l’ASCII, les paires substituts UTF-16 et le raccordement VFS FAT32 restent distincts. Cette séparation évite de mêler une opération destructive de chaîne avec la publication multi-entrée d’un nouveau nom.
+
+## Références internes
+
+- [Fondations LFN FAT32](aos1321_fat32_lfn.md)
+- [Contrats FAT32](../kernel/fs/fat32.h)
+- [Recherche FAT16 par LFN](aos1649_1656_fat16_lfn_read_lookup.md)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -97,6 +97,7 @@
 - [x] AOS-1633…1640 : décodage Q3_K sans branche, équivalence quantifiée et gain QEMU de projection — [aos1633_1640_q3k_branchless_decode.md](aos1633_1640_q3k_branchless_decode.md)
 - [x] AOS-1641…1648 : clôture mesurée de l’axe de latence GGUF, essais non concluants retirés et bascule vers les fonctionnalités FAT16/LFN — [aos1641_1648_gguf_latency_closure.md](aos1641_1648_gguf_latency_closure.md)
 - [x] AOS-1649…1656 : recherche FAT16 par LFN ASCII validé pour lecture totale, lecture à offset et curseur, sans allocation dynamique — [aos1649_1656_fat16_lfn_read_lookup.md](aos1649_1656_fat16_lfn_read_lookup.md)
+- [x] AOS-1657…1664 : suppression FAT32 par alias 8.3 ou LFN ASCII validé, marquage de séquence et libération de chaîne bornée — [aos1657_1664_fat32_lfn_unlink.md](aos1657_1664_fat32_lfn_unlink.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/fs/fat32.c
+++ b/kernel/fs/fat32.c
@@ -288,6 +288,67 @@ int fat32_create_lfn_file(const fat32_volume_t* v, const char* long_name, const 
     rc = fat32_dir_slot(v, alias_index + 1U + count, entry, 1, 1); if (rc != 0) return rc; *out_first_cluster = first; return 0;
 }
 
+
+static int fat32_name_equal_folded(const char* left, const char* right) {
+    uint32_t i;
+    if (!left || !right) return 0;
+    for (i = 0U; i < OS_NAME_MAX; i++) {
+        char a = left[i], b = right[i];
+        if (a >= 'a' && a <= 'z') a = (char)(a - 32);
+        if (b >= 'a' && b <= 'z') b = (char)(b - 32);
+        if (a != b) return 0;
+        if (a == '\0') return 1;
+    }
+    return 0;
+}
+
+int fat32_unlink_file(const fat32_volume_t* v, const char* name) {
+    uint8_t entry[32], short_name[11], lfn_sum = 0U, expected = 0U, valid = 0U;
+    char lfn[OS_NAME_MAX];
+    uint32_t lfn_start = 0U, i, j, limit;
+    uint32_t first;
+    int short_valid;
+    if (!v || !name || !fat32_is_mounted(v) || !v->write_sector) return OS_FAT16_NOT_MOUNTED;
+    short_valid = fat32_short_name(name, short_name) == 0;
+    for (i = 0U; i < OS_NAME_MAX && name[i]; i++)
+        if ((uint8_t)name[i] < 0x20U || (uint8_t)name[i] > 0x7fU || name[i] == '/' || name[i] == '\\') return OS_FAT16_BAD_PATH;
+    if (i == 0U || i == OS_NAME_MAX) return OS_FAT16_BAD_PATH;
+    limit = v->cluster_count * (uint32_t)v->sectors_per_cluster * 16U;
+    for (i = 0U; i < limit; i++) {
+        uint8_t ord;
+        if (fat32_dir_slot(v, i, entry, 0, 0) != 0 || entry[0] == 0U) break;
+        if (entry[0] == 0xe5U) { valid = 0U; continue; }
+        if (entry[11] == 0x0fU) {
+            ord = entry[0] & 0x1fU;
+            if (entry[0] & 0x40U) {
+                if (ord == 0U || ord * 13U >= OS_NAME_MAX) { valid = 0U; continue; }
+                for (j = 0U; j < OS_NAME_MAX; j++) lfn[j] = 0;
+                lfn_sum = entry[13]; expected = ord; lfn_start = i; valid = 1U;
+            }
+            if (!valid || ord == 0U || ord != expected || entry[13] != lfn_sum) { valid = 0U; continue; }
+            fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn, OS_NAME_MAX);
+            fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
+            fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            expected--; continue;
+        }
+        if (entry[11] & 0x08U) { valid = 0U; continue; }
+        { int same = short_valid; for (j = 0U; j < 11U && same; j++) if (entry[j] != short_name[j]) same = 0;
+        if ((!same) &&
+            !(valid && expected == 0U && fat32_lfn_checksum(entry) == lfn_sum && fat32_name_equal_folded(name, lfn))) { valid = 0U; continue; }
+        }
+        first = ((uint32_t)entry[20] << 24U) | ((uint32_t)entry[21] << 16U) | le16(entry + 26U);
+        for (j = valid && expected == 0U ? lfn_start : i; j <= i; j++) {
+            uint8_t deleted[32];
+            if (fat32_dir_slot(v, j, deleted, 0, 0) != 0) return OS_FAT16_CORRUPT;
+            deleted[0] = 0xe5U;
+            if (fat32_dir_slot(v, j, deleted, 1, 0) != 0) return OS_FAT16_CORRUPT;
+        }
+        fat32_release_chain(v, first);
+        return 0;
+    }
+    return OS_FAT16_NOT_FOUND;
+}
+
 int fat32_list_root(const fat32_volume_t* v, os_fat16_dirent_t* out, uint32_t capacity) {
     uint8_t entry[32], lfn_sum = 0U, expected = 0U, valid = 0U; char lfn[OS_NAME_MAX]; uint32_t count = 0U;
     if (!v || !out || capacity == 0U || !fat32_is_mounted(v)) return OS_FAT16_BAD_PATH;

--- a/kernel/fs/fat32.h
+++ b/kernel/fs/fat32.h
@@ -41,5 +41,7 @@ int fat32_encode_lfn_entry(const char* name, uint8_t ordinal, uint8_t checksum, 
 int fat32_create_file(const fat32_volume_t* volume, const char* name, uint8_t attributes, const uint8_t* data, uint32_t size, uint32_t* out_first_cluster);
 int fat32_create_lfn_file(const fat32_volume_t* volume, const char* long_name, const char* short_name, uint8_t attributes, const uint8_t* data, uint32_t size, uint32_t* out_first_cluster);
 int fat32_list_root(const fat32_volume_t* volume, os_fat16_dirent_t* out, uint32_t capacity);
+/* Supprime un alias 8.3 ou une séquence LFN ASCII validée et libère sa chaîne. */
+int fat32_unlink_file(const fat32_volume_t* volume, const char* name);
 
 #endif

--- a/tests/unit/kernel/test_fat32.c
+++ b/tests/unit/kernel/test_fat32.c
@@ -77,6 +77,14 @@ void test_fat32_lfn_file_and_list(void) {
     { int rc = fat32_create_lfn_file(&volume, "Persistent-LLM-Session", "SESSION.BIN", 0x20U, data, sizeof(data), &first); TEST_ASSERT_EQUAL(0, rc); }
     TEST_ASSERT_EQUAL(3U, first); TEST_ASSERT_EQUAL(1, fat32_list_root(&volume, entries, 4U));
     TEST_ASSERT_EQUAL_STRING("Persistent-LLM-Session", entries[0].name); TEST_ASSERT_EQUAL(sizeof(data), entries[0].size);
+    TEST_ASSERT_EQUAL(0, fat32_unlink_file(&volume, "persistent-llm-session"));
+    TEST_ASSERT_EQUAL(0xe5U, disk[2032U * 512U]);
+    TEST_ASSERT_EQUAL(0xe5U, disk[2032U * 512U + 32U]);
+    TEST_ASSERT_EQUAL(0xe5U, disk[2032U * 512U + 64U]);
+    TEST_ASSERT_EQUAL(0xe5U, disk[2032U * 512U + 96U]);
+    TEST_ASSERT_EQUAL(0U, disk[32U * 512U + 12U]);
+    TEST_ASSERT_EQUAL(0, fat32_list_root(&volume, entries, 4U));
+    TEST_ASSERT_EQUAL(OS_FAT16_NOT_FOUND, fat32_unlink_file(&volume, "Persistent-LLM-Session"));
 }
 
 int main(void) { unity_init(); RUN_TEST(test_fat32_mount_and_read_cluster); RUN_TEST(test_fat32_extend_full_root); RUN_TEST(test_fat32_lfn_encoding); RUN_TEST(test_fat32_lfn_file_and_list); unity_print_results(); unity_cleanup(); return 0; }


### PR DESCRIPTION
## Résumé

- ajoute `fat32_unlink_file` pour supprimer un alias 8.3 ou un LFN ASCII validé
- valide les ordinaux LFN et le checksum avant toute suppression
- marque toute la séquence de répertoire puis libère la chaîne FAT32 bornée
- ajoute le test de nom long, marquage LFN, libération FAT, listage et double suppression
- aucune allocation dynamique ni changement de l’état résident

## Validation

- `make -s test-all` : **457/457** tests réussis
- test FAT32 : **4/4** succès
- `git diff --check` : succès

## Documentation

- `docs/aos1657_1664_fat32_lfn_unlink.md`