### PR TITLE
feat: add ATA master slave selection

### DIFF
--- a/docs/aos1689_1696_ata_multidrive.md
+++ b/docs/aos1689_1696_ata_multidrive.md
@@ -1,0 +1,22 @@
+# AOS-1689 à AOS-1696 — sélection ATA primaire maître/esclave
+
+Ce macro-lot étend le pilote ATA PIO LBA28 primaire pour sélectionner explicitement le **maître** ou l’**esclave**. Les interfaces historiques `ata_read_sectors` et `ata_write_sectors` demeurent des wrappers strictement compatibles du maître primaire.
+
+| API | Rôle |
+|---|---|
+| `ata_present_drive(drive)` | Indique si le maître ou l’esclave est détecté. |
+| `ata_read_sectors_drive(drive, lba, count, buffer)` | Lit un intervalle LBA28 sur le disque choisi. |
+| `ata_write_sectors_drive(drive, lba, count, buffer)` | Écrit un intervalle LBA28 sur le disque choisi. |
+| `ata_read_sectors` / `ata_write_sectors` | Compatibilité historique : délégation au maître. |
+
+Le registre ATA `0x1F6` reçoit le bit esclave lorsque nécessaire. La détection de l’esclave reste non bloquante : l’absence de second disque ne retire pas le maître déjà validé. Le pilote ne crée aucun buffer ni état dynamique supplémentaire.
+
+> Cette extension est le prérequis matériel d’une image FAT32 IDE séparée. Le volume GGUF/FAT16 du maître primaire reste inchangé.
+
+La construction i386 réussit et la suite complète valide **457/457 tests**. Les tests matériels QEMU multi-disque et le montage du volume FAT32 constituent l’incrément suivant.
+
+## Références internes
+
+- [Montage VFS FAT16 lecture seule](aos1665_1672_vfs_fat16_readonly_mount.md)
+- [Lecture FAT32 par alias](aos1681_1688_fat32_alias_read.md)
+- [Contrat ATA](../kernel/ata.h)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -101,6 +101,7 @@
 - [x] AOS-1665…1672 : montage VFS protégé `fat16/` en lecture/stat/listage, sans mutation ni allocation dynamique — [aos1665_1672_vfs_fat16_readonly_mount.md](aos1665_1672_vfs_fat16_readonly_mount.md)
 - [x] AOS-1673…1680 : renommage FAT32 LFN validé sans déplacement de chaîne, borné à une cardinalité de séquence identique — [aos1673_1680_fat32_lfn_rename.md](aos1673_1680_fat32_lfn_rename.md)
 - [x] AOS-1681…1688 : lecture FAT32 bornée par alias 8.3, parcours de chaîne contrôlé et prérequis VFS — [aos1681_1688_fat32_alias_read.md](aos1681_1688_fat32_alias_read.md)
