### PR TITLE
feat: reap terminated user tasks after context switch

### DIFF
--- a/docs/aos1889_1896_task_deferred_reaper.md
+++ b/docs/aos1889_1896_task_deferred_reaper.md
@@ -1,0 +1,35 @@
+# AOS-1889…1896 — Réclamation différée des tâches Ring 3 terminées
+
+## Objet
+
+Ce macro-lot complète l’isolation VMM précédente par une réclamation différée des ressources d’une tâche Ring 3 terminée. Une tâche ne peut pas libérer sa propre pile noyau ni son espace d’adressage pendant que le processeur l’utilise. Le scheduler la détache donc immédiatement de la file circulaire, sélectionne une remplaçante, puis conserve son pointeur dans un emplacement de réclamation différée.
+
+La libération est exécutée au prochain passage dans l’ordonnanceur, après qu’une autre tâche et son répertoire VMM sont devenus actifs.
+
+| Moment | Action |
+|---|---|
+| Détection de `TASK_TERMINATED` | La tâche est détachée de la file ; son état CPU n’est pas sauvegardé. |
+| Bascule | Le scheduler active la tâche de remplacement, sa pile noyau et son répertoire VMM. |
+| Passage de scheduler suivant | Le reaper libère le VMM utilisateur inactif, la pile noyau et la structure de tâche. |
+
+## Invariants de sûreté
+
+Le reaper ignore les tâches noyau et ne détruit un répertoire utilisateur que par `vmm_destroy_user_directory()`, lequel refuse le répertoire noyau et tout répertoire encore actif. Les ressources ne sont donc jamais libérées depuis la pile de la tâche concernée, ni depuis le VMM qu’elle exécute encore.
+
+> Le détachement de la file et la libération mémoire sont volontairement séparés par un changement de contexte effectif.
+
+Aucune allocation dynamique n’est ajoutée au reaper : il ne fait que restituer les ressources déjà possédées par la tâche. Les allocations historiques de création de tâche restent inchangées.
+
+## Validation
+
+La suite complète a été exécutée après l’intégration du reaper. Les modules tâches, VMM, PMM, systèmes de fichiers, GPT-2 et réseau restent couverts par le même gate de non-régression.
+
+| Commande | Résultat |
+|---|---:|
+| `make -s test-all` | 479/479 tests réussis |
+| `make -s kernel-only` | Réussi |
+| `git diff --check` | Réussi |
+
+## Référence
+
+[1] [Intel 64 and IA-32 Architectures Software Developer’s Manual — Task Switching and Paging](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -126,6 +126,7 @@
 - [x] AOS-1865…1872 : détection de `close_notify` TLS distant dans les pollers HTTP/SSE, ACK cohérent, transition LLM vers `RESPONSE_READY` et zéro allocation dynamique — [aos1865_1872_tls_peer_close_poller.md](aos1865_1872_tls_peer_close_poller.md)
 - [x] AOS-1873…1880 : réponse TLS `close_notify` best-effort après fermeture distante, transition SSE terminale et zéro allocation dynamique — [aos1873_1880_tls_peer_close_reply.md](aos1873_1880_tls_peer_close_reply.md)
 - [x] AOS-1881…1888 : isolation des tables VMM utilisateur, rollback de création Ring 3 et restitution PMM sans destruction des mappings noyau partagés — [aos1881_1888_user_vmm_isolation.md](aos1881_1888_user_vmm_isolation.md)
+- [x] AOS-1889…1896 : réclamation différée des tâches Ring 3 terminées, destruction VMM hors pile active et libération de pile noyau sans allocation dynamique — [aos1889_1896_task_deferred_reaper.md](aos1889_1896_task_deferred_reaper.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -15,6 +15,8 @@ task_t* current_task = NULL;
 task_t* task_queue = NULL;
 int next_task_id = 0;
 volatile int g_reschedule_needed = 0;
+/* Tâche détachée à libérer lors d’un passage ultérieur, hors de sa pile et de son VMM. */
+static task_t* deferred_reap_task = NULL;
 
 // Externes
 extern vmm_directory_t* kernel_directory;
@@ -28,6 +30,7 @@ void setup_initial_user_context(task_t* task, uint32_t entry_point, uint32_t sta
 
 
 void tasking_init() {
+    deferred_reap_task = NULL;
     current_task = (task_t*)kmalloc(sizeof(task_t));
     current_task->id = next_task_id++;
     current_task->state = TASK_RUNNING;
@@ -94,6 +97,15 @@ void add_task_to_queue(task_t* task) {
 // Déclaration de la fonction assembleur pour le changement de contexte
 extern void jump_to_task(cpu_state_t* next_state);
 
+static void task_reap_deferred(void) {
+    task_t* task = deferred_reap_task;
+    deferred_reap_task = NULL;
+    if (!task || task->type != TASK_TYPE_USER) return;
+    if (task->vmm_dir && vmm_destroy_user_directory(task->vmm_dir) == 0) task->vmm_dir = NULL;
+    if (task->kernel_stack_p) kfree((void*)(task->kernel_stack_p - 4096U));
+    kfree(task);
+}
+
 static void unlink_task(task_t* task) {
     if (!task_queue || !task) return;
     if (task->next == task) {
@@ -111,6 +123,7 @@ static void unlink_task(task_t* task) {
 void schedule(cpu_state_t* cpu) {
     uint32_t now = timer_get_ticks();
     asm volatile("cli"); // Désactiver les interruptions pour la planification
+    task_reap_deferred();
     if (!current_task) {
         asm volatile("sti");
         return;
@@ -122,8 +135,10 @@ void schedule(cpu_state_t* cpu) {
         if (now >= current_task->last_scheduled_ticks) current_task->run_ticks += now - current_task->last_scheduled_ticks;
         memcpy(&current_task->cpu_state, cpu, sizeof(cpu_state_t));
     } else {
+        task_t* terminated_task = current_task;
         print_string_serial("[SCHED] removing terminated task\n");
-        unlink_task(current_task);
+        unlink_task(terminated_task);
+        deferred_reap_task = terminated_task;
         if (!task_queue) {
             asm volatile("sti");
             while(1) asm volatile("hlt");


### PR DESCRIPTION
## Résumé

- détache une tâche Ring 3 terminée sans sauvegarder son état ;
- reporte la destruction de son VMM, de sa pile noyau et de sa structure au prochain passage de scheduler ;
- garantit que la libération survient hors de la pile et du répertoire de la tâche terminée ;
- documente AOS-1889…1896.

## Validation

- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` : réussi ;
- `git diff --check` : réussi.