### PR TITLE
feat: mount static FAT32 secondary volume

### DIFF
--- a/docs/aos1697_1704_fat32_secondary_kernel_mount.md
+++ b/docs/aos1697_1704_fat32_secondary_kernel_mount.md
@@ -1,0 +1,20 @@
+# AOS-1697 à AOS-1704 — volume FAT32 secondaire statique au noyau
+
+Ce macro-lot introduit une instance FAT32 globale statique accessible par `fat32_root()`, puis tente son montage au démarrage sur le disque ATA primaire esclave, au LBA zéro. L’adaptateur de secteur utilise `ata_read_sectors_drive(ATA_DRIVE_SLAVE, ...)`.
+
+Le montage est **non bloquant** : il n’est tenté que lorsqu’un esclave ATA est détecté. Les configurations historiques à disque unique poursuivent donc exactement le montage FAT16 maître au LBA 64, l’overlay et l’initialisation GGUF sans dépendance FAT32.
+
+| Élément | Garantie |
+|---|---|
+| État FAT32 | Instance globale statique ; aucune allocation dynamique. |
+| Support | Disque ATA primaire esclave, LBA zéro. |
+| Absence d’esclave | Aucun échec de boot ; FAT16 maître inchangé. |
+| Volume GGUF | Toujours FAT16 maître LBA 64. |
+
+La construction i386 réussit et la suite complète valide **457/457 tests**. La prochaine étape est la fabrication de l’image FAT32 esclave et son test QEMU multi-disque, avant l’exposition VFS FAT32.
+
+## Références internes
+
+- [Sélection ATA maître/esclave](aos1689_1696_ata_multidrive.md)
+- [Lecture FAT32 par alias](aos1681_1688_fat32_alias_read.md)
+- [Contrats FAT32](../kernel/fs/fat32.h)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -102,6 +102,7 @@
 - [x] AOS-1673…1680 : renommage FAT32 LFN validé sans déplacement de chaîne, borné à une cardinalité de séquence identique — [aos1673_1680_fat32_lfn_rename.md](aos1673_1680_fat32_lfn_rename.md)
 - [x] AOS-1681…1688 : lecture FAT32 bornée par alias 8.3, parcours de chaîne contrôlé et prérequis VFS — [aos1681_1688_fat32_alias_read.md](aos1681_1688_fat32_alias_read.md)
 - [x] AOS-1689…1696 : sélection ATA primaire maître/esclave, prérequis d’un volume FAT32 IDE distinct — [aos1689_1696_ata_multidrive.md](aos1689_1696_ata_multidrive.md)
+- [x] AOS-1697…1704 : volume FAT32 secondaire statique au noyau, montage ATA esclave non bloquant — [aos1697_1704_fat32_secondary_kernel_mount.md](aos1697_1704_fat32_secondary_kernel_mount.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/fs/fat32.c
+++ b/kernel/fs/fat32.c
@@ -1,5 +1,9 @@
 #include "fat32.h"
 
+static fat32_volume_t fat32_root_volume;
+
+fat32_volume_t* fat32_root(void) { return &fat32_root_volume; }
+
 static uint8_t fat32_sector[512];
 
 static uint16_t le16(const uint8_t* p) { return (uint16_t)p[0] | ((uint16_t)p[1] << 8U); }

--- a/kernel/fs/fat32.h
+++ b/kernel/fs/fat32.h
@@ -24,6 +24,7 @@ typedef struct {
     uint8_t mounted;
 } fat32_volume_t;
 
+fat32_volume_t* fat32_root(void);
 int fat32_mount(fat32_volume_t* volume, fat16_read_sector_fn read_sector, uint32_t base_lba);
 int fat32_is_mounted(const fat32_volume_t* volume);
 int fat32_attach_writer(fat32_volume_t* volume, fat16_write_sector_fn write_sector);

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -12,6 +12,7 @@
 #include "../fs/overlay.h"
 #include "ata.h"
 #include "fs/fat16.h"
+#include "fs/fat32.h"
 #include "llm/gpt2_model.h"
 #include "llm/gpt2_gguf.h"
 #include "llm/gpt2_gguf_infer.h"
@@ -628,6 +629,10 @@ static int fat16_ata_read_sectors(uint32_t lba, uint32_t count, void* buffer) {
     return ata_read_sectors(lba, count, buffer);
 }
 
+static int fat32_ata_slave_read_sector(uint32_t lba, void* buffer) {
+    return ata_read_sectors_drive(ATA_DRIVE_SLAVE, lba, 1U, buffer);
+}
+
 void serial_init() {
     // Disable all interrupts
     outb(0x3F8 + 1, 0x00);
@@ -1147,6 +1152,10 @@ void kmain(uint32_t multiboot_magic, uint32_t multiboot_addr) {
             print_string("Overlay FS charge depuis le disque IDE.\n");
         } else {
             print_string("Overlay FS initialise (disque IDE vide).\n");
+        }
+        if (ata_present_drive(ATA_DRIVE_SLAVE) &&
+            fat32_mount(fat32_root(), fat32_ata_slave_read_sector, 0U) == 0) {
+            print_string("FAT32 secondaire monte.\n");
         }
         if (fat16_mount(fat16_root(), fat16_ata_read_sector, 64U) == 0) {
             if (fat16_attach_read_window(fat16_root(), fat16_ata_read_sectors,


### PR DESCRIPTION
Monte un volume FAT32 statique sur l’esclave ATA lorsqu’il est présent, sans modifier FAT16/GGUF et avec 457/457 tests verts.