### PR TITLE
feat: add FAT32 LFN rename

### DIFF
--- a/docs/aos1673_1680_fat32_lfn_rename.md
+++ b/docs/aos1673_1680_fat32_lfn_rename.md
@@ -1,0 +1,21 @@
+# AOS-1673 à AOS-1680 — renommage FAT32 LFN sans déplacement de données
+
+Ce lot ajoute `fat32_rename_lfn_file`. L’opération valide l’alias ou le LFN source par ordinaux et checksum, conserve strictement la chaîne de données existante, puis publie les nouveaux fragments LFN et l’alias court associé. Aucun cluster n’est alloué, déplacé ou libéré.
+
+Le contrat est volontairement borné : le nouveau nom long doit utiliser le même nombre d’entrées LFN que l’ancien. Cette règle évite tout déplacement de répertoire et garantit que la publication s’effectue dans les slots existants. Les noms restent ASCII, de longueur bornée et sans séparateur.
+
+| Garantie | Comportement |
+|---|---|
+| Chaîne de données | Préservée intégralement. |
+| Séquence LFN | Validée par ordinaux et checksum avant modification. |
+| Publication | Nouveaux fragments LFN, puis alias court avec nouveau checksum. |
+| Mémoire | Aucun `malloc`, `kmalloc` ou état persistant supplémentaire. |
+| Périmètre | Renommage de même cardinalité LFN ; les transformations de cardinalité restent refusées. |
+
+Le scénario Unity renomme `Persistent-LLM-Session` en `Persistent-LLM-Record`, vérifie le listage sous le nouveau nom, préserve la taille, puis supprime le fichier renommé. La suite complète valide **457/457** tests.
+
+## Références internes
+
+- [Fondations LFN FAT32](aos1321_fat32_lfn.md)
+- [Suppression FAT32 par LFN](aos1657_1664_fat32_lfn_unlink.md)
+- [Contrats FAT32](../kernel/fs/fat32.h)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -99,6 +99,7 @@
 - [x] AOS-1649…1656 : recherche FAT16 par LFN ASCII validé pour lecture totale, lecture à offset et curseur, sans allocation dynamique — [aos1649_1656_fat16_lfn_read_lookup.md](aos1649_1656_fat16_lfn_read_lookup.md)
 - [x] AOS-1657…1664 : suppression FAT32 par alias 8.3 ou LFN ASCII validé, marquage de séquence et libération de chaîne bornée — [aos1657_1664_fat32_lfn_unlink.md](aos1657_1664_fat32_lfn_unlink.md)
 - [x] AOS-1665…1672 : montage VFS protégé `fat16/` en lecture/stat/listage, sans mutation ni allocation dynamique — [aos1665_1672_vfs_fat16_readonly_mount.md](aos1665_1672_vfs_fat16_readonly_mount.md)
