### PR TITLE
feat: add FAT32 secondary image smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ ISO_IMAGE = build/ai_os.iso
 INITRD_IMAGE = my_initrd.tar
 DISK_IMAGE ?= build/overlay.img
 GGUF_DISK_IMAGE ?= build/gpt2_gguf_fat16.img
+FAT32_SECONDARY_IMAGE ?= build/fat32_secondary.img
 GPT2_GGUF_DEPLOY_MODEL ?= models/gpt2-Q3_K_M.gguf
 DISK_SECTORS ?= 4224
 FAT_BASE_LBA ?= 64
@@ -696,6 +697,9 @@ help:
 
 gguf-disk:
 	@python3 scripts/make_gguf_fat16_image.py --model $(GPT2_GGUF_DEPLOY_MODEL) --image $(GGUF_DISK_IMAGE)
+
+fat32-secondary-disk:
+	@python3 scripts/make_fat32_secondary_image.py --image $(FAT32_SECONDARY_IMAGE)
 
 .PHONY: qemu-gguf-smoke
 qemu-gguf-smoke: $(OS_IMAGE) pack-initrd gguf-disk

--- a/docs/aos1705_1712_fat32_secondary_image_smoke.md
+++ b/docs/aos1705_1712_fat32_secondary_image_smoke.md
@@ -1,0 +1,19 @@
+# AOS-1705 à AOS-1712 — image FAT32 secondaire et smoke QEMU multi-disque
+
+Ce macro-lot ajoute `scripts/make_fat32_secondary_image.py` et la cible `make fat32-secondary-disk`. L’image constitue un disque ATA esclave distinct, avec un BPB FAT32 valide, une racine au cluster 2 et la fixture `FAT32OK.TXT`.
+
+La géométrie comporte 70 000 secteurs avec un secteur par cluster et deux FAT de 600 secteurs. Elle dépasse donc le seuil de 65 525 clusters exigé par le monteur FAT32 du noyau. Cette contrainte distingue explicitement une image FAT32 réelle d’une petite image qui serait classée FAT16 par la géométrie.
+
+Le smoke QEMU attache l’overlay sur le maître et l’image FAT32 sur l’esclave. La trace de démarrage confirme successivement :
+
+> `FAT32 secondaire monte.`
+>
+> `FAT16: volume lecture seule monte`
+
+Ainsi, le nouveau volume est monté sans interférer avec le volume FAT16 maître contenant le profil GGUF. Le processus de génération ne crée aucun état noyau dynamique.
+
+## Références internes
+
+- [Sélection ATA maître/esclave](aos1689_1696_ata_multidrive.md)
+- [Volume FAT32 secondaire statique](aos1697_1704_fat32_secondary_kernel_mount.md)
+- [Lecture FAT32 par alias](aos1681_1688_fat32_alias_read.md)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -103,6 +103,7 @@
 - [x] AOS-1681…1688 : lecture FAT32 bornée par alias 8.3, parcours de chaîne contrôlé et prérequis VFS — [aos1681_1688_fat32_alias_read.md](aos1681_1688_fat32_alias_read.md)
 - [x] AOS-1689…1696 : sélection ATA primaire maître/esclave, prérequis d’un volume FAT32 IDE distinct — [aos1689_1696_ata_multidrive.md](aos1689_1696_ata_multidrive.md)
 - [x] AOS-1697…1704 : volume FAT32 secondaire statique au noyau, montage ATA esclave non bloquant — [aos1697_1704_fat32_secondary_kernel_mount.md](aos1697_1704_fat32_secondary_kernel_mount.md)
+- [x] AOS-1705…1712 : image FAT32 ATA esclave reproductible et smoke QEMU multi-disque de montage réel — [aos1705_1712_fat32_secondary_image_smoke.md](aos1705_1712_fat32_secondary_image_smoke.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/scripts/make_fat32_secondary_image.py
+++ b/scripts/make_fat32_secondary_image.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Construit une image FAT32 secondaire minimale pour le smoke multi-disque AI-OS."""
+import argparse
+from pathlib import Path
+
+SECTOR = 512
+SECTORS_PER_CLUSTER = 1
+RESERVED = 32
+FAT_COUNT = 2
+# Avec un cluster d’un secteur, le monteur FAT32 exige au moins 65 525 clusters.
+FAT_SECTORS = 600
+TOTAL_SECTORS = 70000
+ROOT_CLUSTER = 2
+FIXTURE_CLUSTER = 3
+FIXTURE = b"FAT32 secondary fixture OK\n"
+
+
+def put16(buf, offset, value):
+    buf[offset:offset + 2] = int(value).to_bytes(2, "little")
+
+
+def put32(buf, offset, value):
+    buf[offset:offset + 4] = int(value).to_bytes(4, "little")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", required=True, type=Path)
+    args = parser.parse_args()
+    data_lba = RESERVED + FAT_COUNT * FAT_SECTORS
+    args.image.parent.mkdir(parents=True, exist_ok=True)
+    with args.image.open("wb") as image:
+        image.truncate(TOTAL_SECTORS * SECTOR)
+        boot = bytearray(SECTOR)
+        boot[:3] = b"\xeb\x58\x90"
+        boot[3:11] = b"AIOSF32 "
+        put16(boot, 11, SECTOR)
+        boot[13] = SECTORS_PER_CLUSTER
+        put16(boot, 14, RESERVED)
+        boot[16] = FAT_COUNT
+        put16(boot, 17, 0)
+        put16(boot, 19, 0)
+        boot[21] = 0xF8
+        put16(boot, 22, 0)
+        put16(boot, 24, 32)
+        put16(boot, 26, 64)
+        put32(boot, 28, 0)
+        put32(boot, 32, TOTAL_SECTORS)
+        put32(boot, 36, FAT_SECTORS)
+        put32(boot, 44, ROOT_CLUSTER)
+        boot[64] = 0x80
+        boot[66] = 0x29
+        put32(boot, 67, 0xA105F320)
+        boot[71:82] = b"AIOS FAT32 "
+        boot[82:90] = b"FAT32   "
+        boot[510:512] = b"\x55\xaa"
+        image.seek(0)
+        image.write(boot)
+        fat = bytearray(SECTOR)
+        put32(fat, 0, 0x0FFFFFF8)
+        put32(fat, 4, 0x0FFFFFFF)
+        put32(fat, ROOT_CLUSTER * 4, 0x0FFFFFFF)
+        put32(fat, FIXTURE_CLUSTER * 4, 0x0FFFFFFF)
+        for copy in range(FAT_COUNT):
+            image.seek((RESERVED + copy * FAT_SECTORS) * SECTOR)
+            image.write(fat)
+        root = bytearray(SECTOR)
+        root[:11] = b"FAT32OK TXT"
+        root[11] = 0x20
+        put16(root, 20, 0)
+        put16(root, 26, FIXTURE_CLUSTER)
+        put32(root, 28, len(FIXTURE))
+        image.seek((data_lba + (ROOT_CLUSTER - 2) * SECTORS_PER_CLUSTER) * SECTOR)
+        image.write(root)
+        image.seek((data_lba + (FIXTURE_CLUSTER - 2) * SECTORS_PER_CLUSTER) * SECTOR)
+        image.write(FIXTURE)
+    print(f"FAT32 secondaire: {args.image} ({TOTAL_SECTORS * SECTOR} octets)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Ajoute une image FAT32 esclave reproductible, une cible Makefile et un smoke QEMU multi-disque validant le montage réel ; 457/457 tests verts.