### PR TITLE
feat: add UTF-8 BMP support for FAT LFN

### DIFF
--- a/docs/aos1737_1744_fat_lfn_utf8.md
+++ b/docs/aos1737_1744_fat_lfn_utf8.md
@@ -1,0 +1,79 @@
+# AOS-1737…1744 — Noms longs FAT en UTF-8 BMP
+
+## Objet du macro-lot
+
+Ce macro-lot étend les noms de fichier longs, ou **LFN**, des pilotes FAT16 et FAT32 afin que l’interface interne accepte et restitue des chaînes **UTF-8** représentables dans le plan multilingue de base (**BMP**). Les entrées de répertoire FAT restent conformes à leur représentation UTF-16LE ; la conversion est effectuée aux frontières des pilotes, sans allocation dynamique.
+
+> Le périmètre couvre les caractères BMP valides encodés en UTF-8. Les paires de surrogates, les séquences UTF-8 mal formées, les encodages non minimaux, les caractères de contrôle et les séparateurs de chemin sont refusés.
+
+| Élément | Avant le macro-lot | Après le macro-lot |
+|---|---|---|
+| Création LFN FAT16 | ASCII uniquement | UTF-8 BMP encodé en UTF-16LE |
+| Création et renommage LFN FAT32 | ASCII uniquement | UTF-8 BMP encodé en UTF-16LE |
+| Lecture, recherche et suppression FAT32 | LFN ASCII uniquement | Requêtes et noms LFN UTF-8 BMP |
+| Lecture et listage FAT16 | Caractères non ASCII rendus par `?` | Décodage UTF-16LE vers UTF-8 BMP |
+| Gestion mémoire | Sans allocation dynamique | Inchangée : tableaux automatiques bornés |
+
+## Conception
+
+Le nouveau composant `kernel/fs/lfn_utf8.h` fournit deux fonctions statiques et freestanding. `lfn_utf8_to_utf16_bmp()` décode une chaîne UTF-8 dans un tableau d’unités UTF-16LE logiques. Il limite l’entrée à trois octets par unité de sortie, ce qui borne les parcours tout en couvrant le maximum de trois octets du BMP UTF-8. `lfn_utf16_bmp_to_utf8()` effectue l’opération inverse dans un tampon appartenant à l’appelant.
+
+| Fonction | Entrée | Sortie | Rejets intentionnels |
+|---|---|---|---|
+| `lfn_utf8_to_utf16_bmp` | UTF-8 NUL-terminé | unités UTF-16 BMP | séquences invalides, surlongues, surrogates, contrôle, `/`, `\\` |
+| `lfn_utf16_bmp_to_utf8` | unités UTF-16LE FAT | UTF-8 NUL-terminé | surrogates et dépassement de capacité |
+
+Les fragments LFN FAT sont dorénavant reconstruits dans des tableaux de `uint16_t` avant tout décodage UTF-8. Cette étape est indispensable : une unité UTF-16LE peut représenter deux ou trois octets UTF-8, et l’écriture directe de caractères dans un tableau `char` par ordinal FAT aurait fragmenté les séquences multioctets. Les comparaisons de noms reconstruisent donc une chaîne UTF-8 bornée avant d’appliquer le repli de casse ASCII historique.
+
+## Intégration FAT32
+
+Les opérations `fat32_create_lfn_file()` et `fat32_rename_lfn_file()` transforment d’abord le nom UTF-8 en unités BMP. `fat32_lfn_segment()` sérialise ensuite les treize unités de chaque entrée LFN avec les positions FAT prescrites. Les parcours de lecture, suppression et listage recueillent les unités via `fat32_lfn_get()` puis restituent l’UTF-8 avec une capacité explicite.
+
+Les requêtes de lecture et suppression passent désormais par une validation UTF-8 BMP commune. Un nom long contenant `é`, comme `café-2026.txt`, peut donc être créé, retrouvé et listé sans que l’octet UTF-8 soit confondu avec une unité de répertoire FAT.
+
+## Intégration FAT16
+
+Le pilote FAT16 adopte le même contrat. `fat16_create_lfn_file()` convertit le nom avant de calculer le nombre d’entrées LFN. `fat16_lfn_put()` écrit les unités UTF-16LE et `fat16_lfn_get()` les réassemble dans un tableau d’unités. Le listage et la recherche par nom long produisent ensuite une chaîne UTF-8 complète avant copie ou comparaison.
+
+Aucune modification n’est apportée au format 8.3, aux fenêtres de lecture FAT16, aux caches sectoriels ou aux API de fichiers. Les fichiers dont le nom court reste représentable sont toujours accessibles via leur alias historique.
+
+## Garanties de sûreté
+
+| Garantie | Mécanisme appliqué |
+|---|---|
+| Zéro allocation dynamique | aucun appel à `kmalloc`, `malloc`, `calloc`, `realloc` ou `free` dans le périmètre UTF-8 LFN |
+| Bornes de nom | capacités explicites, maximum `OS_NAME_MAX`, maximum FAT de vingt entrées LFN |
+| Intégrité UTF-8 | rejet des octets de continuation isolés, surlongueurs et séquences tronquées |
+| Intégrité UTF-16 | rejet des surrogates ; arrêt sur `0x0000` ou remplissage `0xFFFF` |
+| Chemins sûrs | rejet des contrôles, de `/` et de `\\` |
+| Compatibilité | comportement ASCII et alias 8.3 préservés |
+
+Le périmètre volontairement exclu est le support des caractères hors BMP ; ceux-ci exigeraient la gestion de paires de surrogates UTF-16. Les transformations de casse Unicode ne sont pas introduites : seul le repli de casse ASCII préexistant est appliqué, de sorte que les comparaisons restent déterministes et freestanding.
+
+## Validation
+
+Les tests unitaires FAT16 et FAT32 ajoutent chacun un scénario complet autour de `café-2026.txt`. Ils vérifient l’écriture de l’unité `U+00E9` sous la forme `E9 00` dans une entrée LFN, la lecture du contenu par le nom UTF-8 et le nom UTF-8 restitué par le listage. Le socle de conversion vérifie également le rejet de l’encodage UTF-8 surlong `C0 80`.
+
+| Vérification | Résultat |
+|---|---|
+| Conversion UTF-8 ↔ UTF-16 BMP bornée | Réussie |
+| Création, lecture et listage FAT16 avec `café-2026.txt` | Réussis |
+| Création, lecture et listage FAT32 avec `café-2026.txt` | Réussis |
+| Recherche/suppression FAT32 avec requête UTF-8 BMP validée | Couverte par le nouveau chemin de validation |
+| Recherche d’allocations dynamiques dans le périmètre | Aucune occurrence |
+| `make -s test-all` | **460/460 tests réussis** |
+
+## Fichiers principaux
+
+| Fichier | Rôle dans le macro-lot |
+|---|---|
+| `kernel/fs/lfn_utf8.h` | conversion UTF-8/UTF-16 BMP freestanding et bornée |
+| `kernel/fs/fat16.c` | création, recherche et listage LFN FAT16 Unicode |
+| `kernel/fs/fat32.c` | création, renommage, lecture, suppression et listage LFN FAT32 Unicode |
+| `tests/unit/kernel/test_fat16.c` | scénario FAT16 `café-2026.txt` |
+| `tests/unit/kernel/test_fat32.c` | conversion, encodage et scénario FAT32 `café-2026.txt` |
+
+## Références
+
+[1] [Microsoft — Long File Names on FAT volumes](https://download.microsoft.com/download/1/2/7/127443f9-8bb5-40a6-8d72-a3c6e5bd12d5/FAT32_WhitePaper.pdf)  
+[2] [Unicode Consortium — UTF-8, UTF-16 et BMP](https://www.unicode.org/standard/standard.html)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -107,6 +107,7 @@
 - [x] AOS-1713…1720 : syscalls FAT32 Ring 3 de lecture et listage de racine, sans mutation ni allocation dynamique — [aos1713_1720_fat32_read_syscalls.md](aos1713_1720_fat32_read_syscalls.md)
 - [x] AOS-1721…1728 : montage VFS protégé `fat32/` en lecture/stat/listage, sans mutation ni allocation dynamique — [aos1721_1728_vfs_fat32_readonly_mount.md](aos1721_1728_vfs_fat32_readonly_mount.md)
 - [x] AOS-1729…1736 : lecture FAT32 par alias ou LFN ASCII validé, ordinaux/checksum contrôlés et parcours de chaîne borné — [aos1729_1736_fat32_lfn_read.md](aos1729_1736_fat32_lfn_read.md)
+- [x] AOS-1737…1744 : LFN FAT16/FAT32 UTF-8 BMP, sérialisation UTF-16LE, recherche/lecture/listage Unicode et zéro allocation dynamique — [aos1737_1744_fat_lfn_utf8.md](aos1737_1744_fat_lfn_utf8.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/fs/fat16.c
+++ b/kernel/fs/fat16.c
@@ -1,4 +1,5 @@
 #include "fat16.h"
+#include "lfn_utf8.h"
 
 #define FAT16_SECTOR_SIZE 512U
 #define FAT16_ENTRY_SIZE 32U
@@ -315,12 +316,13 @@ static int fat16_write_root_slot(const fat16_volume_t* v, uint32_t index, const 
     return fat16_write_sector(v, lba, sector);
 }
 
-static void fat16_lfn_put(uint8_t* entry, uint32_t offset, uint32_t pos, const char* name, uint32_t length) {
+static void fat16_lfn_put(uint8_t* entry, uint32_t offset, uint32_t pos,
+                           const uint16_t* units, uint32_t length) {
     uint32_t i;
     uint32_t limit = offset == 1U ? 5U : (offset == 14U ? 6U : 2U);
     for (i = 0U; i < limit; i++) {
         uint32_t at = pos + i;
-        uint16_t value = at < length ? (uint8_t)name[at] : (at == length ? 0U : 0xFFFFU);
+        uint16_t value = at < length ? units[at] : (at == length ? 0U : 0xFFFFU);
         entry[offset + i * 2U] = (uint8_t)value;
         entry[offset + i * 2U + 1U] = (uint8_t)(value >> 8U);
     }
@@ -330,15 +332,13 @@ int fat16_create_lfn_file(const fat16_volume_t* v, const char* long_name,
                           const char* short_name, uint8_t attributes,
                           const uint8_t* data, uint32_t size, uint16_t* out_first_cluster) {
     uint8_t alias[11], entry[FAT16_ENTRY_SIZE];
+    uint16_t units[OS_NAME_MAX];
     uint32_t length = 0U, i, alias_index = v ? v->root_entries : 0U, count, start;
     uint16_t first = 0U;
     int rc;
     if (!v || !long_name || !short_name || !out_first_cluster) return OS_FAT16_BAD_PATH;
-    while (long_name[length]) {
-        if (length >= OS_NAME_MAX - 1U || (uint8_t)long_name[length] < 0x20U || long_name[length] == '/' || long_name[length] == '\\') return OS_FAT16_BAD_PATH;
-        length++;
-    }
-    if (length == 0U || make_short_name(short_name, alias) != 0) return OS_FAT16_BAD_PATH;
+    if (lfn_utf8_to_utf16_bmp(long_name, units, OS_NAME_MAX, &length) != 0 ||
+        make_short_name(short_name, alias) != 0) return OS_FAT16_BAD_PATH;
     count = (length + 12U) / 13U;
     if (count == 0U || count > 20U) return OS_FAT16_BAD_PATH;
     rc = fat16_create_file(v, short_name, attributes, data, size, &first);
@@ -364,9 +364,9 @@ int fat16_create_lfn_file(const fat16_volume_t* v, const char* long_name,
         entry[0] = (uint8_t)ordinal | (i == 0U ? 0x40U : 0U);
         entry[11] = 0x0FU; entry[12] = 0U; entry[13] = fat16_lfn_checksum(alias);
         entry[26] = 0U; entry[27] = 0U;
-        fat16_lfn_put(entry, 1U, pos, long_name, length);
-        fat16_lfn_put(entry, 14U, pos + 5U, long_name, length);
-        fat16_lfn_put(entry, 28U, pos + 11U, long_name, length);
+        fat16_lfn_put(entry, 1U, pos, units, length);
+        fat16_lfn_put(entry, 14U, pos + 5U, units, length);
+        fat16_lfn_put(entry, 28U, pos + 11U, units, length);
         rc = fat16_write_root_slot(v, start + i, entry);
         if (rc != 0) return rc;
     }
@@ -381,14 +381,16 @@ int fat16_create_lfn_file(const fat16_volume_t* v, const char* long_name,
     return 0;
 }
 
-static void fat16_lfn_get(uint8_t* entry, uint32_t offset, uint32_t pos, char* out, uint32_t max) {
+static void fat16_lfn_get(uint8_t* entry, uint32_t offset, uint32_t pos,
+                           uint16_t* units, uint32_t max) {
     uint32_t i;
     uint32_t limit = offset == 1U ? 5U : (offset == 14U ? 6U : 2U);
     for (i = 0U; i < limit; i++) {
         uint32_t at = pos + i;
-        uint16_t value = (uint16_t)entry[offset + i * 2U] | ((uint16_t)entry[offset + i * 2U + 1U] << 8U);
-        if (at >= max - 1U || value == 0U || value == 0xFFFFU) continue;
-        out[at] = value < 0x80U ? (char)value : '?';
+        uint16_t value = (uint16_t)entry[offset + i * 2U] |
+                         ((uint16_t)entry[offset + i * 2U + 1U] << 8U);
+        if (at >= max || value == 0U || value == 0xFFFFU) continue;
+        units[at] = value;
     }
 }
 
@@ -397,6 +399,7 @@ int fat16_list_root(const fat16_volume_t* v, os_fat16_dirent_t* out, uint32_t ca
     uint32_t count = 0U;
     uint8_t entry[FAT16_ENTRY_SIZE];
     char lfn[OS_NAME_MAX];
+    uint16_t lfn_units[OS_NAME_MAX];
     uint32_t lfn_length = 0U;
     uint8_t lfn_sum = 0U, lfn_expected = 0U, lfn_valid = 0U;
     if (!fat16_is_mounted(v)) return OS_FAT16_NOT_MOUNTED;
@@ -411,24 +414,24 @@ int fat16_list_root(const fat16_volume_t* v, os_fat16_dirent_t* out, uint32_t ca
             if ((entry[0] & 0x40U) != 0U) {
                 lfn_length = ordinal * 13U;
                 if (lfn_length >= OS_NAME_MAX) { lfn_valid = 0U; continue; }
-                for (uint32_t j = 0U; j < OS_NAME_MAX; j++) lfn[j] = '\0';
+                for (uint32_t j = 0U; j < OS_NAME_MAX; j++) lfn_units[j] = 0U;
                 lfn_sum = entry[13]; lfn_expected = ordinal; lfn_valid = 1U;
             }
             if (!lfn_valid || ordinal == 0U || ordinal != lfn_expected || entry[13] != lfn_sum) { lfn_valid = 0U; continue; }
-            fat16_lfn_get(entry, 1U, (uint32_t)(ordinal - 1U) * 13U, lfn, OS_NAME_MAX);
-            fat16_lfn_get(entry, 14U, (uint32_t)(ordinal - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
-            fat16_lfn_get(entry, 28U, (uint32_t)(ordinal - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            fat16_lfn_get(entry, 1U, (uint32_t)(ordinal - 1U) * 13U, lfn_units, OS_NAME_MAX);
+            fat16_lfn_get(entry, 14U, (uint32_t)(ordinal - 1U) * 13U + 5U, lfn_units, OS_NAME_MAX);
+            fat16_lfn_get(entry, 28U, (uint32_t)(ordinal - 1U) * 13U + 11U, lfn_units, OS_NAME_MAX);
             lfn_expected--;
             continue;
         }
         if ((entry[11] & 0x08U) != 0U) { lfn_valid = 0U; continue; }
         if (count >= capacity) return (int)count;
-        if (lfn_valid && lfn_expected == 0U && fat16_lfn_checksum(entry) == lfn_sum) {
-            uint32_t end = 0U;
-            while (end < OS_NAME_MAX - 1U && lfn[end]) end++;
-            lfn[end] = '\0';
-            for (uint32_t j = 0U; j <= end; j++) out[count].name[j] = lfn[j];
-        } else copy_name(out[count].name, entry);
+        if (!(lfn_valid && lfn_expected == 0U && fat16_lfn_checksum(entry) == lfn_sum &&
+              lfn_utf16_bmp_to_utf8(lfn_units, OS_NAME_MAX, lfn, OS_NAME_MAX) >= 0)) {
+            copy_name(out[count].name, entry);
+        } else {
+            for (uint32_t j = 0U; j < OS_NAME_MAX; j++) out[count].name[j] = lfn[j];
+        }
         out[count].size = le32(entry + 28U);
         out[count].flags = (entry[11] & 0x10U) ? OS_DIRENT_DIR : OS_DIRENT_FILE;
         count++;
@@ -438,14 +441,9 @@ int fat16_list_root(const fat16_volume_t* v, os_fat16_dirent_t* out, uint32_t ca
 }
 
 static int fat16_lfn_query_valid(const char* name) {
-    uint32_t i;
-    if (!name) return 0;
-    for (i = 0U; i < OS_NAME_MAX; i++) {
-        uint8_t c = (uint8_t)name[i];
-        if (c == 0U) return i != 0U;
-        if (c < 0x20U || c >= 0x80U || c == (uint8_t)'/' || c == (uint8_t)'\\') return 0;
-    }
-    return 0;
+    uint16_t units[OS_NAME_MAX];
+    uint32_t length;
+    return lfn_utf8_to_utf16_bmp(name, units, OS_NAME_MAX, &length) == 0;
 }
 
 static int fat16_name_equals_folded(const char* left, const char* right) {
@@ -460,6 +458,12 @@ static int fat16_name_equals_folded(const char* left, const char* right) {
     return 0;
 }
 
+static int fat16_lfn_name_equals_folded(const uint16_t* units, const char* name) {
+    char decoded[OS_NAME_MAX];
+    return lfn_utf16_bmp_to_utf8(units, OS_NAME_MAX, decoded, OS_NAME_MAX) >= 0 &&
+           fat16_name_equals_folded(name, decoded);
+}
+
 /* Recherche une entrée de racine à la fois par alias 8.3 et par LFN ASCII
  * validé. Le résultat reste l’entrée courte FAT16 : aucun état ni allocation
  * supplémentaire n’est nécessaire aux lecteurs et curseurs existants. */
@@ -467,7 +471,7 @@ static int fat16_find_root_entry(const fat16_volume_t* v, const char* name,
                                  uint8_t* out) {
     uint8_t short_name[11];
     uint8_t entry[FAT16_ENTRY_SIZE];
-    char lfn[OS_NAME_MAX];
+    uint16_t lfn_units[OS_NAME_MAX];
     uint32_t i;
     uint32_t lfn_length = 0U;
     uint8_t lfn_sum = 0U;
@@ -487,23 +491,23 @@ static int fat16_find_root_entry(const fat16_volume_t* v, const char* name,
             if ((entry[0] & 0x40U) != 0U) {
                 lfn_length = (uint32_t)ordinal * 13U;
                 if (lfn_length >= OS_NAME_MAX) { lfn_valid = 0U; continue; }
-                for (uint32_t j = 0U; j < OS_NAME_MAX; j++) lfn[j] = '\0';
+                for (uint32_t j = 0U; j < OS_NAME_MAX; j++) lfn_units[j] = 0U;
                 lfn_sum = entry[13];
                 lfn_expected = ordinal;
                 lfn_valid = 1U;
             }
             if (!lfn_valid || ordinal == 0U || ordinal != lfn_expected ||
                 entry[13] != lfn_sum) { lfn_valid = 0U; continue; }
-            fat16_lfn_get(entry, 1U, (uint32_t)(ordinal - 1U) * 13U, lfn, OS_NAME_MAX);
-            fat16_lfn_get(entry, 14U, (uint32_t)(ordinal - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
-            fat16_lfn_get(entry, 28U, (uint32_t)(ordinal - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            fat16_lfn_get(entry, 1U, (uint32_t)(ordinal - 1U) * 13U, lfn_units, OS_NAME_MAX);
+            fat16_lfn_get(entry, 14U, (uint32_t)(ordinal - 1U) * 13U + 5U, lfn_units, OS_NAME_MAX);
+            fat16_lfn_get(entry, 28U, (uint32_t)(ordinal - 1U) * 13U + 11U, lfn_units, OS_NAME_MAX);
             lfn_expected--;
             continue;
         }
         if ((entry[11] & 0x08U) != 0U) { lfn_valid = 0U; continue; }
         if ((short_valid && entry_matches(entry, short_name)) ||
             (lfn_valid && lfn_expected == 0U && fat16_lfn_checksum(entry) == lfn_sum &&
-             fat16_name_equals_folded(name, lfn))) {
+             fat16_lfn_name_equals_folded(lfn_units, name))) {
             for (uint32_t j = 0U; j < FAT16_ENTRY_SIZE; j++) out[j] = entry[j];
             return 0;
         }

--- a/kernel/fs/fat32.c
+++ b/kernel/fs/fat32.c
@@ -1,4 +1,5 @@
 #include "fat32.h"
+#include "lfn_utf8.h"
 
 static fat32_volume_t fat32_root_volume;
 
@@ -220,15 +221,16 @@ uint8_t fat32_lfn_checksum(const uint8_t short_name[11]) {
 }
 
 int fat32_encode_lfn_entry(const char* name, uint8_t ordinal, uint8_t checksum, uint8_t entry[32]) {
+    uint16_t units[13];
     uint32_t length = 0U, i, pos;
     static const uint8_t offsets[13] = {1U,3U,5U,7U,9U,14U,16U,18U,20U,22U,24U,28U,30U};
     if (!name || !entry || ordinal == 0U || (ordinal & 0x1fU) == 0U) return OS_FAT16_BAD_PATH;
-    while (name[length]) { if ((uint8_t)name[length] > 0x7fU || name[length] == '/' || length >= 13U) return OS_FAT16_BAD_PATH; length++; }
+    if (lfn_utf8_to_utf16_bmp(name, units, 13U, &length) != 0) return OS_FAT16_BAD_PATH;
     for (i = 0U; i < 32U; i++) entry[i] = 0xffU;
     entry[0] = ordinal; entry[11] = 0x0fU; entry[12] = 0U; entry[13] = checksum; entry[26] = 0U; entry[27] = 0U;
     for (i = 0U; i < 13U; i++) {
         pos = (uint32_t)(ordinal & 0x1fU) * 13U - 13U + i;
-        if (pos < length) { entry[offsets[i]] = (uint8_t)name[pos]; entry[offsets[i] + 1U] = 0U; }
+        if (pos < length) { entry[offsets[i]] = (uint8_t)units[pos]; entry[offsets[i] + 1U] = (uint8_t)(units[pos] >> 8U); }
         else if (pos == length) { entry[offsets[i]] = 0U; entry[offsets[i] + 1U] = 0U; }
     }
     return 0;
@@ -254,37 +256,51 @@ static int fat32_dir_slot(const fat32_volume_t* v, uint32_t index, uint8_t entry
     return 0;
 }
 
-static void fat32_lfn_get(const uint8_t entry[32], uint32_t offset, uint32_t pos, char* out, uint32_t max) {
+static void fat32_lfn_get(const uint8_t entry[32], uint32_t offset, uint32_t pos,
+                            uint16_t* units, uint32_t max) {
     uint32_t limit = offset == 1U ? 5U : (offset == 14U ? 6U : 2U);
-    for (uint32_t i = 0U; i < limit; i++) { uint32_t at = pos + i; uint16_t value = (uint16_t)entry[offset + i * 2U] | ((uint16_t)entry[offset + i * 2U + 1U] << 8U); if (at >= max - 1U || value == 0U || value == 0xffffU) continue; out[at] = value < 0x80U ? (char)value : '?'; }
+    for (uint32_t i = 0U; i < limit; i++) {
+        uint32_t at = pos + i;
+        uint16_t value = (uint16_t)entry[offset + i * 2U] |
+                         ((uint16_t)entry[offset + i * 2U + 1U] << 8U);
+        if (at >= max || value == 0U || value == 0xffffU) continue;
+        units[at] = value;
+    }
 }
 
-static int fat32_lfn_segment(const char* name, uint32_t length, uint32_t count, uint32_t ordinal, uint8_t checksum, uint8_t entry[32]) {
+static int fat32_lfn_segment(const uint16_t* units, uint32_t length, uint32_t count,
+                             uint32_t ordinal, uint8_t checksum, uint8_t entry[32]) {
     static const uint8_t offsets[13] = {1U,3U,5U,7U,9U,14U,16U,18U,20U,22U,24U,28U,30U};
     uint32_t start = (ordinal - 1U) * 13U;
-    if (!name || !entry || ordinal == 0U || ordinal > count) return OS_FAT16_BAD_PATH;
+    if (!units || !entry || ordinal == 0U || ordinal > count) return OS_FAT16_BAD_PATH;
     for (uint32_t i = 0U; i < 32U; i++) entry[i] = 0xffU;
     entry[0] = (uint8_t)ordinal | (ordinal == count ? 0x40U : 0U);
     entry[11] = 0x0fU; entry[12] = 0U; entry[13] = checksum; entry[26] = 0U; entry[27] = 0U;
     for (uint32_t i = 0U; i < 13U; i++) {
         uint32_t at = start + i;
-        uint16_t value = at < length ? (uint8_t)name[at] : (at == length ? 0U : 0xffffU);
-        entry[offsets[i]] = (uint8_t)value; entry[offsets[i] + 1U] = (uint8_t)(value >> 8U);
+        uint16_t value = at < length ? units[at] : (at == length ? 0U : 0xffffU);
+        entry[offsets[i]] = (uint8_t)value;
+        entry[offsets[i] + 1U] = (uint8_t)(value >> 8U);
     }
     return 0;
 }
 
 int fat32_create_lfn_file(const fat32_volume_t* v, const char* long_name, const char* short_name, uint8_t attributes, const uint8_t* data, uint32_t size, uint32_t* out_first_cluster) {
-    uint8_t alias[11], entry[32]; uint32_t length = 0U, count, alias_index = 0xffffffffU, first = 0U, i; int rc;
+    uint8_t alias[11], entry[32];
+    uint16_t units[OS_NAME_MAX];
+    uint32_t length = 0U, count, alias_index = 0xffffffffU, first = 0U, i;
+    int rc;
     if (!v || !long_name || !short_name || !out_first_cluster) return OS_FAT16_BAD_PATH;
-    while (long_name[length]) { if (length >= OS_NAME_MAX - 1U || (uint8_t)long_name[length] < 0x20U || (uint8_t)long_name[length] > 0x7fU || long_name[length] == '/' || long_name[length] == '\\') return OS_FAT16_BAD_PATH; length++; }
-    if (length == 0U || length > 13U * 20U || fat32_short_name(short_name, alias) != 0) return OS_FAT16_BAD_PATH;
-    count = (length + 12U) / 13U; rc = fat32_create_file(v, short_name, attributes, data, size, &first); if (rc != 0) return rc;
+    if (lfn_utf8_to_utf16_bmp(long_name, units, OS_NAME_MAX, &length) != 0 ||
+        length > 13U * 20U || fat32_short_name(short_name, alias) != 0) return OS_FAT16_BAD_PATH;
+    count = (length + 12U) / 13U;
+    rc = fat32_create_file(v, short_name, attributes, data, size, &first);
+    if (rc != 0) return rc;
     for (i = 0U; i < v->cluster_count * (uint32_t)v->sectors_per_cluster * 16U; i++) { if (fat32_dir_slot(v, i, entry, 0, 0) != 0 || entry[0] == 0U) break; int match = 1; for (uint32_t j = 0U; j < 11U; j++) if (entry[j] != alias[j]) { match = 0; break; } if (match) { alias_index = i; break; } }
     if (alias_index == 0xffffffffU) return OS_FAT16_CORRUPT;
     for (i = 0U; i < count + 1U; i++) if (fat32_dir_slot(v, alias_index + 1U + i, entry, 0, 1) != 0 || (entry[0] != 0U && entry[0] != 0xe5U)) return OS_FAT16_NOT_FOUND;
     entry[0] = 0xe5U; rc = fat32_dir_slot(v, alias_index, entry, 1, 0); if (rc != 0) return rc;
-    for (i = 0U; i < count; i++) { rc = fat32_lfn_segment(long_name, length, count, count - i, fat32_lfn_checksum(alias), entry); if (rc != 0) return rc; rc = fat32_dir_slot(v, alias_index + 1U + i, entry, 1, 1); if (rc != 0) return rc; }
+    for (i = 0U; i < count; i++) { rc = fat32_lfn_segment(units, length, count, count - i, fat32_lfn_checksum(alias), entry); if (rc != 0) return rc; rc = fat32_dir_slot(v, alias_index + 1U + i, entry, 1, 1); if (rc != 0) return rc; }
     for (i = 0U; i < 32U; i++) entry[i] = 0U;
     for (i = 0U; i < 11U; i++) entry[i] = alias[i];
     entry[11] = attributes; entry[20] = (uint8_t)(first >> 24U); entry[21] = (uint8_t)(first >> 16U);
@@ -306,17 +322,27 @@ static int fat32_name_equal_folded(const char* left, const char* right) {
     return 0;
 }
 
+static int fat32_lfn_name_equal_folded(const uint16_t* units, const char* name) {
+    char decoded[OS_NAME_MAX];
+    return lfn_utf16_bmp_to_utf8(units, OS_NAME_MAX, decoded, OS_NAME_MAX) >= 0 &&
+           fat32_name_equal_folded(name, decoded);
+}
+
+static int fat32_lfn_query_valid(const char* name) {
+    uint16_t units[OS_NAME_MAX];
+    uint32_t length;
+    return lfn_utf8_to_utf16_bmp(name, units, OS_NAME_MAX, &length) == 0;
+}
+
 int fat32_unlink_file(const fat32_volume_t* v, const char* name) {
     uint8_t entry[32], short_name[11], lfn_sum = 0U, expected = 0U, valid = 0U;
-    char lfn[OS_NAME_MAX];
+    uint16_t lfn_units[OS_NAME_MAX];
     uint32_t lfn_start = 0U, i, j, limit;
     uint32_t first;
     int short_valid;
     if (!v || !name || !fat32_is_mounted(v) || !v->write_sector) return OS_FAT16_NOT_MOUNTED;
     short_valid = fat32_short_name(name, short_name) == 0;
-    for (i = 0U; i < OS_NAME_MAX && name[i]; i++)
-        if ((uint8_t)name[i] < 0x20U || (uint8_t)name[i] > 0x7fU || name[i] == '/' || name[i] == '\\') return OS_FAT16_BAD_PATH;
-    if (i == 0U || i == OS_NAME_MAX) return OS_FAT16_BAD_PATH;
+    if (!fat32_lfn_query_valid(name)) return OS_FAT16_BAD_PATH;
     limit = v->cluster_count * (uint32_t)v->sectors_per_cluster * 16U;
     for (i = 0U; i < limit; i++) {
         uint8_t ord;
@@ -326,19 +352,19 @@ int fat32_unlink_file(const fat32_volume_t* v, const char* name) {
             ord = entry[0] & 0x1fU;
             if (entry[0] & 0x40U) {
                 if (ord == 0U || ord * 13U >= OS_NAME_MAX) { valid = 0U; continue; }
-                for (j = 0U; j < OS_NAME_MAX; j++) lfn[j] = 0;
+                for (j = 0U; j < OS_NAME_MAX; j++) lfn_units[j] = 0U;
                 lfn_sum = entry[13]; expected = ord; lfn_start = i; valid = 1U;
             }
             if (!valid || ord == 0U || ord != expected || entry[13] != lfn_sum) { valid = 0U; continue; }
-            fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn, OS_NAME_MAX);
-            fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
-            fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn_units, OS_NAME_MAX);
+            fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn_units, OS_NAME_MAX);
+            fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn_units, OS_NAME_MAX);
             expected--; continue;
         }
         if (entry[11] & 0x08U) { valid = 0U; continue; }
         { int same = short_valid; for (j = 0U; j < 11U && same; j++) if (entry[j] != short_name[j]) same = 0;
         if ((!same) &&
-            !(valid && expected == 0U && fat32_lfn_checksum(entry) == lfn_sum && fat32_name_equal_folded(name, lfn))) { valid = 0U; continue; }
+            !(valid && expected == 0U && fat32_lfn_checksum(entry) == lfn_sum && fat32_lfn_name_equal_folded(lfn_units, name))) { valid = 0U; continue; }
         }
         first = ((uint32_t)entry[20] << 24U) | ((uint32_t)entry[21] << 16U) | le16(entry + 26U);
         for (j = valid && expected == 0U ? lfn_start : i; j <= i; j++) {
@@ -356,18 +382,13 @@ int fat32_unlink_file(const fat32_volume_t* v, const char* name) {
 int fat32_rename_lfn_file(const fat32_volume_t* v, const char* old_name,
                           const char* new_long_name, const char* new_short_name) {
     uint8_t entry[32], old_short[11], new_short[11], sum = 0U, expected = 0U, valid = 0U;
-    char lfn[OS_NAME_MAX];
+    uint16_t lfn_units[OS_NAME_MAX], units[OS_NAME_MAX];
     uint32_t start = 0U, i, j, limit, old_count = 0U, length = 0U, new_count;
     int old_short_valid;
     if (!v || !old_name || !new_long_name || !new_short_name || !fat32_is_mounted(v) || !v->write_sector) return OS_FAT16_NOT_MOUNTED;
     old_short_valid = fat32_short_name(old_name, old_short) == 0;
     if (fat32_short_name(new_short_name, new_short) != 0) return OS_FAT16_BAD_PATH;
-    while (new_long_name[length]) {
-        if (length >= OS_NAME_MAX - 1U || (uint8_t)new_long_name[length] < 0x20U ||
-            (uint8_t)new_long_name[length] > 0x7fU || new_long_name[length] == '/' || new_long_name[length] == '\\') return OS_FAT16_BAD_PATH;
-        length++;
-    }
-    if (length == 0U) return OS_FAT16_BAD_PATH;
+    if (lfn_utf8_to_utf16_bmp(new_long_name, units, OS_NAME_MAX, &length) != 0) return OS_FAT16_BAD_PATH;
     new_count = (length + 12U) / 13U;
     limit = v->cluster_count * (uint32_t)v->sectors_per_cluster * 16U;
     for (i = 0U; i < limit; i++) {
@@ -377,20 +398,20 @@ int fat32_rename_lfn_file(const fat32_volume_t* v, const char* old_name,
         if (entry[11] == 0x0fU) {
             ord = entry[0] & 0x1fU;
             if (entry[0] & 0x40U) { if (ord == 0U || ord * 13U >= OS_NAME_MAX) { valid = 0U; continue; }
-                for (j = 0U; j < OS_NAME_MAX; j++) lfn[j] = 0;
+                for (j = 0U; j < OS_NAME_MAX; j++) lfn_units[j] = 0U;
                 sum = entry[13]; expected = ord; start = i; old_count = ord; valid = 1U; }
             if (!valid || ord == 0U || ord != expected || entry[13] != sum) { valid = 0U; continue; }
-            fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn, OS_NAME_MAX);
-            fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
-            fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn_units, OS_NAME_MAX);
+            fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn_units, OS_NAME_MAX);
+            fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn_units, OS_NAME_MAX);
             expected--; continue;
         }
         if (entry[11] & 0x08U) { valid = 0U; continue; }
         { int same = old_short_valid; for (j = 0U; j < 11U && same; j++) if (entry[j] != old_short[j]) same = 0;
-          if (!same && !(valid && expected == 0U && fat32_lfn_checksum(entry) == sum && fat32_name_equal_folded(old_name, lfn))) { valid = 0U; continue; } }
+          if (!same && !(valid && expected == 0U && fat32_lfn_checksum(entry) == sum && fat32_lfn_name_equal_folded(lfn_units, old_name))) { valid = 0U; continue; } }
         if (!valid || expected != 0U || old_count != new_count) return OS_FAT16_BAD_PATH;
         for (j = 0U; j < new_count; j++) {
-            if (fat32_lfn_segment(new_long_name, length, new_count, new_count - j, fat32_lfn_checksum(new_short), entry) != 0 ||
+            if (fat32_lfn_segment(units, length, new_count, new_count - j, fat32_lfn_checksum(new_short), entry) != 0 ||
                 fat32_dir_slot(v, start + j, entry, 1, 0) != 0) return OS_FAT16_CORRUPT;
         }
         if (fat32_dir_slot(v, i, entry, 0, 0) != 0) return OS_FAT16_CORRUPT;
@@ -403,15 +424,13 @@ int fat32_rename_lfn_file(const fat32_volume_t* v, const char* old_name,
 
 int fat32_read_file(const fat32_volume_t* v, const char* name, uint8_t* buffer, uint32_t max) {
     uint8_t entry[32], short_name[11], lfn_sum = 0U, expected = 0U, valid = 0U;
-    char lfn[OS_NAME_MAX];
+    uint16_t lfn_units[OS_NAME_MAX];
     uint32_t i, j, limit, size, copied = 0U, cluster_bytes, guard = 0U;
     uint32_t cluster, next;
     int short_valid;
     if (!v || !name || !buffer || max == 0U || !fat32_is_mounted(v)) return OS_FAT16_BAD_PATH;
     short_valid = fat32_short_name(name, short_name) == 0;
-    for (i = 0U; i < OS_NAME_MAX && name[i]; i++)
-        if ((uint8_t)name[i] < 0x20U || (uint8_t)name[i] > 0x7fU || name[i] == '/' || name[i] == '\\') return OS_FAT16_BAD_PATH;
-    if (i == 0U || i == OS_NAME_MAX) return OS_FAT16_BAD_PATH;
+    if (!fat32_lfn_query_valid(name)) return OS_FAT16_BAD_PATH;
     limit = v->cluster_count * (uint32_t)v->sectors_per_cluster * 16U;
     for (i = 0U; i < limit; i++) {
         uint8_t ord;
@@ -421,18 +440,18 @@ int fat32_read_file(const fat32_volume_t* v, const char* name, uint8_t* buffer, 
             ord = entry[0] & 0x1fU;
             if (entry[0] & 0x40U) {
                 if (ord == 0U || ord * 13U >= OS_NAME_MAX) { valid = 0U; continue; }
-                for (j = 0U; j < OS_NAME_MAX; j++) lfn[j] = 0;
+                for (j = 0U; j < OS_NAME_MAX; j++) lfn_units[j] = 0U;
                 lfn_sum = entry[13]; expected = ord; valid = 1U;
             }
             if (!valid || ord == 0U || ord != expected || entry[13] != lfn_sum) { valid = 0U; continue; }
-            fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn, OS_NAME_MAX);
-            fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn, OS_NAME_MAX);
-            fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn, OS_NAME_MAX);
+            fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn_units, OS_NAME_MAX);
+            fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn_units, OS_NAME_MAX);
+            fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn_units, OS_NAME_MAX);
             expected--; continue;
         }
         if (entry[11] & 0x18U) { valid = 0U; continue; }
         { int match = short_valid; for (j = 0U; j < 11U && match; j++) if (entry[j] != short_name[j]) match = 0;
-          if (!match && !(valid && expected == 0U && fat32_lfn_checksum(entry) == lfn_sum && fat32_name_equal_folded(name, lfn))) { valid = 0U; continue; } }
+          if (!match && !(valid && expected == 0U && fat32_lfn_checksum(entry) == lfn_sum && fat32_lfn_name_equal_folded(lfn_units, name))) { valid = 0U; continue; } }
         size = le32(entry + 28U);
         if (size > max) return OS_FAT16_BUFFER_SMALL;
         cluster = ((uint32_t)entry[20] << 24U) | ((uint32_t)entry[21] << 16U) | le16(entry + 26U);
@@ -456,15 +475,26 @@ int fat32_read_file(const fat32_volume_t* v, const char* name, uint8_t* buffer, 
 }
 
 int fat32_list_root(const fat32_volume_t* v, os_fat16_dirent_t* out, uint32_t capacity) {
-    uint8_t entry[32], lfn_sum = 0U, expected = 0U, valid = 0U; char lfn[OS_NAME_MAX]; uint32_t count = 0U;
+    uint8_t entry[32], lfn_sum = 0U, expected = 0U, valid = 0U;
+    uint16_t lfn_units[OS_NAME_MAX];
+    uint32_t count = 0U;
     if (!v || !out || capacity == 0U || !fat32_is_mounted(v)) return OS_FAT16_BAD_PATH;
     for (uint32_t i = 0U; i < v->cluster_count * (uint32_t)v->sectors_per_cluster * 16U; i++) {
         if (fat32_dir_slot(v, i, entry, 0, 0) != 0 || entry[0] == 0U) break;
         if (entry[0] == 0xe5U) { valid = 0U; continue; }
-        if (entry[11] == 0x0fU) { uint8_t ord = entry[0] & 0x1fU; if (entry[0] & 0x40U) { if (ord == 0U || ord * 13U >= OS_NAME_MAX) { valid = 0U; continue; } for (uint32_t j = 0U; j < OS_NAME_MAX; j++) lfn[j] = 0; lfn_sum = entry[13]; expected = ord; valid = 1U; } if (!valid || ord == 0U || ord != expected || entry[13] != lfn_sum) { valid = 0U; continue; } fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn, OS_NAME_MAX); fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn, OS_NAME_MAX); fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn, OS_NAME_MAX); expected--; continue; }
+        if (entry[11] == 0x0fU) { uint8_t ord = entry[0] & 0x1fU; if (entry[0] & 0x40U) { if (ord == 0U || ord * 13U >= OS_NAME_MAX) { valid = 0U; continue; } for (uint32_t j = 0U; j < OS_NAME_MAX; j++) lfn_units[j] = 0U; lfn_sum = entry[13]; expected = ord; valid = 1U; } if (!valid || ord == 0U || ord != expected || entry[13] != lfn_sum) { valid = 0U; continue; } fat32_lfn_get(entry, 1U, (ord - 1U) * 13U, lfn_units, OS_NAME_MAX); fat32_lfn_get(entry, 14U, (ord - 1U) * 13U + 5U, lfn_units, OS_NAME_MAX); fat32_lfn_get(entry, 28U, (ord - 1U) * 13U + 11U, lfn_units, OS_NAME_MAX); expected--; continue; }
         if (entry[11] & 0x08U) { valid = 0U; continue; }
         if (count >= capacity) return (int)count;
-        if (valid && expected == 0U && fat32_lfn_checksum(entry) == lfn_sum) { for (uint32_t j = 0U; j < OS_NAME_MAX; j++) out[count].name[j] = lfn[j]; } else { uint32_t p = 0U; for (uint32_t j = 0U; j < 8U; j++) if (entry[j] != ' ') out[count].name[p++] = (char)entry[j]; if (entry[8] != ' ') { out[count].name[p++] = '.'; for (uint32_t j = 8U; j < 11U; j++) if (entry[j] != ' ') out[count].name[p++] = (char)entry[j]; } out[count].name[p] = 0; }
+        if (!(valid && expected == 0U && fat32_lfn_checksum(entry) == lfn_sum &&
+              lfn_utf16_bmp_to_utf8(lfn_units, OS_NAME_MAX, out[count].name, OS_NAME_MAX) >= 0)) {
+            uint32_t p = 0U;
+            for (uint32_t j = 0U; j < 8U; j++) if (entry[j] != ' ') out[count].name[p++] = (char)entry[j];
+            if (entry[8] != ' ') {
+                out[count].name[p++] = '.';
+                for (uint32_t j = 8U; j < 11U; j++) if (entry[j] != ' ') out[count].name[p++] = (char)entry[j];
+            }
+            out[count].name[p] = 0;
+        }
         out[count].size = le32(entry + 28U); out[count].flags = (entry[11] & 0x10U) ? OS_DIRENT_DIR : OS_DIRENT_FILE; count++; valid = 0U;
     }
     return (int)count;

--- a/kernel/fs/lfn_utf8.h
+++ b/kernel/fs/lfn_utf8.h
@@ -1,0 +1,70 @@
+#ifndef AIOS_LFN_UTF8_H
+#define AIOS_LFN_UTF8_H
+
+#include <stdint.h>
+
+/* Conversion LFN bornée : BMP uniquement, sans surrogates ni allocation. */
+static int lfn_utf8_to_utf16_bmp(const char* input, uint16_t* units,
+                                 uint32_t capacity, uint32_t* unit_count) {
+    uint32_t in = 0U, out = 0U;
+    uint32_t max_bytes;
+    if (!input || !units || !unit_count || capacity == 0U || capacity > 255U) return -1;
+    max_bytes = capacity * 3U;
+    while (in < max_bytes && input[in] != '\0') {
+        uint8_t a = (uint8_t)input[in++];
+        uint32_t codepoint;
+        if (a < 0x80U) {
+            codepoint = a;
+        } else if (a >= 0xC2U && a <= 0xDFU) {
+            uint8_t b;
+            if (in >= max_bytes || input[in] == '\0') return -1;
+            b = (uint8_t)input[in++];
+            if ((b & 0xC0U) != 0x80U) return -1;
+            codepoint = ((uint32_t)(a & 0x1FU) << 6U) | (uint32_t)(b & 0x3FU);
+        } else if (a >= 0xE0U && a <= 0xEFU) {
+            uint8_t b, c;
+            if (in + 1U >= max_bytes || input[in] == '\0' || input[in + 1U] == '\0') return -1;
+            b = (uint8_t)input[in++]; c = (uint8_t)input[in++];
+            if ((b & 0xC0U) != 0x80U || (c & 0xC0U) != 0x80U ||
+                (a == 0xE0U && b < 0xA0U) || (a == 0xEDU && b >= 0xA0U)) return -1;
+            codepoint = ((uint32_t)(a & 0x0FU) << 12U) |
+                        ((uint32_t)(b & 0x3FU) << 6U) | (uint32_t)(c & 0x3FU);
+        } else {
+            return -1;
+        }
+        if (codepoint < 0x20U || codepoint == '/' || codepoint == '\\' ||
+            codepoint == 0x7FU || out >= capacity) return -1;
+        units[out++] = (uint16_t)codepoint;
+    }
+    if (in == max_bytes && input[in] != '\0') return -1;
+    if (out == 0U) return -1;
+    *unit_count = out;
+    return 0;
+}
+
+static int lfn_utf16_bmp_to_utf8(const uint16_t* units, uint32_t unit_count,
+                                  char* output, uint32_t capacity) {
+    uint32_t in, out = 0U;
+    if (!units || !output || capacity == 0U) return -1;
+    for (in = 0U; in < unit_count && units[in] != 0U && units[in] != 0xFFFFU; in++) {
+        uint16_t unit = units[in];
+        if (unit >= 0xD800U && unit <= 0xDFFFU) return -1;
+        if (unit < 0x80U) {
+            if (out + 1U >= capacity) return -1;
+            output[out++] = (char)unit;
+        } else if (unit < 0x800U) {
+            if (out + 2U >= capacity) return -1;
+            output[out++] = (char)(0xC0U | (unit >> 6U));
+            output[out++] = (char)(0x80U | (unit & 0x3FU));
+        } else {
+            if (out + 3U >= capacity) return -1;
+            output[out++] = (char)(0xE0U | (unit >> 12U));
+            output[out++] = (char)(0x80U | ((unit >> 6U) & 0x3FU));
+            output[out++] = (char)(0x80U | (unit & 0x3FU));
+        }
+    }
+    output[out] = '\0';
+    return (int)out;
+}
+
+#endif

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -1075,6 +1075,27 @@ static void test_creates_lfn_file(void) {
     TEST_ASSERT_EQUAL('\0', entries[1].name[14]);
     TEST_ASSERT_EQUAL(3U, entries[1].size);
 }
+static void test_creates_utf8_lfn_file(void) {
+    fat16_volume_t volume;
+    uint8_t data[4] = {'U', 'T', 'F', '8'};
+    char readback[4] = {0};
+    os_fat16_dirent_t entries[4];
+    uint16_t first = 0U;
+    uint32_t root = 35U * 512U;
+    make_volume();
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, fat16_attach_writer(&volume, write_sector));
+    TEST_ASSERT_EQUAL(0, fat16_create_lfn_file(&volume, "caf\xC3\xA9-2026.txt", "CAFE26.TXT",
+                                               0x20U, data, sizeof(data), &first));
+    TEST_ASSERT_EQUAL(3U, first);
+    TEST_ASSERT_EQUAL(0xE9U, disk[root + 64U + 7U]);
+    TEST_ASSERT_EQUAL(0x00U, disk[root + 64U + 8U]);
+    TEST_ASSERT_EQUAL(4, fat16_read_file(&volume, "caf\xC3\xA9-2026.txt", readback, sizeof(readback)));
+    TEST_ASSERT_EQUAL_MEMORY(data, readback, sizeof(data));
+    TEST_ASSERT_EQUAL(2, fat16_list_root(&volume, entries, 4U));
+    TEST_ASSERT_EQUAL_STRING("caf\xC3\xA9-2026.txt", entries[1].name);
+}
+
 static void test_cursor_uses_attached_multisector_window(void) {
     fat16_volume_t volume;
     fat16_file_t file;
@@ -1170,6 +1191,7 @@ int main(void) {
     RUN_TEST(test_writes_only_with_explicit_writer);
     RUN_TEST(test_creates_persistent_file);
     RUN_TEST(test_creates_lfn_file);
+    RUN_TEST(test_creates_utf8_lfn_file);
     unity_print_results();
     unity_cleanup();
     return 0;

--- a/tests/unit/kernel/test_fat32.c
+++ b/tests/unit/kernel/test_fat32.c
@@ -1,5 +1,6 @@
 #include "../../framework/unity.h"
 #include "../../../kernel/fs/fat32.h"
+#include "../../../kernel/fs/lfn_utf8.h"
 
 static uint8_t disk[2048U * 512U];
 static int read_sector(uint32_t lba, void* buffer) {
@@ -57,6 +58,15 @@ void test_fat32_extend_full_root(void) {
     TEST_ASSERT_EQUAL(3U, disk[32U * 512U + 8U]); TEST_ASSERT_EQUAL(0U, disk[2034U * 512U]);
 }
 
+void test_lfn_utf8_bmp_conversion(void) {
+    uint16_t units[8]; char output[16]; uint32_t count = 0U;
+    TEST_ASSERT_EQUAL(0, lfn_utf8_to_utf16_bmp("caf\xC3\xA9", units, 8U, &count));
+    TEST_ASSERT_EQUAL(4U, count); TEST_ASSERT_EQUAL(0x00E9U, units[3]);
+    TEST_ASSERT_EQUAL(5, lfn_utf16_bmp_to_utf8(units, count, output, sizeof(output)));
+    TEST_ASSERT_EQUAL_STRING("caf\xC3\xA9", output);
+    TEST_ASSERT_TRUE(lfn_utf8_to_utf16_bmp("\xC0\x80", units, 8U, &count) < 0);
+}
+
 void test_fat32_lfn_encoding(void) {
     uint8_t alias[11] = {'C','H','A','T',' ',' ',' ',' ','B','I','N'}, entry[32];
     TEST_ASSERT_EQUAL(0, fat32_encode_lfn_entry("Session-2026", 0x41U, fat32_lfn_checksum(alias), entry));
@@ -64,6 +74,8 @@ void test_fat32_lfn_encoding(void) {
     TEST_ASSERT_EQUAL('S', entry[1]); TEST_ASSERT_EQUAL(0U, entry[2]); TEST_ASSERT_EQUAL('n', entry[16]); TEST_ASSERT_EQUAL(0U, entry[17]);
     TEST_ASSERT_EQUAL(0, fat32_encode_lfn_entry("abcdefghijklm", 1U, 0U, entry));
     TEST_ASSERT_EQUAL(OS_FAT16_BAD_PATH, fat32_encode_lfn_entry("abcdefghijklmn", 2U, 0U, entry));
+    TEST_ASSERT_EQUAL(0, fat32_encode_lfn_entry("caf\xC3\xA9", 0x41U, 0U, entry));
+    TEST_ASSERT_EQUAL(0xE9U, entry[7]); TEST_ASSERT_EQUAL(0x00U, entry[8]);
 }
 
 void test_fat32_lfn_file_and_list(void) {
@@ -94,4 +106,28 @@ void test_fat32_lfn_file_and_list(void) {
     TEST_ASSERT_EQUAL(OS_FAT16_NOT_FOUND, fat32_unlink_file(&volume, "Persistent-LLM-Session"));
 }
 
-int main(void) { unity_init(); RUN_TEST(test_fat32_mount_and_read_cluster); RUN_TEST(test_fat32_extend_full_root); RUN_TEST(test_fat32_lfn_encoding); RUN_TEST(test_fat32_lfn_file_and_list); unity_print_results(); unity_cleanup(); return 0; }
+void test_fat32_utf8_lfn_file_roundtrip(void) {
+    fat32_volume_t volume;
+    os_fat16_dirent_t entries[2];
+    uint8_t data[4] = {'U', 'T', 'F', '8'};
+    uint8_t readback[4] = {0U};
+    uint32_t first = 0U;
+    for (uint32_t i = 0U; i < sizeof(disk); i++) disk[i] = 0U;
+    disk[13] = 2U; put16(disk + 11U, 512U); put16(disk + 14U, 32U); disk[16] = 2U;
+    put32(disk + 32U, 200000U); put32(disk + 36U, 1000U); put32(disk + 44U, 2U); put16(disk + 510U, 0xaa55U);
+    disk[32U * 512U + 8U] = 0xf8U; disk[32U * 512U + 9U] = 0xffU;
+    disk[32U * 512U + 10U] = 0xffU; disk[32U * 512U + 11U] = 0x0fU;
+    TEST_ASSERT_EQUAL(0, fat32_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, fat32_attach_writer(&volume, write_sector));
+    TEST_ASSERT_EQUAL(0, fat32_create_lfn_file(&volume, "caf\xC3\xA9-2026.txt", "CAFE26.TXT",
+                                               0x20U, data, sizeof(data), &first));
+    TEST_ASSERT_EQUAL(3U, first);
+    TEST_ASSERT_EQUAL(0xE9U, disk[2032U * 512U + 32U + 7U]);
+    TEST_ASSERT_EQUAL(0x00U, disk[2032U * 512U + 32U + 8U]);
+    TEST_ASSERT_EQUAL(4, fat32_read_file(&volume, "caf\xC3\xA9-2026.txt", readback, sizeof(readback)));
+    TEST_ASSERT_EQUAL_MEMORY(data, readback, sizeof(data));
+    TEST_ASSERT_EQUAL(1, fat32_list_root(&volume, entries, 2U));
+    TEST_ASSERT_EQUAL_STRING("caf\xC3\xA9-2026.txt", entries[0].name);
+}
+
+int main(void) { unity_init(); RUN_TEST(test_fat32_mount_and_read_cluster); RUN_TEST(test_fat32_extend_full_root); RUN_TEST(test_lfn_utf8_bmp_conversion); RUN_TEST(test_fat32_lfn_encoding); RUN_TEST(test_fat32_lfn_file_and_list); RUN_TEST(test_fat32_utf8_lfn_file_roundtrip); unity_print_results(); unity_cleanup(); return 0; }


### PR DESCRIPTION
## Résumé

Implémente le support UTF-8 BMP des noms longs FAT16/FAT32, sans allocation dynamique.

- ajoute une conversion UTF-8 ↔ UTF-16LE BMP bornée ;
- sérialise les fragments LFN FAT16/FAT32 en unités UTF-16LE ;
- décode les LFN vers UTF-8 pour lecture, recherche et listage ;
- active la validation UTF-8 BMP des requêtes FAT32 ;
- couvre la création, lecture et le listage de `café-2026.txt` sur FAT16 et FAT32 ;
- documente AOS-1737…1744 et indexe le backlog.

## Garanties

Aucun appel à `kmalloc`, `malloc`, `calloc`, `realloc` ou `free` n’est introduit. Les surrogates, séquences UTF-8 invalides, surlongues et séparateurs de chemin sont rejetés.

## Validation locale

- `make -s test-all` : **460/460** réussis ;
- `make -s kernel-only` : noyau i386 compilé ;
- `git diff --check` : réussi.
