### PR TITLE
feat: use static pools for user task lifecycle

### DIFF
--- a/docs/aos1913_1924_static_task_vmm_pools.md
+++ b/docs/aos1913_1924_static_task_vmm_pools.md
@@ -1,0 +1,44 @@
+# AOS-1913…1924 — Pools statiques pour tâches Ring 3, piles noyau et VMM
+
+## Objet
+
+Ce macro-lot supprime les allocations de tas du cycle de vie des tâches Ring 3. Les structures de tâche, leurs piles noyau et les conteneurs de répertoire VMM sont désormais fournis par des pools statiques bornés à `OS_TASK_GLOBAL_CAPACITY`.
+
+| Ressource | Avant | Après |
+|---|---|---|
+| Structure `task_t` | Allocation de tas à la création | Slot statique réutilisable |
+| Pile noyau Ring 3 | Allocation de 4 Kio à la création | Bloc statique aligné de 4 Kio par slot |
+| `vmm_directory_t`, pointeurs de tables et répertoire matériel | Allocations de tas distinctes | Conteneurs statiques par slot |
+| Tables privées utilisateur | N/A | Pages PMM caller-owned, libérées au nettoyage |
+
+## Sémantique
+
+Le pool partage la borne déjà exposée par le système : `OS_TASK_GLOBAL_CAPACITY = 16`. L’acquisition initialise le slot entièrement ; la libération intervient seulement après la destruction réussie du VMM utilisateur, puis réinitialise le slot pour une réutilisation ultérieure.
+
+Les conteneurs VMM statiques portent un marqueur explicite. `vmm_destroy_user_directory()` continue de restituer les pages utilisateur et les tables privées fournies par le PMM, mais ne passe jamais les conteneurs statiques à `kfree()`.
+
+> La mémoire de contrôle des tâches est bornée à la compilation ; seuls les cadres physiques mappés aux segments ELF, aux piles utilisateur et aux tables privées transitent encore par le PMM, puis sont restitués au nettoyage.
+
+## Garanties
+
+| Invariant | Garantie |
+|---|---|
+| Capacité | Aucun dépassement : un slot libre est requis avant création. |
+| Rollback | Un échec ELF, pile utilisateur ou initialisation rend le VMM statique au pool. |
+| Sortie / `kill` | La réclamation VMM précède la remise à disposition du slot de tâche. |
+| Allocation de tas dans `task.c` | Aucune. |
+| Mappings noyau | Conservés partagés ; seules les tables utilisateur privées sont détruites. |
+
+## Validation
+
+| Commande | Résultat |
+|---|---:|
+| `make -s test-kernel` | 38/38 suites réussies |
+| `make -s test-all` | 479/479 tests réussis |
+| `make -s kernel-only` | Réussi |
+| Recherche d’allocations dans `kernel/task/task.c` | Aucun appel `kmalloc`, `kfree`, `malloc`, `calloc` ou `realloc` |
+| `git diff --check` | Réussi |
+
+## Référence
+
+[1] [Intel 64 and IA-32 Architectures Software Developer’s Manual — Paging and Task Switching](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -129,6 +129,7 @@
 - [x] AOS-1889…1896 : réclamation différée des tâches Ring 3 terminées, destruction VMM hors pile active et libération de pile noyau sans allocation dynamique — [aos1889_1896_task_deferred_reaper.md](aos1889_1896_task_deferred_reaper.md)
 - [x] AOS-1897…1904 : réclamation forcée des tâches Ring 3 détachées par `kill`, destruction VMM hors contexte actif et zéro allocation dynamique — [aos1897_1904_task_forced_reap.md](aos1897_1904_task_forced_reap.md)
 - [x] AOS-1905…1912 : contrat public de retrait de tâche hors contexte actif, vérification de liste et réclamation Ring 3 sans allocation dynamique — [aos1905_1912_task_public_remove.md](aos1905_1912_task_public_remove.md)
+- [x] AOS-1913…1924 : pools statiques bornés de tâches Ring 3, piles noyau et conteneurs VMM, rollback et zéro allocation de tas dans `task.c` — [aos1913_1924_static_task_vmm_pools.md](aos1913_1924_static_task_vmm_pools.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/mem/vmm.c
+++ b/kernel/mem/vmm.c
@@ -155,6 +155,7 @@ int vmm_destroy_user_directory(vmm_directory_t *dir) {
         }
         pmm_free_page(table);
     }
+    if (dir->static_storage) return 0;
     kfree(dir->physical_dir);
     kfree(dir->tables);
     kfree(dir);

--- a/kernel/mem/vmm.h
+++ b/kernel/mem/vmm.h
@@ -38,6 +38,8 @@ typedef struct {
     page_table_t** tables;
     page_directory_t* physical_dir;
     uint32_t physical_addr;
+    /* Le conteneur est fourni par un pool statique et ne doit pas passer par kfree(). */
+    uint8_t static_storage;
     /* Bitmap des tables clonées pour un espace utilisateur ; les tables noyau restent partagées. */
     uint32_t private_table_mask[ENTRIES_PER_TABLE / 32U];
 } vmm_directory_t;

--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -18,6 +18,81 @@ volatile int g_reschedule_needed = 0;
 /* Tâche détachée à libérer lors d’un passage ultérieur, hors de sa pile et de son VMM. */
 static task_t* deferred_reap_task = NULL;
 
+#define TASK_STATIC_KERNEL_STACK_SIZE 4096U
+static task_t task_static_pool[OS_TASK_GLOBAL_CAPACITY];
+static uint8_t task_static_used[OS_TASK_GLOBAL_CAPACITY];
+static uint8_t task_static_kernel_stacks[OS_TASK_GLOBAL_CAPACITY][TASK_STATIC_KERNEL_STACK_SIZE] __attribute__((aligned(16)));
+static vmm_directory_t task_static_vmm_pool[OS_TASK_GLOBAL_CAPACITY];
+static uint8_t task_static_vmm_used[OS_TASK_GLOBAL_CAPACITY];
+static page_table_t* task_static_vmm_tables[OS_TASK_GLOBAL_CAPACITY][ENTRIES_PER_TABLE];
+static page_directory_t task_static_vmm_physical_dirs[OS_TASK_GLOBAL_CAPACITY] __attribute__((aligned(PAGE_SIZE)));
+
+static vmm_directory_t* task_static_vmm_acquire(void) {
+    uint32_t index, table_index;
+    vmm_directory_t* dir;
+    for (index = 0U; index < OS_TASK_GLOBAL_CAPACITY; index++) {
+        if (task_static_vmm_used[index]) continue;
+        task_static_vmm_used[index] = 1U;
+        dir = &task_static_vmm_pool[index];
+        memset(dir, 0, sizeof(vmm_directory_t));
+        memset(task_static_vmm_tables[index], 0, sizeof(task_static_vmm_tables[index]));
+        memset(&task_static_vmm_physical_dirs[index], 0, sizeof(page_directory_t));
+        dir->tables = task_static_vmm_tables[index];
+        dir->physical_dir = &task_static_vmm_physical_dirs[index];
+        dir->physical_addr = (uint32_t)dir->physical_dir;
+        dir->static_storage = 1U;
+        for (table_index = 0U; table_index < ENTRIES_PER_TABLE; table_index++) {
+            if (kernel_directory->tables[table_index]) {
+                dir->tables[table_index] = kernel_directory->tables[table_index];
+                dir->physical_dir->tablesPhysical[table_index] = kernel_directory->physical_dir->tablesPhysical[table_index];
+            }
+        }
+        return dir;
+    }
+    return NULL;
+}
+
+static void task_static_vmm_release(vmm_directory_t* dir) {
+    uint32_t index;
+    for (index = 0U; index < OS_TASK_GLOBAL_CAPACITY; index++) {
+        if (dir == &task_static_vmm_pool[index]) {
+            task_static_vmm_used[index] = 0U;
+            return;
+        }
+    }
+}
+
+static task_t* task_static_acquire(void) {
+    uint32_t index;
+    for (index = 0U; index < OS_TASK_GLOBAL_CAPACITY; index++) {
+        if (!task_static_used[index]) {
+            task_static_used[index] = 1U;
+            memset(&task_static_pool[index], 0, sizeof(task_t));
+            return &task_static_pool[index];
+        }
+    }
+    return NULL;
+}
+
+static void task_static_release(task_t* task) {
+    uint32_t index;
+    for (index = 0U; index < OS_TASK_GLOBAL_CAPACITY; index++) {
+        if (task == &task_static_pool[index]) {
+            memset(&task_static_pool[index], 0, sizeof(task_t));
+            task_static_used[index] = 0U;
+            return;
+        }
+    }
+}
+
+static uint32_t task_static_kernel_stack_top(const task_t* task) {
+    uint32_t index;
+    for (index = 0U; index < OS_TASK_GLOBAL_CAPACITY; index++) {
+        if (task == &task_static_pool[index]) return (uint32_t)&task_static_kernel_stacks[index][TASK_STATIC_KERNEL_STACK_SIZE];
+    }
+    return 0U;
+}
+
 // Externes
 extern vmm_directory_t* kernel_directory;
 extern vmm_directory_t* current_directory;
@@ -31,7 +106,10 @@ void setup_initial_user_context(task_t* task, uint32_t entry_point, uint32_t sta
 
 void tasking_init() {
     deferred_reap_task = NULL;
-    current_task = (task_t*)kmalloc(sizeof(task_t));
+    memset(task_static_used, 0, sizeof(task_static_used));
+    memset(task_static_vmm_used, 0, sizeof(task_static_vmm_used));
+    current_task = task_static_acquire();
+    if (!current_task) return;
     current_task->id = next_task_id++;
     current_task->state = TASK_RUNNING;
     current_task->type = TASK_TYPE_KERNEL;
@@ -98,11 +176,19 @@ void add_task_to_queue(task_t* task) {
 extern void jump_to_task(cpu_state_t* next_state);
 static void unlink_task(task_t* task);
 
+static int task_destroy_user_vmm(vmm_directory_t* dir) {
+    if (!dir) return 0;
+    if (vmm_destroy_user_directory(dir) != 0) return -1;
+    task_static_vmm_release(dir);
+    return 0;
+}
+
 static void task_release_detached(task_t* task) {
     if (!task || task->type != TASK_TYPE_USER || !task->kernel_stack_p) return;
-    if (task->vmm_dir && vmm_destroy_user_directory(task->vmm_dir) == 0) task->vmm_dir = NULL;
-    kfree((void*)(task->kernel_stack_p - 4096U));
-    kfree(task);
+    if (task_destroy_user_vmm(task->vmm_dir) != 0) return;
+    task->vmm_dir = NULL;
+    task->kernel_stack_p = 0U;
+    task_static_release(task);
 }
 
 static void task_reap_deferred(void) {
@@ -310,13 +396,13 @@ task_t* create_task_from_initrd_file(const char* filename) {
 
     if (entry_point == 0 || user_stack_top == 0) {
         print_string_serial("ERREUR: Chargement ELF ou allocation de pile a echoue\n");
-        (void)vmm_destroy_user_directory(vmm_dir);
+        (void)task_destroy_user_vmm(vmm_dir);
         return NULL;
     }
 
-    task_t* new_task = (task_t*)kmalloc(sizeof(task_t));
+    task_t* new_task = task_static_acquire();
     if (!new_task) {
-        (void)vmm_destroy_user_directory(vmm_dir);
+        (void)task_destroy_user_vmm(vmm_dir);
         return NULL;
     }
     new_task->id = next_task_id++;
@@ -370,14 +456,13 @@ task_t* create_task_from_initrd_file(const char* filename) {
         new_task->name[i] = '\0';
     }
 
-    // Allouer une pile noyau pour cette tâche
-    new_task->kernel_stack_p = (uint32_t)kmalloc(4096);
+    /* Pile noyau dédiée issue du pool statique, sans allocation de tas. */
+    new_task->kernel_stack_p = task_static_kernel_stack_top(new_task);
     if (!new_task->kernel_stack_p) {
-        kfree(new_task);
-        (void)vmm_destroy_user_directory(vmm_dir);
+        task_static_release(new_task);
+        (void)task_destroy_user_vmm(vmm_dir);
         return NULL;
     }
-    new_task->kernel_stack_p += 4096U;
 
     setup_initial_user_context(new_task, entry_point, user_stack_top);
     add_task_to_queue(new_task);
@@ -419,39 +504,10 @@ void setup_initial_user_context(task_t* task, uint32_t entry_point, uint32_t sta
 }
 
 vmm_directory_t* create_user_vmm_directory() {
-    print_string_serial("create_user_vmm_directory: start\n");
-    vmm_directory_t* dir = (vmm_directory_t*)kmalloc(sizeof(vmm_directory_t));
-    if (!dir) {
-        print_string_serial("create_user_vmm_directory: kmalloc for dir failed\n");
-        return NULL;
-    }
-    memset(dir, 0, sizeof(vmm_directory_t));
-
-    dir->tables = (page_table_t**)kmalloc(sizeof(page_table_t*) * 1024);
-    if (!dir->tables) {
-        print_string_serial("create_user_vmm_directory: kmalloc for tables failed\n");
-        kfree(dir);
-        return NULL;
-    }
-    memset(dir->tables, 0, sizeof(page_table_t*) * 1024);
-
-    dir->physical_dir = (page_directory_t*)kmalloc_aligned(sizeof(page_directory_t));
-    if (!dir->physical_dir) {
-        print_string_serial("create_user_vmm_directory: kmalloc_aligned for physical_dir failed\n");
-        kfree(dir->tables);
-        kfree(dir);
-        return NULL;
-    }
-    memset(dir->physical_dir, 0, sizeof(page_directory_t));
-    dir->physical_addr = (uint32_t)dir->physical_dir;
-
-    // Clone kernel space
-    for (int i = 0; i < 1024; i++) {
-         if (kernel_directory->tables[i]) {
-            dir->tables[i] = kernel_directory->tables[i];
-            dir->physical_dir->tablesPhysical[i] = kernel_directory->physical_dir->tablesPhysical[i];
-        }
-    }
+    vmm_directory_t* dir;
+    print_string_serial("create_user_vmm_directory: static pool\n");
+    dir = task_static_vmm_acquire();
+    if (!dir) print_string_serial("create_user_vmm_directory: static pool exhausted\n");
     return dir;
 }
 


### PR DESCRIPTION
## Résumé

- remplace les structures de tâches et piles noyau Ring 3 par des pools statiques bornés ;
- remplace les conteneurs VMM utilisateur de tas par des pools statiques ;
- conserve les pages ELF, piles utilisateur et tables privées sur PMM avec restitution symétrique ;
- supprime tout appel d’allocation de tas dans `kernel/task/task.c` ;
- documente AOS-1913…1924.

## Validation

- `make -s test-kernel` : 38/38 suites vertes ;
- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` et `git diff --check` : réussis ;
- recherche d’allocations dans `kernel/task/task.c` : aucune occurrence.