### PR TITLE
docs: clarify transactional ELF rollback

### DIFF
--- a/docs/aos1965_1972_elf_transactional_rollback.md
+++ b/docs/aos1965_1972_elf_transactional_rollback.md
@@ -1,0 +1,26 @@
+# AOS-1965…1972 — Rollback transactionnel du chargement ELF
+
+## Objet
+
+Le chargeur ELF retourne immédiatement un échec lorsqu’une page physique ne peut pas être obtenue ou mappée. La remarque historique suggérant un nettoyage local restait obsolète depuis la mise en place du cycle de vie VMM transactionnel.
+
+| Étape | Garantie |
+|---|---|
+| Chargement ELF | Toute erreur retourne `0` sans publier de tâche. |
+| Appelant des tâches | Restaure d’abord le répertoire de pages actif précédent. |
+| Destruction VMM | `task_destroy_user_vmm()` détruit alors le répertoire partiel hors contexte actif. |
+| Restitution mémoire | Les pages utilisateur mappées et les tables privées sont rendues au PMM. |
+
+> Le rollback reste centralisé au niveau du propriétaire du répertoire VMM. Le chargeur n’essaie donc jamais de détruire l’espace d’adressage qu’il venait d’activer.
+
+## Validation
+
+| Commande | Résultat |
+|---|---:|
+| `make -s test-all` | 479/479 tests réussis |
+| `git diff --check` | Réussi |
+| Recherche du TODO de rollback ELF | Aucune occurrence |
+
+## Référence
+
+[1] [System V ABI — ELF gABI](https://refspecs.linuxfoundation.org/elf/gabi4+/contents.html)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -135,6 +135,7 @@
 - [x] AOS-1941…1948 : réconciliation des limites historiques, renvoi vers les macro-lots successeurs et index documentaire cohérent — [aos1941_1948_backlog_documentation_reconciliation.md](aos1941_1948_backlog_documentation_reconciliation.md)
 - [x] AOS-1949…1956 : captures QEMU GUI portables, saisie contrôlée avec reprise et validation shell/IA/NE2000 reproductible — [aos1949_1956_portable_gui_captures.md](aos1949_1956_portable_gui_captures.md)
 - [x] AOS-1957…1964 : réconciliation GGUF, validation `C/V/T` et axes de couches branchés aux kernels quantifiés caller-owned — [aos1957_1964_gguf_dimension_reconciliation.md](aos1957_1964_gguf_dimension_reconciliation.md)
+- [x] AOS-1965…1972 : rollback ELF transactionnel après restauration du VMM actif et restitution PMM des mappings partiels — [aos1965_1972_elf_transactional_rollback.md](aos1965_1972_elf_transactional_rollback.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/kernel/elf.c
+++ b/kernel/elf.c
@@ -64,7 +64,9 @@ uint32_t elf_load(uint8_t* file_data, vmm_directory_t* vmm_dir) {
                 void* phys_page = pmm_alloc_page();
                 if (!phys_page) {
                     print_string_serial("ERROR: pmm_alloc_page failed for ELF segment.\n");
-                    // TODO: Here we should unmap all previously mapped pages
+                    /* Le chargeur rend l’échec à l’appelant. Après restauration du
+                     * répertoire actif, task_destroy_user_vmm() détruit le VMM partiel,
+                     * restitue les pages utilisateur et les tables privées au PMM. */
                     return 0;
                 }
                 if (vmm_map_page_in_directory(vmm_dir, phys_page, (void*)page_addr, page_flags) != 0) {


### PR DESCRIPTION
## Résumé

- remplace le TODO ELF obsolète par le contrat transactionnel actuel ;
- documente la restauration du VMM actif avant la destruction des mappings partiels ;
- indexe AOS-1965…1972.

## Validation

- `make -s test-all` : **479/479** tests verts ;
- `git diff --check` : réussi ;
- recherche du TODO de rollback ELF : aucune occurrence.