### PR TITLE
feat: expose FAT32 read syscalls

### DIFF
--- a/docs/aos1713_1720_fat32_read_syscalls.md
+++ b/docs/aos1713_1720_fat32_read_syscalls.md
@@ -1,0 +1,18 @@
+# AOS-1713 à AOS-1720 — syscalls FAT32 de lecture et listage
+
+Ce macro-lot expose le volume FAT32 secondaire statique aux programmes Ring 3 par deux appels ABI lecture seule : `SYS_FAT32_READ` (111) et `SYS_FAT32_LIST` (112).
+
+| Appel | Registres | Contrat |
+|---|---|---|
+| `SYS_FAT32_READ` | EBX nom 8.3, ECX buffer, EDX capacité | Lit le fichier depuis le volume FAT32 secondaire dans un buffer utilisateur borné. |
+| `SYS_FAT32_LIST` | EBX tableau `os_fat16_dirent_t`, ECX capacité | Liste la racine FAT32 dans le tableau fourni par l’appelant. |
+
+Les deux chemins refusent les appels non Ring 3, les arguments nuls et les capacités nulles avant toute opération de disque. Ils délèguent aux primitives FAT32 existantes, n’ajoutent aucun cache de fichier et n’exposent aucune mutation. Les codes d’erreur FAT existants sont conservés.
+
+La construction i386 réussit et la suite complète valide **457/457 tests**. Le prochain incrément connecte ces appels au médiateur VFS sous un montage `fat32/` lecture seule.
+
+## Références internes
+
+- [Lecture FAT32 par alias](aos1681_1688_fat32_alias_read.md)
+- [Image FAT32 secondaire](aos1705_1712_fat32_secondary_image_smoke.md)
+- [ABI des syscalls](../include/os_syscalls.h)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -104,6 +104,7 @@
 - [x] AOS-1689…1696 : sélection ATA primaire maître/esclave, prérequis d’un volume FAT32 IDE distinct — [aos1689_1696_ata_multidrive.md](aos1689_1696_ata_multidrive.md)
 - [x] AOS-1697…1704 : volume FAT32 secondaire statique au noyau, montage ATA esclave non bloquant — [aos1697_1704_fat32_secondary_kernel_mount.md](aos1697_1704_fat32_secondary_kernel_mount.md)
 - [x] AOS-1705…1712 : image FAT32 ATA esclave reproductible et smoke QEMU multi-disque de montage réel — [aos1705_1712_fat32_secondary_image_smoke.md](aos1705_1712_fat32_secondary_image_smoke.md)
+- [x] AOS-1713…1720 : syscalls FAT32 Ring 3 de lecture et listage de racine, sans mutation ni allocation dynamique — [aos1713_1720_fat32_read_syscalls.md](aos1713_1720_fat32_read_syscalls.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/include/os_syscalls.h
+++ b/include/os_syscalls.h
@@ -206,6 +206,10 @@
 #define SYS_GPT2_GGUF_GENERATE 109
 /* buffer de réponse (ECX), taille du buffer (EDX) ; poursuit la session GGUF locale. */
 #define SYS_GPT2_GGUF_CONTINUE 110
+/* EBX = chemin FAT32 8.3, ECX = buffer, EDX = taille maximale ; lecture esclave. */
+#define SYS_FAT32_READ 111
+/* EBX = tableau os_dirent_t, ECX = capacité ; liste de la racine FAT32 esclave. */
+#define SYS_FAT32_LIST 112
 #define MAX_SYSCALLS 111
 
 typedef struct {

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -16,6 +16,7 @@
 #include "../llm/gpt2_tokenizer.h"
 #include "../service_registry.h"
 #include "../fs/fat16.h"
+#include "../fs/fat32.h"
 #include "../net_socket.h"
 /* Completions locales : BPE, top-k basse temperature, arret newline/EOT/repetition. */
 #define GPT2_BAREMETAL_GENERATION_STEPS 12U
@@ -316,6 +317,12 @@ void syscall_handler(cpu_state_t* cpu) {
             break;
         case SYS_FAT16_LIST:
             cpu->eax = (uint32_t)sys_fat16_list((os_fat16_dirent_t*)cpu->ebx, cpu->ecx);
+            break;
+        case SYS_FAT32_READ:
+            cpu->eax = (uint32_t)sys_fat32_read((const char*)cpu->ebx, (char*)cpu->ecx, cpu->edx);
+            break;
+        case SYS_FAT32_LIST:
+            cpu->eax = (uint32_t)sys_fat32_list((os_fat16_dirent_t*)cpu->ebx, cpu->ecx);
             break;
         case SYS_SOCKET_OPEN:
             cpu->eax = (uint32_t)sys_socket_open((uint16_t)cpu->ebx, (uint16_t)cpu->ecx, cpu->edx);
@@ -622,6 +629,18 @@ int sys_fat16_list(os_fat16_dirent_t* out, uint32_t capacity) {
     if (!current_task || current_task->type != TASK_TYPE_USER) return OS_FAT16_NOT_MOUNTED;
     if (!out || capacity == 0U) return OS_FAT16_BAD_PATH;
     return fat16_list_root(fat16_root(), out, capacity);
+}
+
+int sys_fat32_read(const char* name, char* buffer, uint32_t max) {
+    if (!current_task || current_task->type != TASK_TYPE_USER) return OS_FAT16_NOT_MOUNTED;
+    if (!name || !buffer || max == 0U) return OS_FAT16_BAD_PATH;
+    return fat32_read_file(fat32_root(), name, (uint8_t*)buffer, max);
+}
+
+int sys_fat32_list(os_fat16_dirent_t* out, uint32_t capacity) {
+    if (!current_task || current_task->type != TASK_TYPE_USER) return OS_FAT16_NOT_MOUNTED;
+    if (!out || capacity == 0U) return OS_FAT16_BAD_PATH;
+    return fat32_list_root(fat32_root(), out, capacity);
 }
 
 static int syscall_user_range(const void* pointer, uint32_t length, int write) {

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -69,6 +69,8 @@ int sys_task_supervision_notify_budget(uint32_t limit);
 int sys_task_supervision_notify_budget_status(os_task_supervision_notify_budget_status_t* out);
 int sys_fat16_read(const char* name, char* buffer, uint32_t max);
 int sys_fat16_list(os_fat16_dirent_t* out, uint32_t capacity);
+int sys_fat32_read(const char* name, char* buffer, uint32_t max);
+int sys_fat32_list(os_fat16_dirent_t* out, uint32_t capacity);
 int sys_socket_open(uint16_t local_port, uint16_t remote_port, uint32_t local_sequence);
 int sys_socket_listen(uint16_t local_port, uint32_t local_sequence);
 int sys_socket_accept_syn(int socket_id, const os_socket_passive_view_t* view);


### PR DESCRIPTION
Expose les syscalls FAT32 de lecture et listage Ring 3, sans mutation ni allocation dynamique ; 457/457 tests verts.