### PR TITLE
feat: add FAT32 alias file reader

### DIFF
--- a/docs/aos1681_1688_fat32_alias_read.md
+++ b/docs/aos1681_1688_fat32_alias_read.md
@@ -1,0 +1,24 @@
+# AOS-1681 à AOS-1688 — lecture FAT32 par alias 8.3
+
+Ce macro-lot ajoute `fat32_read_file`, une lecture FAT32 bornée par alias 8.3 dans un buffer fourni par l’appelant. Le lecteur localise l’entrée courte racine, valide la taille et les attributs, puis parcourt la chaîne FAT32 avec une garde bornée par `cluster_count`.
+
+Le buffer de cluster statique déjà utilisé par le créateur FAT32 est réemployé : aucune allocation dynamique, aucun cache de fichier persistant et aucune copie de la chaîne complète ne sont introduits. Les erreurs de cluster invalide, EOC prématuré, chaîne trop longue, buffer insuffisant ou nom absent sont retournées avant toute lecture non bornée.
+
+| Élément | Garantie |
+|---|---|
+| Nom | Alias 8.3 validé par le parseur FAT32 existant. |
+| Données | Copie bornée par `max` et par la taille de l’entrée. |
+| Chaîne | Lecture cluster par cluster avec garde de corruption. |
+| Mémoire | Buffer caller-owned pour la sortie ; workspace statique existant pour le cluster. |
+
+Le test FAT32 lit les données du fichier LFN créé via son alias `SESSION.BIN`, ce qui valide la compatibilité avec les fichiers qui portent une séquence LFN et une entrée courte associée. La suite complète confirme **457/457** tests réussis.
+
+## Limites
+
+La sélection directe par nom long LFN dans le lecteur FAT32 et son exposition VFS restent les incréments suivants. Le parcours de données est toutefois déjà commun et prêt à être réutilisé.
+
+## Références internes
+
+- [Fondations LFN FAT32](aos1321_fat32_lfn.md)
+- [Renommage FAT32 LFN](aos1673_1680_fat32_lfn_rename.md)
+- [Contrats FAT32](../kernel/fs/fat32.h)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -100,6 +100,7 @@
 - [x] AOS-1657…1664 : suppression FAT32 par alias 8.3 ou LFN ASCII validé, marquage de séquence et libération de chaîne bornée — [aos1657_1664_fat32_lfn_unlink.md](aos1657_1664_fat32_lfn_unlink.md)
 - [x] AOS-1665…1672 : montage VFS protégé `fat16/` en lecture/stat/listage, sans mutation ni allocation dynamique — [aos1665_1672_vfs_fat16_readonly_mount.md](aos1665_1672_vfs_fat16_readonly_mount.md)
 - [x] AOS-1673…1680 : renommage FAT32 LFN validé sans déplacement de chaîne, borné à une cardinalité de séquence identique — [aos1673_1680_fat32_lfn_rename.md](aos1673_1680_fat32_lfn_rename.md)
