### PR TITLE
feat: mount FAT16 read-only in VFS

### DIFF
--- a/docs/aos1665_1672_vfs_fat16_readonly_mount.md
+++ b/docs/aos1665_1672_vfs_fat16_readonly_mount.md
@@ -1,0 +1,35 @@
+# AOS-1665 à AOS-1672 — montage VFS FAT16 en lecture seule
+
+## Objet
+
+Ce macro-lot raccorde le volume FAT16 déjà monté par le noyau au médiateur VFS Ring 3. Il ajoute la source de montage `OS_VFS_MOUNT_SOURCE_FAT16` et le montage protégé `fat16/`, sans allocation dynamique et sans changer les sources `initrd/` ou `overlay/`.
+
+## Contrat
+
+| Montage | Droits fonctionnels | Implémentation |
+|---|---|---|
+| `initrd/` | Lecture, métadonnées, listage | Inchangé. |
+| `overlay/` | Lecture, écriture, suppression, renommage, répertoires | Inchangé. |
+| `fat16/` | Lecture, métadonnées et listage de racine | Nouveau, lecture seule. |
+
+Le serveur VFS appelle les syscalls FAT16 préexistants pour la lecture et le listage. La racine `fat16/` est un montage protégé et les opérations d’écriture, de création de répertoire, de suppression et de renommage continuent à vérifier explicitement que la source est `overlay`.
+
+> Aucun état de fichier, cache de noms ou allocation dynamique n’est ajouté : les réponses continuent d’utiliser les buffers IPC bornés et les structures publiques `os_dirent_t` et `os_fat16_dirent_t`, dont la représentation est compatible.
+
+## Chemins pris en charge
+
+La lecture transmet exclusivement le suffixe du montage au lecteur FAT16. `fat16/FICHIER.TXT` et les LFN ASCII supportés par le volume suivent donc le même chemin de validation que les syscalls FAT16 directs. Le listage accepte uniquement la racine du volume, cohérente avec l’absence de sous-répertoires FAT16 dans ce périmètre.
+
+## Validation
+
+La construction i386 complète réussit avec le serveur VFS étendu. La suite de non-régression valide **457 tests sur 457**, notamment FAT16, FAT32, protocole VFS, IPC, services et userspace. Les chemins d’écriture overlay ne sont pas modifiés.
+
+## Limites
+
+Les volumes FAT32, les sous-répertoires FAT16 et le montage de volumes FAT écrits depuis VFS restent hors de ce lot. La source FAT16 est intentionnellement lecture seule afin de préserver les invariants du volume de déploiement GPT2.GGU.
+
+## Références internes
+
+- [Recherche FAT16 par LFN](aos1649_1656_fat16_lfn_read_lookup.md)
+- [Suppression FAT32 par LFN](aos1657_1664_fat32_lfn_unlink.md)
+- [Contrats de service VFS](../include/os_vfs_service.h)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -98,6 +98,7 @@
 - [x] AOS-1641…1648 : clôture mesurée de l’axe de latence GGUF, essais non concluants retirés et bascule vers les fonctionnalités FAT16/LFN — [aos1641_1648_gguf_latency_closure.md](aos1641_1648_gguf_latency_closure.md)
 - [x] AOS-1649…1656 : recherche FAT16 par LFN ASCII validé pour lecture totale, lecture à offset et curseur, sans allocation dynamique — [aos1649_1656_fat16_lfn_read_lookup.md](aos1649_1656_fat16_lfn_read_lookup.md)
 - [x] AOS-1657…1664 : suppression FAT32 par alias 8.3 ou LFN ASCII validé, marquage de séquence et libération de chaîne bornée — [aos1657_1664_fat32_lfn_unlink.md](aos1657_1664_fat32_lfn_unlink.md)
