### PR TITLE
feat: isolate user VMM tables and rollback task creation

### DIFF
--- a/docs/aos1881_1888_user_vmm_isolation.md
+++ b/docs/aos1881_1888_user_vmm_isolation.md
@@ -1,0 +1,36 @@
+# AOS-1881…1888 — Isolation VMM utilisateur et rollback de création Ring 3
+
+## Objet
+
+Ce macro-lot corrige le prérequis de propriété mémoire qui empêchait toute libération sûre d’un espace utilisateur. Un répertoire créé pour une tâche Ring 3 héritait des pointeurs de tables du noyau ; un mapping ELF ou de pile utilisateur pouvait alors modifier une table partagée. La destruction ultérieure de cette table aurait risqué d’endommager les mappings noyau.
+
+Le VMM privatise désormais la table concernée avant tout mapping marqué `PAGE_USER`. La copie conserve les entrées noyau visibles par la tâche, tandis que l’entrée utilisateur est écrite uniquement dans la table privée. Un bitmap compact de 32 mots identifie les tables possédées par le répertoire utilisateur.
+
+| Élément | Garantie |
+|---|---|
+| Mapping `PAGE_USER` | Clonage préalable de la table, puis écriture isolée. |
+| Tables noyau héritées | Conservées et jamais libérées par le destructeur utilisateur. |
+| Pages ELF et pile | Restituées au PMM uniquement si marquées présentes et utilisateur. |
+| Répertoire actif ou noyau | Refusé par `vmm_destroy_user_directory()`. |
+
+## Rollback transactionnel
+
+`vmm_map_page_in_directory()` retourne désormais un statut. Le chargeur ELF restitue la page physique immédiatement si son mapping échoue ; l’appelant restaure ensuite l’espace noyau avant de détruire le répertoire utilisateur partiellement construit. L’allocation de pile utilisateur applique le même contrat, et les échecs d’allocation de structure de tâche ou de pile noyau déclenchent aussi la destruction du répertoire déjà créé.
+
+> Le nettoyage ne s’exécute qu’après le retour explicite au répertoire précédent. Il ne peut donc pas détruire l’espace d’adressage encore utilisé par le processeur.
+
+Les tables privées sont elles-mêmes fournies par le PMM et restituées avec `pmm_free_page()`. Le chemin ajouté ne crée aucune nouvelle allocation de tas ; le bitmap de propriété n’ajoute que 128 octets par répertoire VMM.
+
+## Validation
+
+La compilation noyau et la suite noyau complète ont été exécutées après la mise en place des tables privées, puis après leur migration du tas vers le PMM. Les 38 suites unitaires noyau restent vertes, y compris la suite de tâches qui exerce les allocations de masse de sa fixture.
+
+| Commande | Résultat |
+|---|---:|
+| `make -s kernel-only` | Réussi |
+| `make -s test-kernel` | 38/38 suites réussies |
+| Vérification de tables privées PMM | Réussi à la compilation et aux tests de tâches |
+
+## Références
+
+[1] [Intel 64 and IA-32 Architectures Software Developer’s Manual — Paging](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -125,6 +125,7 @@
 - [x] AOS-1857…1864 : parsing strict de `close_notify` TLS distant, validation sans mutation et zéro allocation dynamique — [aos1857_1864_tls_peer_close_notify.md](aos1857_1864_tls_peer_close_notify.md)
 - [x] AOS-1865…1872 : détection de `close_notify` TLS distant dans les pollers HTTP/SSE, ACK cohérent, transition LLM vers `RESPONSE_READY` et zéro allocation dynamique — [aos1865_1872_tls_peer_close_poller.md](aos1865_1872_tls_peer_close_poller.md)
 - [x] AOS-1873…1880 : réponse TLS `close_notify` best-effort après fermeture distante, transition SSE terminale et zéro allocation dynamique — [aos1873_1880_tls_peer_close_reply.md](aos1873_1880_tls_peer_close_reply.md)
+- [x] AOS-1881…1888 : isolation des tables VMM utilisateur, rollback de création Ring 3 et restitution PMM sans destruction des mappings noyau partagés — [aos1881_1888_user_vmm_isolation.md](aos1881_1888_user_vmm_isolation.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/elf.c
+++ b/kernel/elf.c
@@ -67,7 +67,11 @@ uint32_t elf_load(uint8_t* file_data, vmm_directory_t* vmm_dir) {
                     // TODO: Here we should unmap all previously mapped pages
                     return 0;
                 }
-                vmm_map_page_in_directory(vmm_dir, phys_page, (void*)page_addr, page_flags);
+                if (vmm_map_page_in_directory(vmm_dir, phys_page, (void*)page_addr, page_flags) != 0) {
+                    pmm_free_page(phys_page);
+                    print_string_serial("ERROR: Could not map ELF segment page.\n");
+                    return 0;
+                }
             }
 
             // Copy data from file (filesz)

--- a/kernel/mem/vmm.c
+++ b/kernel/mem/vmm.c
@@ -105,15 +105,58 @@ page_t *vmm_get_page(uint32_t address, int make, vmm_directory_t *dir) {
     }
 }
 