+- [x] AOS-1681…1688 : lecture FAT32 bornée par alias 8.3, parcours de chaîne contrôlé et prérequis VFS — [aos1681_1688_fat32_alias_read.md](aos1681_1688_fat32_alias_read.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/fs/fat32.c
+++ b/kernel/fs/fat32.c
@@ -397,6 +397,41 @@ int fat32_rename_lfn_file(const fat32_volume_t* v, const char* old_name,
     return OS_FAT16_NOT_FOUND;
 }
 
+int fat32_read_file(const fat32_volume_t* v, const char* name, uint8_t* buffer, uint32_t max) {
+    uint8_t entry[32], short_name[11];
+    uint32_t i, j, limit, size, copied = 0U, cluster_bytes, guard = 0U;
+    uint32_t cluster, next;
+    if (!v || !name || !buffer || max == 0U || !fat32_is_mounted(v)) return OS_FAT16_BAD_PATH;
+    if (fat32_short_name(name, short_name) != 0) return OS_FAT16_BAD_PATH;
+    limit = v->cluster_count * (uint32_t)v->sectors_per_cluster * 16U;
+    for (i = 0U; i < limit; i++) {
+        int match = 1;
+        if (fat32_dir_slot(v, i, entry, 0, 0) != 0 || entry[0] == 0U) break;
+        if (entry[0] == 0xe5U || entry[11] == 0x0fU || (entry[11] & 0x18U)) continue;
+        for (j = 0U; j < 11U; j++) if (entry[j] != short_name[j]) match = 0;
+        if (!match) continue;
+        size = le32(entry + 28U);
+        if (size > max) return OS_FAT16_BUFFER_SMALL;
+        cluster = ((uint32_t)entry[20] << 24U) | ((uint32_t)entry[21] << 16U) | le16(entry + 26U);
+        cluster_bytes = (uint32_t)v->sectors_per_cluster * 512U;
+        if (cluster_bytes == 0U || cluster_bytes > sizeof(fat32_file_cluster)) return OS_FAT16_CORRUPT;
+        while (copied < size) {
+            uint32_t take = size - copied;
+            if (cluster < 2U || cluster > v->cluster_count + 1U || cluster == FAT32_BAD_CLUSTER || guard++ > v->cluster_count) return OS_FAT16_CORRUPT;
+            if (fat32_read_cluster(v, cluster, fat32_file_cluster) != 0) return OS_FAT16_CORRUPT;
+            if (take > cluster_bytes) take = cluster_bytes;
+            for (j = 0U; j < take; j++) buffer[copied + j] = fat32_file_cluster[j];
+            copied += take;
+            if (copied < size) {
+                if (fat32_read_fat_entry(v, cluster, &next) != 0 || next < 2U || next >= FAT32_EOC_MIN || next == FAT32_BAD_CLUSTER) return OS_FAT16_CORRUPT;
+                cluster = next;
+            }
+        }
+        return (int)copied;
+    }
+    return OS_FAT16_NOT_FOUND;
+}
+
 int fat32_list_root(const fat32_volume_t* v, os_fat16_dirent_t* out, uint32_t capacity) {
     uint8_t entry[32], lfn_sum = 0U, expected = 0U, valid = 0U; char lfn[OS_NAME_MAX]; uint32_t count = 0U;
     if (!v || !out || capacity == 0U || !fat32_is_mounted(v)) return OS_FAT16_BAD_PATH;

--- a/kernel/fs/fat32.h
+++ b/kernel/fs/fat32.h
@@ -41,6 +41,8 @@ int fat32_encode_lfn_entry(const char* name, uint8_t ordinal, uint8_t checksum, 
 int fat32_create_file(const fat32_volume_t* volume, const char* name, uint8_t attributes, const uint8_t* data, uint32_t size, uint32_t* out_first_cluster);
 int fat32_create_lfn_file(const fat32_volume_t* volume, const char* long_name, const char* short_name, uint8_t attributes, const uint8_t* data, uint32_t size, uint32_t* out_first_cluster);
 int fat32_list_root(const fat32_volume_t* volume, os_fat16_dirent_t* out, uint32_t capacity);
+/* Lit un fichier FAT32 8.3 dans un buffer caller-owned, sans allocation dynamique. */
+int fat32_read_file(const fat32_volume_t* volume, const char* name, uint8_t* buffer, uint32_t max);
 /* Supprime un alias 8.3 ou une séquence LFN ASCII validée et libère sa chaîne. */
 int fat32_unlink_file(const fat32_volume_t* volume, const char* name);
 /* Renomme une séquence LFN validée sans déplacer ni recopier sa chaîne de données. */

--- a/tests/unit/kernel/test_fat32.c
+++ b/tests/unit/kernel/test_fat32.c
@@ -75,7 +75,8 @@ void test_fat32_lfn_file_and_list(void) {
     for (uint32_t i = 0U; i < sizeof(data); i++) data[i] = (uint8_t)i;
     TEST_ASSERT_EQUAL(0, fat32_mount(&volume, read_sector, 0U)); TEST_ASSERT_EQUAL(0, fat32_attach_writer(&volume, write_sector));
     { int rc = fat32_create_lfn_file(&volume, "Persistent-LLM-Session", "SESSION.BIN", 0x20U, data, sizeof(data), &first); TEST_ASSERT_EQUAL(0, rc); }
-    TEST_ASSERT_EQUAL(3U, first); TEST_ASSERT_EQUAL(1, fat32_list_root(&volume, entries, 4U));
+    TEST_ASSERT_EQUAL(3U, first); TEST_ASSERT_EQUAL(16, fat32_read_file(&volume, "SESSION.BIN", data + 0U, sizeof(data)));
+    TEST_ASSERT_EQUAL(1, fat32_list_root(&volume, entries, 4U));
     TEST_ASSERT_EQUAL_STRING("Persistent-LLM-Session", entries[0].name); TEST_ASSERT_EQUAL(sizeof(data), entries[0].size);
     TEST_ASSERT_EQUAL(0, fat32_rename_lfn_file(&volume, "persistent-llm-session",
                                                 "Persistent-LLM-Record", "RECORD.BIN"));


### PR DESCRIPTION
Ajoute la lecture FAT32 bornée par alias 8.3, sans allocation dynamique, validée par 457/457 tests.