### PR TITLE
feat: reclaim detached user tasks after kill

### DIFF
--- a/docs/aos1897_1904_task_forced_reap.md
+++ b/docs/aos1897_1904_task_forced_reap.md
@@ -1,0 +1,33 @@
+# AOS-1897…1904 — Réclamation forcée des tâches Ring 3 détachées
+
+## Objet
+
+Les opérations `task_kill()` et `task_kill_direct_children()` détachaient déjà les tâches cibles de la file d’ordonnancement, mais les ressources de tâches Ring 3 réelles pouvaient rester retenues jusqu’à une réclamation future. Ce lot applique la même primitive de libération contrôlée aux tâches supprimées hors contexte actif.
+
+| Chemin | Traitement après détachement |
+|---|---|
+| Sortie de la tâche courante | Réclamation différée au passage ultérieur du scheduler. |
+| `task_kill()` sur un enfant non courant | Réclamation immédiate après détachement. |
+| `task_kill_direct_children()` | Réclamation immédiate de chaque enfant détaché. |
+
+## Sûreté
+
+La primitive factorisée ne libère une tâche que si elle est Ring 3 et possède une pile noyau réelle. Cette garde évite d’interpréter les fixtures unitaires ou des structures incomplètes comme des contextes de production. Pour une tâche réelle, elle détruit le VMM utilisateur par le destructeur qui refuse tout espace actif, restitue la pile noyau puis libère la structure de tâche.
+
+> Les suppressions forcées ne s’exécutent jamais depuis le VMM ni depuis la pile de la tâche cible : la cible est distincte de la tâche qui émet la demande.
+
+La réclamation ne crée aucune allocation dynamique. Elle restitue seulement les ressources déjà attribuées au cycle de vie Ring 3.
+
+## Validation
+
+| Commande | Résultat |
+|---|---:|
+| `make -s test-all` | 479/479 tests réussis |
+| `make -s kernel-only` | Réussi |
+| `git diff --check` | Réussi |
+
+La suite de tâches, les composants VMM/PMM, le réseau et les tests GPT-2 restent tous verts sous le gate de non-régression.
+
+## Référence
+
+[1] [Intel 64 and IA-32 Architectures Software Developer’s Manual — Task Switching and Paging](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -127,6 +127,7 @@
 - [x] AOS-1873…1880 : réponse TLS `close_notify` best-effort après fermeture distante, transition SSE terminale et zéro allocation dynamique — [aos1873_1880_tls_peer_close_reply.md](aos1873_1880_tls_peer_close_reply.md)
 - [x] AOS-1881…1888 : isolation des tables VMM utilisateur, rollback de création Ring 3 et restitution PMM sans destruction des mappings noyau partagés — [aos1881_1888_user_vmm_isolation.md](aos1881_1888_user_vmm_isolation.md)
 - [x] AOS-1889…1896 : réclamation différée des tâches Ring 3 terminées, destruction VMM hors pile active et libération de pile noyau sans allocation dynamique — [aos1889_1896_task_deferred_reaper.md](aos1889_1896_task_deferred_reaper.md)
+- [x] AOS-1897…1904 : réclamation forcée des tâches Ring 3 détachées par `kill`, destruction VMM hors contexte actif et zéro allocation dynamique — [aos1897_1904_task_forced_reap.md](aos1897_1904_task_forced_reap.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -97,13 +97,17 @@ void add_task_to_queue(task_t* task) {
 // Déclaration de la fonction assembleur pour le changement de contexte
 extern void jump_to_task(cpu_state_t* next_state);
 
+static void task_release_detached(task_t* task) {
+    if (!task || task->type != TASK_TYPE_USER || !task->kernel_stack_p) return;
+    if (task->vmm_dir && vmm_destroy_user_directory(task->vmm_dir) == 0) task->vmm_dir = NULL;
+    kfree((void*)(task->kernel_stack_p - 4096U));
+    kfree(task);
+}
+
 static void task_reap_deferred(void) {
     task_t* task = deferred_reap_task;
     deferred_reap_task = NULL;
-    if (!task || task->type != TASK_TYPE_USER) return;
-    if (task->vmm_dir && vmm_destroy_user_directory(task->vmm_dir) == 0) task->vmm_dir = NULL;
-    if (task->kernel_stack_p) kfree((void*)(task->kernel_stack_p - 4096U));
-    kfree(task);
+    task_release_detached(task);
 }
 
 static void unlink_task(task_t* task) {
@@ -600,6 +604,7 @@ int task_kill(int requester_pid, int pid) {
     task_reparent_children(t);
     t->state = TASK_TERMINATED;
     unlink_task(t);
+    task_release_detached(t);
     return 0;
 }
 
@@ -624,6 +629,7 @@ int task_kill_direct_children(int requester_pid) {
         task_reparent_children(child);
         child->state = TASK_TERMINATED;
         unlink_task(child);
+        task_release_detached(child);
     }
     return (int)count;
 }


### PR DESCRIPTION
## Résumé

- factorise la libération des tâches Ring 3 détachées ;
- réclamme immédiatement les ressources des enfants supprimés hors contexte actif ;
- conserve la réclamation différée pour la tâche courante sortante ;
- documente AOS-1897…1904.

## Validation

- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` : réussi ;
- `git diff --check` : réussi.