### PR TITLE
feat: add full Unicode support for FAT LFN

### DIFF
--- a/docs/aos1745_1752_fat_lfn_unicode_full.md
+++ b/docs/aos1745_1752_fat_lfn_unicode_full.md
@@ -1,0 +1,43 @@
+# AOS-1745…1752 — LFN FAT16/FAT32 Unicode hors BMP
+
+## Objet
+
+Ce macro-lot complète le support UTF-8 des noms longs FAT en acceptant les caractères Unicode hors BMP. Les caractères encodés UTF-8 sur quatre octets sont convertis en une **paire de surrogates UTF-16LE** dans les entrées LFN FAT16 et FAT32, puis restitués dans leur forme UTF-8 d’origine lors de la lecture et du listage.
+
+| Cas | Traitement |
+|---|---|
+| UTF-8 sur un à trois octets | Comportement compatible avec AOS-1737…1744 |
+| UTF-8 sur quatre octets `U+10000…U+10FFFF` | Sérialisation en paire UTF-16LE haute/basse |
+| Surrogate haut isolé | Rejet au décodage |
+| Surrogate bas isolé | Rejet au décodage |
+| UTF-8 surlong, tronqué ou au-delà de `U+10FFFF` | Rejet à l’encodage |
+
+## Conception
+
+`lfn_utf8_to_utf16_bmp()` conserve son contrat statique et borné, mais accepte désormais les séquences UTF-8 de quatre octets. Le point de code est décalé de `0x10000`, puis séparé en un surrogate haut `0xD800…0xDBFF` et un surrogate bas `0xDC00…0xDFFF`. La capacité est toujours exprimée en **unités UTF-16**, ce qui garantit qu’une paire n’est jamais écrite partiellement.
+
+La conversion inverse contrôle qu’un surrogate haut est suivi d’un surrogate bas valide avant de publier les quatre octets UTF-8. Elle refuse également un surrogate bas isolé. Les entrées LFN existantes conservent leurs fragments de treize unités UTF-16LE : aucun changement n’est requis dans l’ordre FAT, le checksum 8.3 ou les interfaces FAT16/FAT32.
+
+> Aucun appel à `kmalloc`, `malloc`, `calloc`, `realloc` ou `free` n’est introduit. Tous les tableaux restent bornés et appartiennent à l’appelant ou à la pile.
+
+## Validation
+
+Les tests introduisent le nom `rocket-😀.txt`, dont `U+1F600` est représenté par `D83D DE00` en UTF-16LE. Les scénarios FAT16 et FAT32 vérifient la sérialisation des quatre octets de la paire, la lecture de contenu par le nom UTF-8 et le nom restitué par le listage. Le test de conversion vérifie en outre le round-trip `A😀` et le refus d’un surrogate haut isolé.
+
+| Vérification | Résultat |
+|---|---|
+| UTF-8 `F0 9F 98 80` vers `D83D DE00` | Réussie |
+| Décodage de la paire vers UTF-8 | Réussi |
+| Création, lecture et listage FAT16 `rocket-😀.txt` | Réussis |
+| Création, lecture et listage FAT32 `rocket-😀.txt` | Réussis |
+| Absence d’allocation dynamique dans le socle | Confirmée |
+| `make -s test-all` | **462/462 tests réussis** |
+
+## Limites
+
+Le traitement reste volontairement limité aux noms LFN de taille bornée par `OS_NAME_MAX` et aux règles de chemin existantes. La comparaison de casse reste ASCII uniquement ; aucune normalisation Unicode, aucune transformation de casse linguistique et aucune allocation dynamique ne sont ajoutées.
+
+## Références
+
+[1] [Unicode Consortium — UTF-8 et UTF-16](https://www.unicode.org/standard/standard.html)  
+[2] [Microsoft — Long File Names on FAT volumes](https://download.microsoft.com/download/1/2/7/127443f9-8bb5-40a6-8d72-a3c6e5bd12d5/FAT32_WhitePaper.pdf)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -108,6 +108,7 @@
 - [x] AOS-1721…1728 : montage VFS protégé `fat32/` en lecture/stat/listage, sans mutation ni allocation dynamique — [aos1721_1728_vfs_fat32_readonly_mount.md](aos1721_1728_vfs_fat32_readonly_mount.md)
 - [x] AOS-1729…1736 : lecture FAT32 par alias ou LFN ASCII validé, ordinaux/checksum contrôlés et parcours de chaîne borné — [aos1729_1736_fat32_lfn_read.md](aos1729_1736_fat32_lfn_read.md)
 - [x] AOS-1737…1744 : LFN FAT16/FAT32 UTF-8 BMP, sérialisation UTF-16LE, recherche/lecture/listage Unicode et zéro allocation dynamique — [aos1737_1744_fat_lfn_utf8.md](aos1737_1744_fat_lfn_utf8.md)
+- [x] AOS-1745…1752 : LFN FAT16/FAT32 Unicode hors BMP par paires de surrogates UTF-16LE, lecture/listage UTF-8 complet et zéro allocation dynamique — [aos1745_1752_fat_lfn_unicode_full.md](aos1745_1752_fat_lfn_unicode_full.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/fs/lfn_utf8.h
+++ b/kernel/fs/lfn_utf8.h
@@ -3,13 +3,13 @@
 
 #include <stdint.h>
 
-/* Conversion LFN bornée : BMP uniquement, sans surrogates ni allocation. */
+/* Conversion LFN bornée UTF-8/UTF-16LE, y compris paires de surrogates. */
 static int lfn_utf8_to_utf16_bmp(const char* input, uint16_t* units,
                                  uint32_t capacity, uint32_t* unit_count) {
     uint32_t in = 0U, out = 0U;
     uint32_t max_bytes;
     if (!input || !units || !unit_count || capacity == 0U || capacity > 255U) return -1;
-    max_bytes = capacity * 3U;
+    max_bytes = capacity * 4U;
     while (in < max_bytes && input[in] != '\0') {
         uint8_t a = (uint8_t)input[in++];
         uint32_t codepoint;
@@ -29,12 +29,25 @@ static int lfn_utf8_to_utf16_bmp(const char* input, uint16_t* units,
                 (a == 0xE0U && b < 0xA0U) || (a == 0xEDU && b >= 0xA0U)) return -1;
             codepoint = ((uint32_t)(a & 0x0FU) << 12U) |
                         ((uint32_t)(b & 0x3FU) << 6U) | (uint32_t)(c & 0x3FU);
+        } else if (a >= 0xF0U && a <= 0xF4U) {
+            uint8_t b, c, d;
+            if (in + 2U >= max_bytes || input[in] == '\0' || input[in + 1U] == '\0' || input[in + 2U] == '\0') return -1;
+            b = (uint8_t)input[in++]; c = (uint8_t)input[in++]; d = (uint8_t)input[in++];
+            if ((b & 0xC0U) != 0x80U || (c & 0xC0U) != 0x80U || (d & 0xC0U) != 0x80U ||
+                (a == 0xF0U && b < 0x90U) || (a == 0xF4U && b > 0x8FU)) return -1;
+            codepoint = ((uint32_t)(a & 0x07U) << 18U) | ((uint32_t)(b & 0x3FU) << 12U) |
+                        ((uint32_t)(c & 0x3FU) << 6U) | (uint32_t)(d & 0x3FU);
+        } else return -1;
+        if (codepoint < 0x20U || codepoint == '/' || codepoint == '\\' || codepoint == 0x7FU) return -1;
+        if (codepoint >= 0x10000U) {
+            uint32_t value = codepoint - 0x10000U;
+            if (out + 1U >= capacity) return -1;
+            units[out++] = (uint16_t)(0xD800U | (value >> 10U));
+            units[out++] = (uint16_t)(0xDC00U | (value & 0x3FFU));
         } else {
-            return -1;
+            if (out >= capacity) return -1;
+            units[out++] = (uint16_t)codepoint;
         }
-        if (codepoint < 0x20U || codepoint == '/' || codepoint == '\\' ||
-            codepoint == 0x7FU || out >= capacity) return -1;
-        units[out++] = (uint16_t)codepoint;
     }
     if (in == max_bytes && input[in] != '\0') return -1;
     if (out == 0U) return -1;
@@ -48,8 +61,19 @@ static int lfn_utf16_bmp_to_utf8(const uint16_t* units, uint32_t unit_count,
     if (!units || !output || capacity == 0U) return -1;
     for (in = 0U; in < unit_count && units[in] != 0U && units[in] != 0xFFFFU; in++) {
         uint16_t unit = units[in];
-        if (unit >= 0xD800U && unit <= 0xDFFFU) return -1;
-        if (unit < 0x80U) {
+        if (unit >= 0xD800U && unit <= 0xDBFFU) {
+            uint16_t low;
+            uint32_t codepoint;
+            if (in + 1U >= unit_count || units[in + 1U] < 0xDC00U || units[in + 1U] > 0xDFFFU) return -1;
+            low = units[++in];
+            codepoint = 0x10000U + (((uint32_t)(unit - 0xD800U) << 10U) | (uint32_t)(low - 0xDC00U));
+            if (out + 4U >= capacity) return -1;
+            output[out++] = (char)(0xF0U | (codepoint >> 18U));
+            output[out++] = (char)(0x80U | ((codepoint >> 12U) & 0x3FU));
+            output[out++] = (char)(0x80U | ((codepoint >> 6U) & 0x3FU));
+            output[out++] = (char)(0x80U | (codepoint & 0x3FU));
+        } else if (unit >= 0xDC00U && unit <= 0xDFFFU) return -1;
+        else if (unit < 0x80U) {
             if (out + 1U >= capacity) return -1;
             output[out++] = (char)unit;
         } else if (unit < 0x800U) {

--- a/tests/unit/kernel/test_fat16.c
+++ b/tests/unit/kernel/test_fat16.c
@@ -1096,6 +1096,29 @@ static void test_creates_utf8_lfn_file(void) {
     TEST_ASSERT_EQUAL_STRING("caf\xC3\xA9-2026.txt", entries[1].name);
 }
 
+static void test_creates_non_bmp_lfn_file(void) {
+    fat16_volume_t volume;
+    uint8_t data[5] = {'A', 'S', 'T', 'R', 'A'};
+    char readback[5] = {0};
+    os_fat16_dirent_t entries[4];
+    uint16_t first = 0U;
+    uint32_t root = 35U * 512U;
+    make_volume();
+    TEST_ASSERT_EQUAL(0, fat16_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, fat16_attach_writer(&volume, write_sector));
+    TEST_ASSERT_EQUAL(0, fat16_create_lfn_file(&volume, "rocket-\xF0\x9F\x98\x80.txt", "ROCKT1.TXT",
+                                               0x20U, data, sizeof(data), &first));
+    TEST_ASSERT_EQUAL(3U, first);
+    TEST_ASSERT_EQUAL(0x3DU, disk[root + 64U + 18U]);
+    TEST_ASSERT_EQUAL(0xD8U, disk[root + 64U + 19U]);
+    TEST_ASSERT_EQUAL(0x00U, disk[root + 64U + 20U]);
+    TEST_ASSERT_EQUAL(0xDEU, disk[root + 64U + 21U]);
+    TEST_ASSERT_EQUAL(5, fat16_read_file(&volume, "rocket-\xF0\x9F\x98\x80.txt", readback, sizeof(readback)));
+    TEST_ASSERT_EQUAL_MEMORY(data, readback, sizeof(data));
+    TEST_ASSERT_EQUAL(2, fat16_list_root(&volume, entries, 4U));
+    TEST_ASSERT_EQUAL_STRING("rocket-\xF0\x9F\x98\x80.txt", entries[1].name);
+}
+
 static void test_cursor_uses_attached_multisector_window(void) {
     fat16_volume_t volume;
     fat16_file_t file;
@@ -1192,6 +1215,7 @@ int main(void) {
     RUN_TEST(test_creates_persistent_file);
     RUN_TEST(test_creates_lfn_file);
     RUN_TEST(test_creates_utf8_lfn_file);
+    RUN_TEST(test_creates_non_bmp_lfn_file);
     unity_print_results();
     unity_cleanup();
     return 0;

--- a/tests/unit/kernel/test_fat32.c
+++ b/tests/unit/kernel/test_fat32.c
@@ -64,6 +64,12 @@ void test_lfn_utf8_bmp_conversion(void) {
     TEST_ASSERT_EQUAL(4U, count); TEST_ASSERT_EQUAL(0x00E9U, units[3]);
     TEST_ASSERT_EQUAL(5, lfn_utf16_bmp_to_utf8(units, count, output, sizeof(output)));
     TEST_ASSERT_EQUAL_STRING("caf\xC3\xA9", output);
+    TEST_ASSERT_EQUAL(0, lfn_utf8_to_utf16_bmp("A\xF0\x9F\x98\x80", units, 8U, &count));
+    TEST_ASSERT_EQUAL(3U, count); TEST_ASSERT_EQUAL(0xD83DU, units[1]); TEST_ASSERT_EQUAL(0xDE00U, units[2]);
+    TEST_ASSERT_EQUAL(5, lfn_utf16_bmp_to_utf8(units, count, output, sizeof(output)));
+    TEST_ASSERT_EQUAL_STRING("A\xF0\x9F\x98\x80", output);
+    units[0] = 0xD83DU; units[1] = 0U;
+    TEST_ASSERT_TRUE(lfn_utf16_bmp_to_utf8(units, 2U, output, sizeof(output)) < 0);
     TEST_ASSERT_TRUE(lfn_utf8_to_utf16_bmp("\xC0\x80", units, 8U, &count) < 0);
 }
 
@@ -130,4 +136,30 @@ void test_fat32_utf8_lfn_file_roundtrip(void) {
     TEST_ASSERT_EQUAL_STRING("caf\xC3\xA9-2026.txt", entries[0].name);
 }
 
-int main(void) { unity_init(); RUN_TEST(test_fat32_mount_and_read_cluster); RUN_TEST(test_fat32_extend_full_root); RUN_TEST(test_lfn_utf8_bmp_conversion); RUN_TEST(test_fat32_lfn_encoding); RUN_TEST(test_fat32_lfn_file_and_list); RUN_TEST(test_fat32_utf8_lfn_file_roundtrip); unity_print_results(); unity_cleanup(); return 0; }
+void test_fat32_utf8_lfn_non_bmp_roundtrip(void) {
+    fat32_volume_t volume;
+    os_fat16_dirent_t entries[2];
+    uint8_t data[5] = {'A', 'S', 'T', 'R', 'A'};
+    uint8_t readback[5] = {0U};
+    uint32_t first = 0U;
+    for (uint32_t i = 0U; i < sizeof(disk); i++) disk[i] = 0U;
+    disk[13] = 2U; put16(disk + 11U, 512U); put16(disk + 14U, 32U); disk[16] = 2U;
+    put32(disk + 32U, 200000U); put32(disk + 36U, 1000U); put32(disk + 44U, 2U); put16(disk + 510U, 0xaa55U);
+    disk[32U * 512U + 8U] = 0xf8U; disk[32U * 512U + 9U] = 0xffU;
+    disk[32U * 512U + 10U] = 0xffU; disk[32U * 512U + 11U] = 0x0fU;
+    TEST_ASSERT_EQUAL(0, fat32_mount(&volume, read_sector, 0U));
+    TEST_ASSERT_EQUAL(0, fat32_attach_writer(&volume, write_sector));
+    TEST_ASSERT_EQUAL(0, fat32_create_lfn_file(&volume, "rocket-\xF0\x9F\x98\x80.txt", "ROCKT1.TXT",
+                                               0x20U, data, sizeof(data), &first));
+    TEST_ASSERT_EQUAL(3U, first);
+    TEST_ASSERT_EQUAL(0x3DU, disk[2032U * 512U + 32U + 18U]);
+    TEST_ASSERT_EQUAL(0xD8U, disk[2032U * 512U + 32U + 19U]);
+    TEST_ASSERT_EQUAL(0x00U, disk[2032U * 512U + 32U + 20U]);
+    TEST_ASSERT_EQUAL(0xDEU, disk[2032U * 512U + 32U + 21U]);
+    TEST_ASSERT_EQUAL(5, fat32_read_file(&volume, "rocket-\xF0\x9F\x98\x80.txt", readback, sizeof(readback)));
+    TEST_ASSERT_EQUAL_MEMORY(data, readback, sizeof(data));
+    TEST_ASSERT_EQUAL(1, fat32_list_root(&volume, entries, 2U));
+    TEST_ASSERT_EQUAL_STRING("rocket-\xF0\x9F\x98\x80.txt", entries[0].name);
+}
+
+int main(void) { unity_init(); RUN_TEST(test_fat32_mount_and_read_cluster); RUN_TEST(test_fat32_extend_full_root); RUN_TEST(test_lfn_utf8_bmp_conversion); RUN_TEST(test_fat32_lfn_encoding); RUN_TEST(test_fat32_lfn_file_and_list); RUN_TEST(test_fat32_utf8_lfn_file_roundtrip); RUN_TEST(test_fat32_utf8_lfn_non_bmp_roundtrip); unity_print_results(); unity_cleanup(); return 0; }


### PR DESCRIPTION
## Résumé

Étend les LFN FAT16/FAT32 aux caractères Unicode hors BMP.

- décode l’UTF-8 à quatre octets ;
- sérialise les paires de surrogates UTF-16LE dans les entrées LFN ;
- reconstruit l’UTF-8 à quatre octets lors de la lecture et du listage ;
- rejette les surrogates isolés, séquences surlongues et entrées invalides ;
- ajoute les scénarios FAT16/FAT32 `rocket-😀.txt` ;
- documente AOS-1745…1752.

## Validation

- `make -s test-all` : **462/462** réussis ;
- `make -s kernel-only` : compilé ;
- aucune allocation dynamique dans le socle Unicode LFN ;
- `git diff --check` : réussi.
