### PR TITLE
feat: expose safe task removal contract

### DIFF
--- a/docs/aos1905_1912_task_public_remove.md
+++ b/docs/aos1905_1912_task_public_remove.md
@@ -1,0 +1,32 @@
+# AOS-1905…1912 — Contrat public de retrait de tâche hors contexte actif
+
+## Objet
+
+Le fichier d’en-tête des tâches exposait `remove_task()` sans implémentation de production. Ce lot complète ce contrat public pour les appels souhaitant retirer une tâche **non courante** de la file d’ordonnancement.
+
+La fonction vérifie d’abord que la cible est non nulle, que la file existe, qu’elle ne désigne pas la tâche courante et qu’elle appartient effectivement à la liste circulaire. Elle la détache ensuite par le primitive interne unique et réutilise la réclamation sûre des ressources Ring 3.
+
+| Cas | Résultat |
+|---|---|
+| Cible nulle, file vide ou cible absente | Aucun effet. |
+| Tâche courante | Refus implicite : le scheduler reste le seul chemin de sortie sûr. |
+| Tâche non courante de la file | Détachement atomique ; les ressources Ring 3 réelles sont réclamées. |
+
+## Sûreté
+
+La garde sur la tâche courante évite de libérer une pile noyau ou un VMM encore actifs. Les tâches Ring 3 réelles sont traitées par la primitive déjà employée par les chemins de sortie différée et de suppression forcée. Aucun buffer ni allocation supplémentaire n’est introduit.
+
+> Le contrat public de retrait ne court-circuite pas le changement de contexte : seule une tâche hors exécution peut être détachée par cet appel.
+
+## Validation
+
+| Commande | Résultat |
+|---|---:|
+| `make -s test-kernel` | 38/38 suites réussies |
+| `make -s test-all` | 479/479 tests réussis |
+| `make -s kernel-only` | Réussi |
+| `git diff --check` | Réussi |
+
+## Référence
+
+[1] [Intel 64 and IA-32 Architectures Software Developer’s Manual — Task Switching](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -128,6 +128,7 @@
 - [x] AOS-1881…1888 : isolation des tables VMM utilisateur, rollback de création Ring 3 et restitution PMM sans destruction des mappings noyau partagés — [aos1881_1888_user_vmm_isolation.md](aos1881_1888_user_vmm_isolation.md)
 - [x] AOS-1889…1896 : réclamation différée des tâches Ring 3 terminées, destruction VMM hors pile active et libération de pile noyau sans allocation dynamique — [aos1889_1896_task_deferred_reaper.md](aos1889_1896_task_deferred_reaper.md)
 - [x] AOS-1897…1904 : réclamation forcée des tâches Ring 3 détachées par `kill`, destruction VMM hors contexte actif et zéro allocation dynamique — [aos1897_1904_task_forced_reap.md](aos1897_1904_task_forced_reap.md)
+- [x] AOS-1905…1912 : contrat public de retrait de tâche hors contexte actif, vérification de liste et réclamation Ring 3 sans allocation dynamique — [aos1905_1912_task_public_remove.md](aos1905_1912_task_public_remove.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -96,6 +96,7 @@ void add_task_to_queue(task_t* task) {
 
 // Déclaration de la fonction assembleur pour le changement de contexte
 extern void jump_to_task(cpu_state_t* next_state);
+static void unlink_task(task_t* task);
 
 static void task_release_detached(task_t* task) {
     if (!task || task->type != TASK_TYPE_USER || !task->kernel_stack_p) return;
@@ -107,6 +108,20 @@ static void task_release_detached(task_t* task) {
 static void task_reap_deferred(void) {
     task_t* task = deferred_reap_task;
     deferred_reap_task = NULL;
+    task_release_detached(task);
+}
+
+void remove_task(task_t* task) {
+    task_t* cursor;
+    int found = 0;
+    if (!task || task == current_task || !task_queue) return;
+    cursor = task_queue;
+    do {
+        if (cursor == task) { found = 1; break; }
+        cursor = cursor->next;
+    } while (cursor && cursor != task_queue);
+    if (!found) return;
+    unlink_task(task);
     task_release_detached(task);
 }
 


### PR DESCRIPTION
## Résumé

- implémente le contrat public `remove_task()` ;
- vérifie la présence dans la file et refuse la tâche courante ;
- réutilise la réclamation sûre des ressources Ring 3 ;
- documente AOS-1905…1912.

## Validation

- `make -s test-kernel` : 38/38 suites vertes ;
- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` et `git diff --check` : réussis.