### PR TITLE
docs: reconcile delivered backlog capabilities

### DIFF
--- a/docs/aos1289_fat32_create_file.md
+++ b/docs/aos1289_fat32_create_file.md
@@ -17,6 +17,6 @@ En cas d’échec d’allocation, d’écriture, de chaînage ou de publication,
 | Tests noyau | 35/35 |
 | Validation au moment du lot | 419 tests verts |
 
-La création de fichier reste volontairement limitée à un alias 8.3 et séparée de la recherche par nom long. Depuis ce lot, l’extension de la racine et les primitives LFN FAT32 bornées ont été livrées ; la publication multi-entrée, la reconstruction LFN et l’intégration VFS restent à réaliser.
+> **Note historique réconciliée.** Les capacités FAT32 LFN bornées de publication, reconstruction, lecture, suppression et renommage ont depuis été livrées par [AOS-1321](aos1321_fat32_lfn.md), [AOS-1657…1664](aos1657_1664_fat32_lfn_unlink.md), [AOS-1673…1680](aos1673_1680_fat32_lfn_rename.md), [AOS-1729…1736](aos1729_1736_fat32_lfn_read.md) et [AOS-1737…1752](aos1737_1744_fat_lfn_utf8.md). Cette page conserve le contrat historique de création 8.3 de ce lot initial.
 
 **Auteur :** Manus AI

--- a/docs/aos1373_1384_llm_socket_http_sse.md
+++ b/docs/aos1373_1384_llm_socket_http_sse.md
@@ -23,7 +23,7 @@ Le test `test_llm_socket_opens_http_response` produit un record TLS côté serve
 
 ## Limites restantes
 
-Les adaptateurs de construction, transmission NE2000, réception TLS, HTTP et SSE sont désormais composables sur socket. Il reste à les appeler depuis un orchestrateur unique pilotant DNS, SYN, handshake TLS, émission, polling et retry, puis à raccorder ce chemin à la commande `ai` avec une configuration de fournisseur sûre. La planification périodique DHCP est également distincte et reste ouverte.
+> **Note historique réconciliée.** L’orchestration de contexte réseau LLM, le polling périodique, le retry SSE, la reprise inter-session et le renouvellement DHCP ont depuis été raccordés par [AOS-649…664](aos649_656_llm_network_context.md), [AOS-1017…1032](aos1017_1024_pit_sse_polling.md), [AOS-1769…1824](aos1769_1776_sse_session_context.md) et les macro-lots de fermeture TLS AOS-1833…1880. Cette note décrit donc uniquement le périmètre initial de l’adaptateur socket.
 
 ## Références
 

--- a/docs/aos1941_1948_backlog_documentation_reconciliation.md
+++ b/docs/aos1941_1948_backlog_documentation_reconciliation.md
@@ -1,0 +1,23 @@
+# AOS-1941…1948 — Réconciliation de la documentation historique du backlog
+
+## Objet
+
+Plusieurs documents de macro-lots anciens décrivaient des fonctionnalités comme futures parce qu’elles n’étaient pas disponibles à leur date de publication. Ces formulations restaient visibles après la livraison des lots successeurs et pouvaient faire apparaître à tort des axes déjà clôturés comme ouverts.
+
+Ce lot conserve les contrats et résultats historiques, mais remplace les limites obsolètes par une note de succession reliant chaque domaine aux implémentations qui l’ont complété.
+
+| Document historique | Réconciliation |
+|---|---|
+| AOS-729…736 bigint | ECDSA P-256, X.509 ECDSA et TLS ECDHE-ECDSA référencés vers AOS-745…808. |
+| AOS-1289…1304 FAT32 | Publication, lecture, suppression et renommage LFN référencées vers AOS-1321 et AOS-1657…1752. |
+| AOS-1373…1384 LLM socket | Orchestration réseau, polling SSE, reprise, retry et DHCP référencés vers AOS-649…664, AOS-1017…1032 et AOS-1769…1880. |
+
+## Méthode
+
+Les passages modifiés sont explicitement signalés comme des **notes historiques réconciliées**. Cette formulation empêche d’attribuer rétroactivement les fonctions au lot d’origine tout en maintenant un chemin de lecture exact vers les livraisons ultérieures. Les limites réellement hors périmètre, telles que la révocation et les chaînes X.509 non bornées, restent indiquées.
+
+> L’index de backlog devient ainsi la source opérationnelle de l’état livré, tandis que chaque document de lot reste une archive technique fidèle de son propre périmètre.
+
+## Validation
+
+La réconciliation ne modifie aucun binaire, contrat C ni vecteur de test. `git diff --check` assure l’intégrité de format ; la suite complète reste exécutée avant publication du lot documentaire.

