### PR TITLE
docs: clarify shell builtin section

### DIFF
--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -2441,7 +2441,7 @@ void cmd_clear(shell_context_t* ctx, char args[][128], int arg_count) {
     print_string("\n");
 }
 
-// === Builtins manquants / stubs ===
+// === Builtins de navigation et de lecture de fichiers ===
 static void cmd_pwd(shell_context_t* ctx) {
     print_string(ctx->current_dir);
     print_string("\n");


### PR DESCRIPTION
## Résumé

- remplace le marqueur historique « builtins manquants / stubs » par la description des builtins effectivement implémentés.

## Validation

- `make -s test-all` : **479/479** tests verts ;
- `git diff --check` : réussi ;
- le marqueur obsolète ne subsiste plus dans les sources utilisateurs.