-// Mappe une page physique à une adresse virtuelle dans un répertoire spécifique
-void vmm_map_page_in_directory(vmm_directory_t *dir, void *physaddr, void *virtualaddr, uint32_t flags) {
-    page_t *page = vmm_get_page((uint32_t)virtualaddr, 1, dir);
-    if (!page) return;
+static uint8_t vmm_table_is_private(const vmm_directory_t* dir, uint32_t table_index) {
+    return (uint8_t)((dir->private_table_mask[table_index / 32U] >> (table_index % 32U)) & 1U);
+}
 
+static void vmm_table_mark_private(vmm_directory_t* dir, uint32_t table_index) {
+    dir->private_table_mask[table_index / 32U] |= (uint32_t)1U << (table_index % 32U);
+}
+
+static int vmm_ensure_private_user_table(vmm_directory_t *dir, uint32_t table_index) {
+    page_table_t* private_table;
+    if (!dir || table_index >= ENTRIES_PER_TABLE) return -1;
+    if (vmm_table_is_private(dir, table_index)) return 0;
+    private_table = (page_table_t*)pmm_alloc_page();
+    if (!private_table) return -2;
+    if (dir->tables[table_index]) memcpy(private_table, dir->tables[table_index], sizeof(page_table_t));
+    else memset(private_table, 0, sizeof(page_table_t));
+    dir->tables[table_index] = private_table;
+    dir->physical_dir->tablesPhysical[table_index] = (uint32_t)private_table | 0x7U;
+    vmm_table_mark_private(dir, table_index);
+    return 0;
+}
+
+/* Mappe une page physique à une adresse virtuelle dans un répertoire spécifique. */
+int vmm_map_page_in_directory(vmm_directory_t *dir, void *physaddr, void *virtualaddr, uint32_t flags) {
+    uint32_t table_index; page_t *page;
+    if (!dir || !physaddr || !virtualaddr) return -1;
+    table_index = ((uint32_t)virtualaddr / PAGE_SIZE) / ENTRIES_PER_TABLE;
+    if ((flags & PAGE_USER) && dir != kernel_directory && vmm_ensure_private_user_table(dir, table_index) != 0) return -2;
+    page = vmm_get_page((uint32_t)virtualaddr, 1, dir);
+    if (!page) return -3;
     page->present = (flags & PAGE_PRESENT) ? 1 : 0;
     page->rw = (flags & PAGE_WRITE) ? 1 : 0;
     page->user = (flags & PAGE_USER) ? 1 : 0;
-    page->frame = (uint32_t)physaddr / 0x1000;
-
+    page->frame = (uint32_t)physaddr / PAGE_SIZE;
     asm volatile ("invlpg (%0)" :: "r" (virtualaddr) : "memory");
+    return 0;
+}
+
+int vmm_destroy_user_directory(vmm_directory_t *dir) {
+    uint32_t table_index, page_index;
+    if (!dir || dir == kernel_directory || dir == current_directory) return -1;
+    for (table_index = 0U; table_index < ENTRIES_PER_TABLE; table_index++) {
+        page_table_t* table = dir->tables[table_index];
+        if (!vmm_table_is_private(dir, table_index) || !table) continue;
+        for (page_index = 0U; page_index < ENTRIES_PER_TABLE; page_index++) {
+            page_t* page = &table->pages[page_index];
+            if (page->present && page->user) pmm_free_page((void*)(page->frame * PAGE_SIZE));
+        }
+        pmm_free_page(table);
+    }
+    kfree(dir->physical_dir);
+    kfree(dir->tables);
+    kfree(dir);
+    return 0;
 }

--- a/kernel/mem/vmm.h
+++ b/kernel/mem/vmm.h
@@ -38,13 +38,18 @@ typedef struct {
     page_table_t** tables;
     page_directory_t* physical_dir;
     uint32_t physical_addr;
+    /* Bitmap des tables clonées pour un espace utilisateur ; les tables noyau restent partagées. */
+    uint32_t private_table_mask[ENTRIES_PER_TABLE / 32U];
 } vmm_directory_t;
 
 // Fonctions publiques
 void vmm_init();
 void vmm_switch_page_directory(uint32_t physical_addr);
 page_t *vmm_get_page(uint32_t address, int make, vmm_directory_t *dir);
-void vmm_map_page_in_directory(vmm_directory_t *dir, void *physaddr, void *virtualaddr, uint32_t flags);
+/* Retourne 0 après mapping ; négatif si une table privée ne peut pas être obtenue. */
+int vmm_map_page_in_directory(vmm_directory_t *dir, void *physaddr, void *virtualaddr, uint32_t flags);
+/* Libère uniquement un répertoire utilisateur inactif et ses pages marquées utilisateur. */
+int vmm_destroy_user_directory(vmm_directory_t *dir);
 
 // Variables globales
 extern vmm_directory_t *kernel_directory;

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -276,11 +276,15 @@ task_t* create_task_from_initrd_file(const char* filename) {
 
     if (entry_point == 0 || user_stack_top == 0) {
         print_string_serial("ERREUR: Chargement ELF ou allocation de pile a echoue\n");
-        // TODO: Liberer vmm_dir et toutes les pages allouées
+        (void)vmm_destroy_user_directory(vmm_dir);
         return NULL;
     }
 
     task_t* new_task = (task_t*)kmalloc(sizeof(task_t));
+    if (!new_task) {
+        (void)vmm_destroy_user_directory(vmm_dir);
+        return NULL;
+    }
     new_task->id = next_task_id++;
     new_task->state = TASK_READY;
     new_task->type = TASK_TYPE_USER;
@@ -333,7 +337,13 @@ task_t* create_task_from_initrd_file(const char* filename) {
     }
 
     // Allouer une pile noyau pour cette tâche
-    new_task->kernel_stack_p = (uint32_t)kmalloc(4096) + 4096;
+    new_task->kernel_stack_p = (uint32_t)kmalloc(4096);
+    if (!new_task->kernel_stack_p) {
+        kfree(new_task);
+        (void)vmm_destroy_user_directory(vmm_dir);
+        return NULL;
+    }
+    new_task->kernel_stack_p += 4096U;
 
     setup_initial_user_context(new_task, entry_point, user_stack_top);
     add_task_to_queue(new_task);
@@ -425,7 +435,10 @@ uint32_t allocate_user_stack(vmm_directory_t* vmm_dir) {
             // In a real scenario, we should free previously allocated pages
             return 0;
         }
-        vmm_map_page_in_directory(vmm_dir, stack_phys_page, (void*)addr, PAGE_PRESENT | PAGE_WRITE | PAGE_USER);
+        if (vmm_map_page_in_directory(vmm_dir, stack_phys_page, (void*)addr, PAGE_PRESENT | PAGE_WRITE | PAGE_USER) != 0) {
+            pmm_free_page(stack_phys_page);
+            return 0;
+        }
     }
 
     print_string_serial("User stack allocated at 0x");


### PR DESCRIPTION
## Résumé

- privatise les tables touchées par les mappings `PAGE_USER` ;
- empêche la destruction des mappings noyau partagés ;
- ajoute la destruction VMM d’un répertoire utilisateur inactif et les rollbacks de création Ring 3 ;
- restitue les tables privées et pages utilisateur au PMM ;
- documente AOS-1881…1888.

## Validation

- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` : réussi ;
- `git diff --check` : réussi ;
- aucune nouvelle allocation de tas dans le chemin de tables privées.