### PR TITLE
feat: read FAT32 files by LFN

### DIFF
--- a/docs/aos1729_1736_fat32_lfn_read.md
+++ b/docs/aos1729_1736_fat32_lfn_read.md
@@ -1,0 +1,19 @@
+# AOS-1729 à AOS-1736 — lecture FAT32 par LFN ASCII validé
+
+Ce macro-lot étend `fat32_read_file` : la fonction accepte désormais un alias 8.3 ou un nom long FAT32 ASCII. La recherche reconstruit les fragments LFN dans un buffer automatique borné, exige des ordinaux continus et vérifie le checksum contre l’entrée courte associée avant toute lecture de la chaîne de données.
+
+| Chemin | Validation |
+|---|---|
+| Alias 8.3 | Parseur 8.3 FAT32 historique. |
+| LFN ASCII | Caractères bornés, ordinaux LFN, checksum et comparaison insensible à la casse. |
+| Données | Parcours de chaîne FAT32 déjà validé, borne par la taille de fichier et `cluster_count`. |
+
+Les séquences supprimées, rompues ou dont le checksum ne correspond pas ne permettent pas une correspondance LFN. Aucun état persistant, cache de nom ou allocation dynamique n’est introduit.
+
+Le vecteur FAT32 crée `Persistent-LLM-Session`, puis le lit par `persistent-llm-session` en casse différente avant de vérifier listage, renommage et suppression. La suite complète valide **457/457 tests**.
+
+## Références internes
+
+- [Fondations LFN FAT32](aos1321_fat32_lfn.md)
+- [Lecture FAT32 par alias](aos1681_1688_fat32_alias_read.md)
+- [Montage VFS FAT32](aos1721_1728_vfs_fat32_readonly_mount.md)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -106,6 +106,7 @@
 - [x] AOS-1705…1712 : image FAT32 ATA esclave reproductible et smoke QEMU multi-disque de montage réel — [aos1705_1712_fat32_secondary_image_smoke.md](aos1705_1712_fat32_secondary_image_smoke.md)
 - [x] AOS-1713…1720 : syscalls FAT32 Ring 3 de lecture et listage de racine, sans mutation ni allocation dynamique — [aos1713_1720_fat32_read_syscalls.md](aos1713_1720_fat32_read_syscalls.md)
 - [x] AOS-1721…1728 : montage VFS protégé `fat32/` en lecture/stat/listage, sans mutation ni allocation dynamique — [aos1721_1728_vfs_fat32_readonly_mount.md](aos1721_1728_vfs_fat32_readonly_mount.md)
+- [x] AOS-1729…1736 : lecture FAT32 par alias ou LFN ASCII validé, ordinaux/checksum contrôlés et parcours de chaîne borné — [aos1729_1736_fat32_lfn_read.md](aos1729_1736_fat32_lfn_read.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/fs/fat32.c
+++ b/kernel/fs/fat32.c
@@ -402,18 +402,37 @@ int fat32_rename_lfn_file(const fat32_volume_t* v, const char* old_name,
 }
 
 int fat32_read_file(const fat32_volume_t* v, const char* name, uint8_t* buffer, uint32_t max) {
-    uint8_t entry[32], short_name[11];
+    uint8_t entry[32], short_name[11], lfn_sum = 0U, expected = 0U, valid = 0U;
+    char lfn[OS_NAME_MAX];
     uint32_t i, j, limit, size, copied = 0U, cluster_bytes, guard = 0U;
     uint32_t cluster, next;
+    int short_valid;
     if (!v || !name || !buffer || max == 0U || !fat32_is_mounted(v)) return OS_FAT16_BAD_PATH;
-    if (fat32_short_name(name, short_name) != 0) return OS_FAT16_BAD_PATH;
+    short_valid = fat32_short_name(name, short_name) == 0;
+    for (i = 0U; i < OS_NAME_MAX && name[i]; i++)
+        if ((uint8_t)name[i] < 0x20U || (uint8_t)name[i] > 0x7fU || name[i] == '/' || name[i] == '\\') return OS_FAT16_BAD_PATH;
+    if (i == 0U || i == OS_NAME_MAX) return OS_FAT16_BAD_PATH;
     limit = v->cluster_count * (uint32_t)v->sectors_per_cluster * 16U;
     for (i = 0U; i < limit; i++) {
-        int match = 1;
+        uint8_t ord;
         if (fat32_dir_slot(v, i, entry, 0, 0) != 0 || entry[0] == 0U) break;
-        if (entry[0] == 0xe5U || entry[11] == 0x0fU || (entry[11] & 0x18U)) continue;
-        for (j = 0U; j < 11U; j++) if (entry[j] != short_name[j]) match = 0;
-        if (!match) continue;
+        if (entry[0] == 0xe5U) { valid = 0U; continue; }
+        if (entry[11] == 0x0fU) {
+            ord = entry[0] & 0x1fU;
+            if (entry[0] & 0x40U) {
+                if (ord == 0U || ord * 13U >= OS_NAME_MAX) { valid = 0U; continue; }
+                for (j = 0U; j < OS_NAME_MAX; j++) lfn[j] = 0;
+                lfn_sum = entry[13]; expected = ord; valid = 1U;
+            }
+            if (!valid || ord == 0U || ord != expected || entry[13] != lfn_sum) { valid = 0U; continue; }
+            fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn, OS_NAME_MAX);
+            fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
+            fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            expected--; continue;
+        }
+        if (entry[11] & 0x18U) { valid = 0U; continue; }
+        { int match = short_valid; for (j = 0U; j < 11U && match; j++) if (entry[j] != short_name[j]) match = 0;
+          if (!match && !(valid && expected == 0U && fat32_lfn_checksum(entry) == lfn_sum && fat32_name_equal_folded(name, lfn))) { valid = 0U; continue; } }
         size = le32(entry + 28U);
         if (size > max) return OS_FAT16_BUFFER_SMALL;
         cluster = ((uint32_t)entry[20] << 24U) | ((uint32_t)entry[21] << 16U) | le16(entry + 26U);

--- a/tests/unit/kernel/test_fat32.c
+++ b/tests/unit/kernel/test_fat32.c
@@ -76,6 +76,7 @@ void test_fat32_lfn_file_and_list(void) {
     TEST_ASSERT_EQUAL(0, fat32_mount(&volume, read_sector, 0U)); TEST_ASSERT_EQUAL(0, fat32_attach_writer(&volume, write_sector));
     { int rc = fat32_create_lfn_file(&volume, "Persistent-LLM-Session", "SESSION.BIN", 0x20U, data, sizeof(data), &first); TEST_ASSERT_EQUAL(0, rc); }
     TEST_ASSERT_EQUAL(3U, first); TEST_ASSERT_EQUAL(16, fat32_read_file(&volume, "SESSION.BIN", data + 0U, sizeof(data)));
+    TEST_ASSERT_EQUAL(16, fat32_read_file(&volume, "persistent-llm-session", data + 0U, sizeof(data)));
     TEST_ASSERT_EQUAL(1, fat32_list_root(&volume, entries, 4U));
     TEST_ASSERT_EQUAL_STRING("Persistent-LLM-Session", entries[0].name); TEST_ASSERT_EQUAL(sizeof(data), entries[0].size);
     TEST_ASSERT_EQUAL(0, fat32_rename_lfn_file(&volume, "persistent-llm-session",


### PR DESCRIPTION
Ajoute la lecture FAT32 par LFN ASCII validé, sans allocation dynamique ; 457/457 tests verts.