### PR TITLE
feat: allocate VMM tables from PMM

### DIFF
--- a/docs/aos1925_1932_vmm_pmm_tables.md
+++ b/docs/aos1925_1932_vmm_pmm_tables.md
@@ -1,0 +1,30 @@
+# AOS-1925…1932 — Tables VMM allouées par le PMM
+
+## Objet
+
+La création à la demande d’une table de pages dans `vmm_get_page()` utilisait encore une allocation de tas alignée. Ce lot la remplace par une page allouée directement par le PMM, conformément au modèle de propriété des tables de pagination du noyau.
+
+| Chemin VMM | Fournisseur de mémoire |
+|---|---|
+| Répertoire noyau | PMM |
+| Tables d’identité du noyau | PMM |
+| Table créée à la demande | PMM |
+| Table utilisateur privatisée | PMM |
+
+La table obtenue est toujours mise à zéro avant publication dans le répertoire. Les conteneurs VMM dynamiques historiques restent pris en charge par le destructeur, tandis que les tables de pages créées pendant le mapping sont physiquement alignées et gérées par le PMM.
+
+> Les structures de pagination sont désormais allouées selon un modèle unique : pages PMM alignées et contrôlées, sans dépendance au tas pour créer une table VMM.
+
+## Validation
+
+| Commande | Résultat |
+|---|---:|
+| `make -s test-kernel` | 38/38 suites réussies |
+| `make -s test-all` | 479/479 tests réussis |
+| `make -s kernel-only` | Réussi |
+| Recherche d’allocations dans `kernel/mem/vmm.c` | Aucun appel d’allocation de tas |
+| `git diff --check` | Réussi |
+
+## Référence
+
+[1] [Intel 64 and IA-32 Architectures Software Developer’s Manual — Paging](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -130,6 +130,7 @@
 - [x] AOS-1897…1904 : réclamation forcée des tâches Ring 3 détachées par `kill`, destruction VMM hors contexte actif et zéro allocation dynamique — [aos1897_1904_task_forced_reap.md](aos1897_1904_task_forced_reap.md)
 - [x] AOS-1905…1912 : contrat public de retrait de tâche hors contexte actif, vérification de liste et réclamation Ring 3 sans allocation dynamique — [aos1905_1912_task_public_remove.md](aos1905_1912_task_public_remove.md)
 - [x] AOS-1913…1924 : pools statiques bornés de tâches Ring 3, piles noyau et conteneurs VMM, rollback et zéro allocation de tas dans `task.c` — [aos1913_1924_static_task_vmm_pools.md](aos1913_1924_static_task_vmm_pools.md)
+- [x] AOS-1925…1932 : tables VMM créées par le PMM, alignement matériel cohérent et zéro allocation de tas dans `vmm.c` — [aos1925_1932_vmm_pmm_tables.md](aos1925_1932_vmm_pmm_tables.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/mem/vmm.c
+++ b/kernel/mem/vmm.c
@@ -92,7 +92,7 @@ page_t *vmm_get_page(uint32_t address, int make, vmm_directory_t *dir) {
     if (dir->tables[table_idx]) {
         return &dir->tables[table_idx]->pages[address % 1024];
     } else if (make) {
-        page_table_t* new_table = (page_table_t*)kmalloc_aligned(sizeof(page_table_t));
+        page_table_t* new_table = (page_table_t*)pmm_alloc_page();
         if (!new_table) return 0;
         memset(new_table, 0, sizeof(page_table_t));
         


### PR DESCRIPTION
## Résumé

- remplace la dernière création de table VMM par une page PMM ;
- unifie la provenance des structures de pagination ;
- évite toute allocation de tas dans `kernel/mem/vmm.c` ;
- documente AOS-1925…1932.

## Validation

- `make -s test-kernel` : 38/38 suites vertes ;
- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` et `git diff --check` : réussis ;
- recherche d’allocations de tas dans `vmm.c` : aucune occurrence.