### PR TITLE
feat: mount FAT32 read-only in VFS

### DIFF
--- a/docs/aos1721_1728_vfs_fat32_readonly_mount.md
+++ b/docs/aos1721_1728_vfs_fat32_readonly_mount.md
@@ -1,0 +1,20 @@
+# AOS-1721 à AOS-1728 — montage VFS FAT32 en lecture seule
+
+Ce macro-lot ajoute `OS_VFS_MOUNT_SOURCE_FAT32` et le montage protégé `fat32/` au serveur VFS Ring 3. La source utilise exclusivement les syscalls FAT32 lecture et listage du volume secondaire réel.
+
+| Opération VFS | Source `fat32/` |
+|---|---|
+| Lecture | Autorisée par `SYS_FAT32_READ`. |
+| Stat | Autorisé par recherche dans le listage de racine. |
+| Listage et pagination | Autorisés, racine FAT32 uniquement. |
+| Écriture, suppression, renommage, mkdir, rmdir | Refusés : réservés à `overlay/`. |
+
+Le montage est protégé et s’ajoute aux sources `initrd/`, `overlay/` et `fat16/`. Les buffers IPC, les structures de répertoire et les droits de backend restent inchangés. Aucune allocation dynamique, mutation FAT32 ni ouverture de capacité supplémentaire n’est introduite.
+
+La construction complète et la suite de non-régression valident **457/457 tests**. Le volume FAT32 lui-même est déjà validé par le smoke QEMU multi-disque ; le serveur VFS s’y connecte désormais en lecture seule.
+
+## Références internes
+
+- [Syscalls FAT32 lecture seule](aos1713_1720_fat32_read_syscalls.md)
+- [Image FAT32 secondaire](aos1705_1712_fat32_secondary_image_smoke.md)
+- [Montage VFS FAT16 lecture seule](aos1665_1672_vfs_fat16_readonly_mount.md)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -105,6 +105,7 @@
 - [x] AOS-1697…1704 : volume FAT32 secondaire statique au noyau, montage ATA esclave non bloquant — [aos1697_1704_fat32_secondary_kernel_mount.md](aos1697_1704_fat32_secondary_kernel_mount.md)
 - [x] AOS-1705…1712 : image FAT32 ATA esclave reproductible et smoke QEMU multi-disque de montage réel — [aos1705_1712_fat32_secondary_image_smoke.md](aos1705_1712_fat32_secondary_image_smoke.md)
 - [x] AOS-1713…1720 : syscalls FAT32 Ring 3 de lecture et listage de racine, sans mutation ni allocation dynamique — [aos1713_1720_fat32_read_syscalls.md](aos1713_1720_fat32_read_syscalls.md)
