### PR TITLE
feat: enforce static VMM storage contract

### DIFF
--- a/docs/aos1933_1940_vmm_static_contract.md
+++ b/docs/aos1933_1940_vmm_static_contract.md
@@ -1,0 +1,34 @@
+# AOS-1933…1940 — Contrat VMM sans tas dynamique
+
+## Objet
+
+Après le transfert des tables de pagination vers le PMM et des répertoires utilisateur vers des pools statiques, le VMM ne doit plus conserver de chemin historique vers le tas. Ce lot verrouille explicitement ce contrat.
+
+`vmm_destroy_user_directory()` accepte uniquement un répertoire utilisateur identifié comme conteneur statique. Il restitue les pages utilisateur et les tables privées au PMM, mais ne tente jamais de libérer le conteneur VMM, sa table de pointeurs ou son répertoire matériel par le tas.
+
+| Répertoire | Origine | Destruction autorisée |
+|---|---|---|
+| Noyau | PMM | Refusée |
+| Actif | Toute origine | Refusée |
+| Utilisateur statique | Pool de tâches | Pages et tables privées PMM uniquement |
+| Répertoire non statique | Ancien modèle | Refusée |
+
+## Garanties
+
+> Le module VMM ne réalise plus d’appel à `kmalloc`, `kmalloc_aligned`, `kfree`, `malloc`, `calloc` ou `realloc`.
+
+Le sous-système de tas reste initialisé par le noyau pour les composants qui l’emploient encore, mais le VMM ne lui délègue plus de gestion de tables ou de répertoires. Les chemins de création et de destruction se limitent donc à des capacités statiques ou à des pages PMM alignées.
+
+## Validation
+
+| Commande | Résultat |
+|---|---:|
+| `make -s test-kernel` | 38/38 suites réussies |
+| `make -s test-all` | 479/479 tests réussis |
+| `make -s kernel-only` | Réussi |
+| Recherche d’allocations dans `kernel/mem/vmm.c` | Aucune occurrence |
+| `git diff --check` | Réussi |
+
+## Référence
+
+[1] [Intel 64 and IA-32 Architectures Software Developer’s Manual — Paging](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -131,6 +131,7 @@
 - [x] AOS-1905…1912 : contrat public de retrait de tâche hors contexte actif, vérification de liste et réclamation Ring 3 sans allocation dynamique — [aos1905_1912_task_public_remove.md](aos1905_1912_task_public_remove.md)
 - [x] AOS-1913…1924 : pools statiques bornés de tâches Ring 3, piles noyau et conteneurs VMM, rollback et zéro allocation de tas dans `task.c` — [aos1913_1924_static_task_vmm_pools.md](aos1913_1924_static_task_vmm_pools.md)
 - [x] AOS-1925…1932 : tables VMM créées par le PMM, alignement matériel cohérent et zéro allocation de tas dans `vmm.c` — [aos1925_1932_vmm_pmm_tables.md](aos1925_1932_vmm_pmm_tables.md)
+- [x] AOS-1933…1940 : contrat VMM sans tas, répertoires utilisateur statiques et restitution PMM des pages privées — [aos1933_1940_vmm_static_contract.md](aos1933_1940_vmm_static_contract.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/mem/vmm.c
+++ b/kernel/mem/vmm.c
@@ -146,6 +146,7 @@ int vmm_map_page_in_directory(vmm_directory_t *dir, void *physaddr, void *virtua
 int vmm_destroy_user_directory(vmm_directory_t *dir) {
     uint32_t table_index, page_index;
     if (!dir || dir == kernel_directory || dir == current_directory) return -1;
+    if (!dir->static_storage) return -2;
     for (table_index = 0U; table_index < ENTRIES_PER_TABLE; table_index++) {
         page_table_t* table = dir->tables[table_index];
         if (!vmm_table_is_private(dir, table_index) || !table) continue;
@@ -155,9 +156,5 @@ int vmm_destroy_user_directory(vmm_directory_t *dir) {
         }
         pmm_free_page(table);
     }
-    if (dir->static_storage) return 0;
-    kfree(dir->physical_dir);
-    kfree(dir->tables);
-    kfree(dir);
     return 0;
 }


### PR DESCRIPTION
## Résumé

- verrouille les répertoires utilisateur VMM sur les conteneurs statiques ;
- retire les opérations de tas du destructeur VMM ;
- conserve la restitution des pages et tables privées au PMM ;
- documente AOS-1933…1940.

## Validation

- `make -s test-kernel` : 38/38 suites vertes ;
- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` et `git diff --check` : réussis ;
- recherche d’allocations dans `vmm.c` : aucune occurrence.