+- [x] AOS-1665…1672 : montage VFS protégé `fat16/` en lecture/stat/listage, sans mutation ni allocation dynamique — [aos1665_1672_vfs_fat16_readonly_mount.md](aos1665_1672_vfs_fat16_readonly_mount.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/include/os_vfs_service.h
+++ b/include/os_vfs_service.h
@@ -84,6 +84,7 @@
 #define OS_VFS_STATUS_NOT_EMPTY (-5)
 #define OS_VFS_MOUNT_SOURCE_INITRD 1U
 #define OS_VFS_MOUNT_SOURCE_OVERLAY 2U
+#define OS_VFS_MOUNT_SOURCE_FAT16 3U
 
 #define OS_VFS_STATUS_OK          0
 #define OS_VFS_STATUS_INVALID    (-60)
@@ -179,7 +180,8 @@ static inline int os_vfs_mount_prefix_is_valid(const char* mount) {
 }
 
 static inline int os_vfs_mount_source_is_valid(uint32_t source) {
-    return source == OS_VFS_MOUNT_SOURCE_INITRD || source == OS_VFS_MOUNT_SOURCE_OVERLAY;
+    return source == OS_VFS_MOUNT_SOURCE_INITRD || source == OS_VFS_MOUNT_SOURCE_OVERLAY ||
+           source == OS_VFS_MOUNT_SOURCE_FAT16;
 }
 
 /* Le listage cible un répertoire : il accepte la racine du montage ou un

--- a/userspace/vfs_server.c
+++ b/userspace/vfs_server.c
@@ -94,6 +94,30 @@ static int backend_overlay_read(const char* path, char* buffer, uint32_t max) {
     asm volatile("int $0x80" : "=a"(result) : "a"(SYS_VFS_OVERLAY_READ), "b"(path), "c"(buffer), "d"(max));
     return result;
 }
+static int backend_fat16_read(const char* path, char* buffer, uint32_t max) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_FAT16_READ), "b"(path), "c"(buffer), "d"(max));
+    return result;
+}
+static int backend_fat16_listdir(const char* path, os_dirent_t* out, int max_n) {
+    int result;
+    if (!path || path[0] != '/' || path[1] != '\0') return -1;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_FAT16_LIST), "b"(out), "c"(max_n));
+    return result;
+}
+static int backend_fat16_stat(const char* path, os_dirent_t* out) {
+    os_dirent_t entries[OS_VFS_LIST_ENTRY_MAX + 1U];
+    int count, i;
+    if (!path || !out || path[0] == '\0' || path[0] == '/') return -1;
+    count = backend_fat16_listdir("/", entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U));
+    if (count < 0) return count;
+    for (i = 0; i < count; i++) {
+        uint32_t j = 0U;
+        while (entries[i].name[j] && path[j] && entries[i].name[j] == path[j]) j++;
+        if (entries[i].name[j] == '\0' && path[j] == '\0') { *out = entries[i]; return 0; }
+    }
+    return -1;
+}
 
 static int backend_initrd_stat(const char* path, os_dirent_t* out) {
     int result;
@@ -182,7 +206,7 @@ static int string_equal(const char* left, const char* right) {
  * alias dynamiques restent possibles. Les noms dynamiques sont bornés pour
  * que la source virtuelle `vfs-mounts` tienne toujours dans 80 octets. */
 #define VFS_MOUNT_MAX 5U
-#define VFS_BOOT_MOUNT_COUNT 2U
+#define VFS_BOOT_MOUNT_COUNT 3U
 #define VFS_DYNAMIC_MOUNT_MAX 13U
 typedef struct {
     char prefix[OS_VFS_PATH_MAX];
@@ -192,6 +216,7 @@ typedef struct {
 static vfs_mount_t vfs_mounts[VFS_MOUNT_MAX] = {
     { "initrd/", OS_VFS_MOUNT_SOURCE_INITRD, 1U },
     { "overlay/", OS_VFS_MOUNT_SOURCE_OVERLAY, 1U },
+    { "fat16/", OS_VFS_MOUNT_SOURCE_FAT16, 1U },
 };
 static uint32_t vfs_mount_count = VFS_BOOT_MOUNT_COUNT;
 
@@ -313,7 +338,9 @@ static int read_mounted_backend(const char* path, uint8_t* data, uint32_t* size)
         if (os_vfs_match_mount(path, vfs_mounts[i].prefix, &relative)) {
             int read = vfs_mounts[i].source == OS_VFS_MOUNT_SOURCE_INITRD
                 ? backend_initrd_read(relative, (char*)data, OS_VFS_READ_MAX)
-                : backend_overlay_read(relative, (char*)data, OS_VFS_READ_MAX);
+                : (vfs_mounts[i].source == OS_VFS_MOUNT_SOURCE_FAT16
+                    ? backend_fat16_read(relative, (char*)data, OS_VFS_READ_MAX)
+                    : backend_overlay_read(relative, (char*)data, OS_VFS_READ_MAX));
             if (read < 0) return read;
             *size = (uint32_t)read;
             return OS_VFS_STATUS_OK;
@@ -330,7 +357,9 @@ static int stat_mounted_backend(const char* path, os_dirent_t* out) {
         if (os_vfs_match_mount(path, vfs_mounts[i].prefix, &relative)) {
             return vfs_mounts[i].source == OS_VFS_MOUNT_SOURCE_INITRD
                 ? backend_initrd_stat(relative, out)
-                : backend_overlay_stat(relative, out);
+                : (vfs_mounts[i].source == OS_VFS_MOUNT_SOURCE_FAT16
+                    ? backend_fat16_stat(relative, out)
+                    : backend_overlay_stat(relative, out));
         }
     }
     return OS_VFS_STATUS_NOT_MOUNTED;
@@ -370,7 +399,9 @@ static int list_mounted_backend(const char* path, uint8_t* data, uint32_t* size,
         if (list_path_matches_mount(path, vfs_mounts[mount_index].prefix, &relative)) {
             listed = vfs_mounts[mount_index].source == OS_VFS_MOUNT_SOURCE_INITRD
                 ? backend_initrd_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U))
-                : backend_overlay_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U));
+                : (vfs_mounts[mount_index].source == OS_VFS_MOUNT_SOURCE_FAT16
+                    ? backend_fat16_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U))
+                    : backend_overlay_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U)));
             if (listed < 0) return listed;
             for (uint32_t entry_index = 0U;
                  entry_index < (uint32_t)listed && entry_index < OS_VFS_LIST_ENTRY_MAX;


### PR DESCRIPTION
## Résumé

- ajoute la source VFS `FAT16` et le montage protégé `fat16/`
- raccorde lecture, stat et listage de racine aux syscalls FAT16 existants
- conserve toutes les mutations strictement limitées à l’overlay
- ne crée aucun cache, état de fichier ou allocation dynamique

## Validation

- build i386 complet : succès
- `make -s test-all` : **457/457** tests réussis
- `git diff --check` : succès

## Documentation

- `docs/aos1665_1672_vfs_fat16_readonly_mount.md`