+- [x] AOS-1721…1728 : montage VFS protégé `fat32/` en lecture/stat/listage, sans mutation ni allocation dynamique — [aos1721_1728_vfs_fat32_readonly_mount.md](aos1721_1728_vfs_fat32_readonly_mount.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/include/os_vfs_service.h
+++ b/include/os_vfs_service.h
@@ -85,6 +85,7 @@
 #define OS_VFS_MOUNT_SOURCE_INITRD 1U
 #define OS_VFS_MOUNT_SOURCE_OVERLAY 2U
 #define OS_VFS_MOUNT_SOURCE_FAT16 3U
+#define OS_VFS_MOUNT_SOURCE_FAT32 4U
 
 #define OS_VFS_STATUS_OK          0
 #define OS_VFS_STATUS_INVALID    (-60)
@@ -181,7 +182,7 @@ static inline int os_vfs_mount_prefix_is_valid(const char* mount) {
 
 static inline int os_vfs_mount_source_is_valid(uint32_t source) {
     return source == OS_VFS_MOUNT_SOURCE_INITRD || source == OS_VFS_MOUNT_SOURCE_OVERLAY ||
-           source == OS_VFS_MOUNT_SOURCE_FAT16;
+           source == OS_VFS_MOUNT_SOURCE_FAT16 || source == OS_VFS_MOUNT_SOURCE_FAT32;
 }
 
 /* Le listage cible un répertoire : il accepte la racine du montage ou un

--- a/userspace/vfs_server.c
+++ b/userspace/vfs_server.c
@@ -118,6 +118,30 @@ static int backend_fat16_stat(const char* path, os_dirent_t* out) {
     }
     return -1;
 }
+static int backend_fat32_read(const char* path, char* buffer, uint32_t max) {
+    int result;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_FAT32_READ), "b"(path), "c"(buffer), "d"(max));
+    return result;
+}
+static int backend_fat32_listdir(const char* path, os_dirent_t* out, int max_n) {
+    int result;
+    if (!path || path[0] != '/' || path[1] != '\0') return -1;
+    asm volatile("int $0x80" : "=a"(result) : "a"(SYS_FAT32_LIST), "b"(out), "c"(max_n));
+    return result;
+}
+static int backend_fat32_stat(const char* path, os_dirent_t* out) {
+    os_dirent_t entries[OS_VFS_LIST_ENTRY_MAX + 1U];
+    int count, i;
+    if (!path || !out || path[0] == '\0' || path[0] == '/') return -1;
+    count = backend_fat32_listdir("/", entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U));
+    if (count < 0) return count;
+    for (i = 0; i < count; i++) {
+        uint32_t j = 0U;
+        while (entries[i].name[j] && path[j] && entries[i].name[j] == path[j]) j++;
+        if (entries[i].name[j] == '\0' && path[j] == '\0') { *out = entries[i]; return 0; }
+    }
+    return -1;
+}
 
 static int backend_initrd_stat(const char* path, os_dirent_t* out) {
     int result;
@@ -206,7 +230,7 @@ static int string_equal(const char* left, const char* right) {
  * alias dynamiques restent possibles. Les noms dynamiques sont bornés pour
  * que la source virtuelle `vfs-mounts` tienne toujours dans 80 octets. */
 #define VFS_MOUNT_MAX 5U
-#define VFS_BOOT_MOUNT_COUNT 3U
+#define VFS_BOOT_MOUNT_COUNT 4U
 #define VFS_DYNAMIC_MOUNT_MAX 13U
 typedef struct {
     char prefix[OS_VFS_PATH_MAX];
@@ -217,6 +241,7 @@ static vfs_mount_t vfs_mounts[VFS_MOUNT_MAX] = {
     { "initrd/", OS_VFS_MOUNT_SOURCE_INITRD, 1U },
     { "overlay/", OS_VFS_MOUNT_SOURCE_OVERLAY, 1U },
     { "fat16/", OS_VFS_MOUNT_SOURCE_FAT16, 1U },
+    { "fat32/", OS_VFS_MOUNT_SOURCE_FAT32, 1U },
 };
 static uint32_t vfs_mount_count = VFS_BOOT_MOUNT_COUNT;
 
@@ -340,7 +365,9 @@ static int read_mounted_backend(const char* path, uint8_t* data, uint32_t* size)
                 ? backend_initrd_read(relative, (char*)data, OS_VFS_READ_MAX)
                 : (vfs_mounts[i].source == OS_VFS_MOUNT_SOURCE_FAT16
                     ? backend_fat16_read(relative, (char*)data, OS_VFS_READ_MAX)
-                    : backend_overlay_read(relative, (char*)data, OS_VFS_READ_MAX));
+                    : (vfs_mounts[i].source == OS_VFS_MOUNT_SOURCE_FAT32
+                        ? backend_fat32_read(relative, (char*)data, OS_VFS_READ_MAX)
+                        : backend_overlay_read(relative, (char*)data, OS_VFS_READ_MAX)));
             if (read < 0) return read;
             *size = (uint32_t)read;
             return OS_VFS_STATUS_OK;
@@ -359,7 +386,9 @@ static int stat_mounted_backend(const char* path, os_dirent_t* out) {
                 ? backend_initrd_stat(relative, out)
                 : (vfs_mounts[i].source == OS_VFS_MOUNT_SOURCE_FAT16
                     ? backend_fat16_stat(relative, out)
-                    : backend_overlay_stat(relative, out));
+                    : (vfs_mounts[i].source == OS_VFS_MOUNT_SOURCE_FAT32
+                        ? backend_fat32_stat(relative, out)
+                        : backend_overlay_stat(relative, out)));
         }
     }
     return OS_VFS_STATUS_NOT_MOUNTED;
@@ -401,7 +430,9 @@ static int list_mounted_backend(const char* path, uint8_t* data, uint32_t* size,
                 ? backend_initrd_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U))
                 : (vfs_mounts[mount_index].source == OS_VFS_MOUNT_SOURCE_FAT16
                     ? backend_fat16_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U))
-                    : backend_overlay_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U)));
+                    : (vfs_mounts[mount_index].source == OS_VFS_MOUNT_SOURCE_FAT32
+                        ? backend_fat32_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U))
+                        : backend_overlay_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U))));
             if (listed < 0) return listed;
             for (uint32_t entry_index = 0U;
                  entry_index < (uint32_t)listed && entry_index < OS_VFS_LIST_ENTRY_MAX;
@@ -442,7 +473,11 @@ static int list_mounted_backend_page(const char* path, uint32_t start, uint8_t* 
         if (!list_path_matches_mount(path, vfs_mounts[mount_index].prefix, &relative)) continue;
         listed = vfs_mounts[mount_index].source == OS_VFS_MOUNT_SOURCE_INITRD
             ? backend_initrd_listdir_page(relative, entries, start)
-            : backend_overlay_listdir_page(relative, entries, start);
+            : (vfs_mounts[mount_index].source == OS_VFS_MOUNT_SOURCE_FAT16
+                ? backend_fat16_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U))
+                : (vfs_mounts[mount_index].source == OS_VFS_MOUNT_SOURCE_FAT32
+                    ? backend_fat32_listdir(relative, entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U))
+                    : backend_overlay_listdir_page(relative, entries, start)));
         if (listed < 0) return listed;
         for (uint32_t entry_index = 0U;
              entry_index < (uint32_t)listed && entry_index < OS_VFS_LIST_ENTRY_MAX;


### PR DESCRIPTION
Ajoute le montage VFS protégé fat32/ avec lecture, stat et listage de racine ; les mutations restent limitées à overlay ; 457/457 tests verts.