+- [x] AOS-1673…1680 : renommage FAT32 LFN validé sans déplacement de chaîne, borné à une cardinalité de séquence identique — [aos1673_1680_fat32_lfn_rename.md](aos1673_1680_fat32_lfn_rename.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/fs/fat32.c
+++ b/kernel/fs/fat32.c
@@ -349,6 +349,54 @@ int fat32_unlink_file(const fat32_volume_t* v, const char* name) {
     return OS_FAT16_NOT_FOUND;
 }
 
+int fat32_rename_lfn_file(const fat32_volume_t* v, const char* old_name,
+                          const char* new_long_name, const char* new_short_name) {
+    uint8_t entry[32], old_short[11], new_short[11], sum = 0U, expected = 0U, valid = 0U;
+    char lfn[OS_NAME_MAX];
+    uint32_t start = 0U, i, j, limit, old_count = 0U, length = 0U, new_count;
+    int old_short_valid;
+    if (!v || !old_name || !new_long_name || !new_short_name || !fat32_is_mounted(v) || !v->write_sector) return OS_FAT16_NOT_MOUNTED;
+    old_short_valid = fat32_short_name(old_name, old_short) == 0;
+    if (fat32_short_name(new_short_name, new_short) != 0) return OS_FAT16_BAD_PATH;
+    while (new_long_name[length]) {
+        if (length >= OS_NAME_MAX - 1U || (uint8_t)new_long_name[length] < 0x20U ||
+            (uint8_t)new_long_name[length] > 0x7fU || new_long_name[length] == '/' || new_long_name[length] == '\\') return OS_FAT16_BAD_PATH;
+        length++;
+    }
+    if (length == 0U) return OS_FAT16_BAD_PATH;
+    new_count = (length + 12U) / 13U;
+    limit = v->cluster_count * (uint32_t)v->sectors_per_cluster * 16U;
+    for (i = 0U; i < limit; i++) {
+        uint8_t ord;
+        if (fat32_dir_slot(v, i, entry, 0, 0) != 0 || entry[0] == 0U) break;
+        if (entry[0] == 0xe5U) { valid = 0U; continue; }
+        if (entry[11] == 0x0fU) {
+            ord = entry[0] & 0x1fU;
+            if (entry[0] & 0x40U) { if (ord == 0U || ord * 13U >= OS_NAME_MAX) { valid = 0U; continue; }
+                for (j = 0U; j < OS_NAME_MAX; j++) lfn[j] = 0;
+                sum = entry[13]; expected = ord; start = i; old_count = ord; valid = 1U; }
+            if (!valid || ord == 0U || ord != expected || entry[13] != sum) { valid = 0U; continue; }
+            fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn, OS_NAME_MAX);
+            fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
+            fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            expected--; continue;
+        }
+        if (entry[11] & 0x08U) { valid = 0U; continue; }
+        { int same = old_short_valid; for (j = 0U; j < 11U && same; j++) if (entry[j] != old_short[j]) same = 0;
+          if (!same && !(valid && expected == 0U && fat32_lfn_checksum(entry) == sum && fat32_name_equal_folded(old_name, lfn))) { valid = 0U; continue; } }
+        if (!valid || expected != 0U || old_count != new_count) return OS_FAT16_BAD_PATH;
+        for (j = 0U; j < new_count; j++) {
+            if (fat32_lfn_segment(new_long_name, length, new_count, new_count - j, fat32_lfn_checksum(new_short), entry) != 0 ||
+                fat32_dir_slot(v, start + j, entry, 1, 0) != 0) return OS_FAT16_CORRUPT;
+        }
+        if (fat32_dir_slot(v, i, entry, 0, 0) != 0) return OS_FAT16_CORRUPT;
+        for (j = 0U; j < 11U; j++) entry[j] = new_short[j];
+        if (fat32_dir_slot(v, i, entry, 1, 0) != 0) return OS_FAT16_CORRUPT;
+        return 0;
+    }
+    return OS_FAT16_NOT_FOUND;
+}
+
 int fat32_list_root(const fat32_volume_t* v, os_fat16_dirent_t* out, uint32_t capacity) {
     uint8_t entry[32], lfn_sum = 0U, expected = 0U, valid = 0U; char lfn[OS_NAME_MAX]; uint32_t count = 0U;
     if (!v || !out || capacity == 0U || !fat32_is_mounted(v)) return OS_FAT16_BAD_PATH;

--- a/kernel/fs/fat32.h
+++ b/kernel/fs/fat32.h
@@ -43,5 +43,8 @@ int fat32_create_lfn_file(const fat32_volume_t* volume, const char* long_name, c
 int fat32_list_root(const fat32_volume_t* volume, os_fat16_dirent_t* out, uint32_t capacity);
 /* Supprime un alias 8.3 ou une séquence LFN ASCII validée et libère sa chaîne. */
 int fat32_unlink_file(const fat32_volume_t* volume, const char* name);
+/* Renomme une séquence LFN validée sans déplacer ni recopier sa chaîne de données. */
+int fat32_rename_lfn_file(const fat32_volume_t* volume, const char* old_name,
+                          const char* new_long_name, const char* new_short_name);
 
 #endif

--- a/tests/unit/kernel/test_fat32.c
+++ b/tests/unit/kernel/test_fat32.c
@@ -77,7 +77,12 @@ void test_fat32_lfn_file_and_list(void) {
     { int rc = fat32_create_lfn_file(&volume, "Persistent-LLM-Session", "SESSION.BIN", 0x20U, data, sizeof(data), &first); TEST_ASSERT_EQUAL(0, rc); }
     TEST_ASSERT_EQUAL(3U, first); TEST_ASSERT_EQUAL(1, fat32_list_root(&volume, entries, 4U));
     TEST_ASSERT_EQUAL_STRING("Persistent-LLM-Session", entries[0].name); TEST_ASSERT_EQUAL(sizeof(data), entries[0].size);
-    TEST_ASSERT_EQUAL(0, fat32_unlink_file(&volume, "persistent-llm-session"));
+    TEST_ASSERT_EQUAL(0, fat32_rename_lfn_file(&volume, "persistent-llm-session",
+                                                "Persistent-LLM-Record", "RECORD.BIN"));
+    TEST_ASSERT_EQUAL(1, fat32_list_root(&volume, entries, 4U));
+    TEST_ASSERT_EQUAL_STRING("Persistent-LLM-Record", entries[0].name);
+    TEST_ASSERT_EQUAL(sizeof(data), entries[0].size);
+    TEST_ASSERT_EQUAL(0, fat32_unlink_file(&volume, "persistent-llm-record"));
     TEST_ASSERT_EQUAL(0xe5U, disk[2032U * 512U]);
     TEST_ASSERT_EQUAL(0xe5U, disk[2032U * 512U + 32U]);
     TEST_ASSERT_EQUAL(0xe5U, disk[2032U * 512U + 64U]);


### PR DESCRIPTION
Renommage LFN FAT32 sans déplacement de chaîne, validé par 457/457 tests.