--- a/docs/aos729_736_bigint_multilimb_modexp.md
+++ b/docs/aos729_736_bigint_multilimb_modexp.md
@@ -46,7 +46,7 @@ Le test vérifie aussi le rejet d’un workspace inférieur aux quatre limbs req
 
 ## Limites connues
 
-ECDSA P-256 reste à implémenter : arithmétique de courbe, validation de point, parsing ASN.1 `r,s`, clé publique X.509 `id-ecPublicKey`, signatures de certificats ECDSA, signature `ServerKeyExchange`, extension ClientHello et suite `ECDHE_ECDSA`. La révocation, les chaînes de confiance multiples, les credentials OpenAI, la fermeture/annulation, timeout/retry, outils, multimodal et Unicode complet restent également hors périmètre.
+> **Note historique réconciliée.** Les capacités ECDSA P-256, X.509 `id-ecPublicKey`, validation de signatures, `ServerKeyExchange` et vol TLS `ECDHE_ECDSA` ont depuis été livrées dans les macro-lots [AOS-745…752](aos745_752_ecdsa_p256_verify.md), [AOS-753…760](aos753_760_x509_ecdsa_p256.md), [AOS-761…768](aos761_768_tls_ecdhe_ecdsa.md) et [AOS-785…808](aos785_808_https_ecdhe_ecdsa_end_to_end.md). Les sujets qui demeurent hors de ce lot historique sont notamment la révocation et les chaînes de confiance non bornées.
 
 ## Références
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -132,6 +132,7 @@
 - [x] AOS-1913…1924 : pools statiques bornés de tâches Ring 3, piles noyau et conteneurs VMM, rollback et zéro allocation de tas dans `task.c` — [aos1913_1924_static_task_vmm_pools.md](aos1913_1924_static_task_vmm_pools.md)
 - [x] AOS-1925…1932 : tables VMM créées par le PMM, alignement matériel cohérent et zéro allocation de tas dans `vmm.c` — [aos1925_1932_vmm_pmm_tables.md](aos1925_1932_vmm_pmm_tables.md)
 - [x] AOS-1933…1940 : contrat VMM sans tas, répertoires utilisateur statiques et restitution PMM des pages privées — [aos1933_1940_vmm_static_contract.md](aos1933_1940_vmm_static_contract.md)
+- [x] AOS-1941…1948 : réconciliation des limites historiques, renvoi vers les macro-lots successeurs et index documentaire cohérent — [aos1941_1948_backlog_documentation_reconciliation.md](aos1941_1948_backlog_documentation_reconciliation.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)


### PR DESCRIPTION
## Résumé

- remplace trois limites historiques devenues obsolètes par des notes de succession ;
- relie les domaines ECDSA, FAT32 LFN et LLM/SSE aux macro-lots qui les ont livrés ;
- conserve les limites réellement hors périmètre ;
- indexe AOS-1941…1948.

## Validation

- `make -s test-all` : **479/479** tests verts ;
- `git diff --check` : réussi ;
- recherche des formulations historiques ciblées : aucune occurrence restante.