+- [x] AOS-1689…1696 : sélection ATA primaire maître/esclave, prérequis d’un volume FAT32 IDE distinct — [aos1689_1696_ata_multidrive.md](aos1689_1696_ata_multidrive.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/ata.c
+++ b/kernel/ata.c
@@ -26,6 +26,7 @@ extern void outb(unsigned short port, unsigned char data);
 #define ATA_TIMEOUT 500000u
 
 static int g_ata_present;
+static uint8_t g_ata_drive_present[2];
 
 static unsigned short ata_inw(unsigned short port) {
     unsigned short ret;
@@ -71,8 +72,8 @@ static int ata_wait_drq(void) {
     return -1;
 }
 
-static void ata_select_lba(uint32_t lba, uint8_t count) {
-    outb(ATA_DRIVE, (uint8_t)(0xE0 | ((lba >> 24) & 0x0F)));
+static void ata_select_lba(uint8_t drive, uint32_t lba, uint8_t count) {
+    outb(ATA_DRIVE, (uint8_t)(0xE0 | (drive ? 0x10U : 0U) | ((lba >> 24) & 0x0F)));
     ata_io_delay();
     outb(ATA_SECCOUNT, count);
     outb(ATA_LBA0, (uint8_t)lba);
@@ -80,8 +81,10 @@ static void ata_select_lba(uint32_t lba, uint8_t count) {
     outb(ATA_LBA2, (uint8_t)(lba >> 16));
 }
 
-int ata_present(void) {
-    return g_ata_present;
+int ata_present(void) { return g_ata_present; }
+
+int ata_present_drive(uint8_t drive) {
+    return drive < 2U && g_ata_drive_present[drive];
 }
 
 int ata_init(void) {
@@ -89,6 +92,7 @@ int ata_init(void) {
     uint32_t i;
 
     g_ata_present = 0;
+    g_ata_drive_present[0] = 0U; g_ata_drive_present[1] = 0U;
 
     outb(ATA_DRIVE, 0xA0);
     ata_io_delay();
@@ -113,17 +117,21 @@ int ata_init(void) {
     }
 
     g_ata_present = 1;
+    g_ata_drive_present[0] = 1U;
+    outb(ATA_DRIVE, 0xB0); ata_io_delay();
+    st = inb(ATA_STATUS);
+    if (st != 0x00 && st != 0xFF) g_ata_drive_present[1] = 1U;
     return 0;
 }
 
-int ata_read_sectors(uint32_t lba, uint32_t count, void* buf) {
+int ata_read_sectors_drive(uint8_t drive, uint32_t lba, uint32_t count, void* buf) {
     uint8_t* out = (uint8_t*)buf;
     uint32_t s;
 
-    if (!g_ata_present || !buf || count == 0 || count > 256) return -1;
+    if (drive > ATA_DRIVE_SLAVE || !g_ata_drive_present[drive] || !buf || count == 0 || count > 256) return -1;
     if (lba + count < lba) return -1;
 
-    ata_select_lba(lba, (uint8_t)count);
+    ata_select_lba(drive, lba, (uint8_t)count);
     outb(ATA_CMD, ATA_CMD_READ_PIO);
 
     for (s = 0; s < count; s++) {
@@ -135,14 +143,14 @@ int ata_read_sectors(uint32_t lba, uint32_t count, void* buf) {
     return 0;
 }
 
-int ata_write_sectors(uint32_t lba, uint32_t count, const void* buf) {
+int ata_write_sectors_drive(uint8_t drive, uint32_t lba, uint32_t count, const void* buf) {
     const uint8_t* in = (const uint8_t*)buf;
     uint32_t s;
 
-    if (!g_ata_present || !buf || count == 0 || count > 256) return -1;
+    if (drive > ATA_DRIVE_SLAVE || !g_ata_drive_present[drive] || !buf || count == 0 || count > 256) return -1;
     if (lba + count < lba) return -1;
 
-    ata_select_lba(lba, (uint8_t)count);
+    ata_select_lba(drive, lba, (uint8_t)count);
     outb(ATA_CMD, ATA_CMD_WRITE_PIO);
 
     for (s = 0; s < count; s++) {
@@ -152,4 +160,12 @@ int ata_write_sectors(uint32_t lba, uint32_t count, const void* buf) {
         if (ata_wait_not_busy() < 0) return -1;
     }
     return 0;
+}
+
+int ata_read_sectors(uint32_t lba, uint32_t count, void* buf) {
+    return ata_read_sectors_drive(ATA_DRIVE_MASTER, lba, count, buf);
+}
+
+int ata_write_sectors(uint32_t lba, uint32_t count, const void* buf) {
+    return ata_write_sectors_drive(ATA_DRIVE_MASTER, lba, count, buf);
 }

--- a/kernel/ata.h
+++ b/kernel/ata.h
@@ -3,11 +3,16 @@
 
 #include <stdint.h>
 
-/* ATA PIO LBA28 on the primary master (0x1F0). No IRQ14. */
+/* ATA PIO LBA28 primaire (0x1F0), maître ou esclave. No IRQ14. */
+#define ATA_DRIVE_MASTER 0U
+#define ATA_DRIVE_SLAVE  1U
 
 int ata_init(void);
 int ata_present(void);
+int ata_present_drive(uint8_t drive);
 int ata_read_sectors(uint32_t lba, uint32_t count, void* buf);
+int ata_read_sectors_drive(uint8_t drive, uint32_t lba, uint32_t count, void* buf);
 int ata_write_sectors(uint32_t lba, uint32_t count, const void* buf);
+int ata_write_sectors_drive(uint8_t drive, uint32_t lba, uint32_t count, const void* buf);
 
 #endif


### PR DESCRIPTION
Ajoute l’accès ATA maître/esclave, conserve les wrappers maître et valide 457/457 tests.