### PR TITLE
docs: reconcile FAT32 LFN and GGUF runtime

### DIFF
--- a/docs/ETAT_REEL.md
+++ b/docs/ETAT_REEL.md
@@ -10,8 +10,8 @@
 
 | Domaine | État au 20 août 2026 |
 |---|---|
-| FAT16/FAT32 | FAT16 dispose des primitives d’écriture 8.3 et LFN ; FAT32 valide le BPB, lit et écrit les FAT 28 bits répliquées, alloue et chaîne les clusters, crée des fichiers avec rollback, étend la chaîne racine et encode une entrée LFN ASCII UTF-16LE bornée. |
-| LFN FAT32 | Le checksum 8.3, la publication multi-entrée et la reconstruction au listage sont livrés ; l’intégration VFS complète, Unicode hors ASCII et suppression/renommage restent à réaliser. |
+| FAT16/FAT32 | FAT16 dispose des primitives d’écriture 8.3 et LFN ; FAT32 valide le BPB, lit et écrit les FAT 28 bits répliquées, alloue et chaîne les clusters, crée des fichiers avec rollback, étend la chaîne racine et gère les LFN UTF-8/UTF-16LE bornés. |
+| LFN FAT32 | Le checksum 8.3, la publication multi-entrée, la reconstruction et la lecture par nom long, le renommage et la suppression sont livrés. La conversion UTF-8/UTF-16LE couvre les caractères BMP et les paires substituts ; l’intégration FAT32 au VFS reste un axe séparé. |
 | Réseau utilisateur | Le registre TCP statique expose le cycle actif et passif ; les syscalls 99–108 valident les requêtes et buffers page-par-page dans l’espace utilisateur VMM. Les opérations passives `listen`, SYN entrant, SYN-ACK et ACK final sont disponibles. L’émission/réception NE2000 automatique reste à intégrer. |
 | Validation | Le runner noyau passe **35/35** tests et la suite complète passe **425/425** avec le registre et les syscalls passifs. La CI et le smoke QEMU de la PR suivante restent à valider. |
 | Mémoire | Les lots concernés n’introduisent aucune allocation dynamique ; les buffers restent statiques ou caller-owned. |
@@ -21,8 +21,8 @@ AI-OS démarre sans OS préinstallé dans QEMU, charge une archive initrd TAR, l
 | Périmètre | État vérifié |
 |---|---|
 | Démarrage et espace utilisateur | Noyau Multiboot i386, VGA/série, clavier PS/2, shell ELF Ring 3, curseur bloc et historique d’écran (Page Up/Down) |
-| IA locale | GPT-2 124M `llm.c v3`, BPE, cache KV, SSE2 et top-k, sans réseau au boot ; kernels GGML Q3_K/Q4_K/Q6_K vérifiés au niveau mathématique |
-| Stockage | Archive initrd TAR en lecture seule, overlay AIOV V2 sur ATA PIO aux LBA 0–63, volume FAT16 et primitives FAT32 d’écriture/chaînage hors intégration VFS complète |
+| IA locale | GPT-2 124M `llm.c v3`, BPE, cache KV, SSE2 et top-k, sans réseau au boot ; le runtime GGUF prépare et exécute la génération quantifiée Q3_K/Q4_K/Q6_K sur buffers statiques ou caller-owned |
+| Stockage | Archive initrd TAR en lecture seule, overlay AIOV V2 sur ATA PIO aux LBA 0–63, volume FAT16 et primitives FAT32 avec LFN UTF-8, renommage et suppression ; le branchement FAT32 au VFS reste distinct |
 | Ordonnancement et télémétrie | Coopératif par syscall et quantum IRQ0 sûr entre tâches utilisateur ; instantané de ticks, sélections, priorité CPU, parent et enfants directs ; terminaison, réattribution, attente et capacité de création limitées à la filiation directe |
 | IPC/VFS Foundation MOHHOS | Boîte aux lettres FIFO non bloquante entre tâches Ring 3, 4 entrées par tâche, charge de 96 octets et `request_id` corrélé ; capacité de deux messages clients et état borné pour un propriétaire de service, médiateur VFS, métadonnées et listage de racine ou de sous-répertoire source-spécifiques, sources virtuelles, compteurs volatils et alias initrd/overlay dynamiques |
 | Découverte Foundation MOHHOS | Registre volatile de 8 services nommés ; retrait, transfert par propriétaire, révocation VFS, abonnements de service best-effort et nettoyage à la terminaison |
@@ -242,7 +242,7 @@ La commande `ai-provider openai` ne réalise **aucun** appel réseau. Elle ne fa
 
 | Jalons AOS | Livraison réellement vérifiée |
 |---|---|
-| AOS-020 | Sonde GGUF v3, kernels Q3_K/Q4_K/Q6_K, index et mapping ; génération quantifiée non livrée |
+| AOS-020 | Sonde GGUF v3, kernels Q3_K/Q4_K/Q6_K, index et mapping ; la génération quantifiée est désormais préparée puis exécutée par le runtime GGUF avec cache KV et top-k caller-owned. |
 | AOS-021 | BPE UTF-8 avec catégories de lettres Unicode ciblées |
 | AOS-022 | Contrat QEMU versionné : boot, runtime IA, overlay, append et retour au shell |
 | AOS-023 | Snapshot ATA overlay V2 avec restauration V1/V2 |

--- a/docs/aos1321_fat32_lfn.md
+++ b/docs/aos1321_fat32_lfn.md
@@ -2,7 +2,7 @@
 
 ## Objectif
 
-Ce macro-lot ajoute les primitives déterministes nécessaires à la génération d’une entrée **Long File Name (LFN)** FAT32. Le contrat est volontairement borné : l’appelant fournit le buffer de 32 octets, aucun `kmalloc` n’est utilisé et une entrée représente au plus 13 caractères ASCII encodés en UTF-16LE.
+Ce macro-lot ajoute les primitives déterministes nécessaires à la génération d’une entrée **Long File Name (LFN)** FAT32. Le contrat demeure borné : l’appelant fournit le buffer de 32 octets, aucun `kmalloc` n’est utilisé et une entrée représente au plus 13 unités UTF-16LE issues d’un nom UTF-8 validé.
 
 ## Contrat technique
 
@@ -11,21 +11,21 @@ Ce macro-lot ajoute les primitives déterministes nécessaires à la génératio
 | `fat32_lfn_checksum` | Calcule le checksum FAT sur les 11 octets de l’alias 8.3. |
 | `fat32_encode_lfn_entry` | Initialise et encode une entrée LFN de 32 octets dans un buffer fourni par l’appelant. |
 | Mémoire | Zéro allocation dynamique ; buffers statiques ou caller-owned uniquement. |
-| Encodage | ASCII strict, conversion directe vers UTF-16LE, 13 caractères maximum par entrée. |
+| Encodage | UTF-8 validé, conversion UTF-16LE y compris paires substituts, 13 unités UTF-16 maximum par entrée. |
 | Métadonnées | Attribut `0x0F`, type nul, checksum alias, cluster initial nul. |
 
-L’algorithme de checksum applique la rotation droite d’un bit puis l’addition de chaque octet de l’alias. Les caractères sont écrits aux offsets FAT LFN standards `1,3,5,7,9`, `14,16,18,20,22,24`, puis `28,30`; les octets hauts UTF-16LE sont nuls pour l’alphabet ASCII. Les emplacements après le terminateur sont initialisés à `0xFFFF` et le terminateur est écrit lorsqu’il reste une position dans l’entrée.
+L’algorithme de checksum applique la rotation droite d’un bit puis l’addition de chaque octet de l’alias. Les unités UTF-16LE sont écrites aux offsets FAT LFN standards `1,3,5,7,9`, `14,16,18,20,22,24`, puis `28,30`; les paires substituts sont produites et validées pour les points de code non-BMP. Les emplacements après le terminateur sont initialisés à `0xFFFF` et le terminateur est écrit lorsqu’il reste une position dans l’entrée.
 
 ## Publication et reconstruction livrées
 
 `fat32_create_lfn_file` réserve d’abord les données via le créateur FAT32 transactionnel, localise l’alias 8.3, libère son slot logique puis publie les ordinals LFN décroissants dans les slots suivants avant de réécrire l’alias court. Les slots traversent la chaîne du répertoire racine et peuvent provoquer son extension automatique ; les buffers restent caller-owned et aucune allocation dynamique n’est introduite.
 
-`fat32_list_root` parcourt la chaîne racine, ignore les entrées supprimées et les volumes, reconstitue les fragments UTF-16LE ASCII dans un buffer `os_fat16_dirent_t` fourni par l’appelant, puis n’accepte le nom long que si la séquence d’ordinals et le checksum de l’alias sont cohérents. En cas de séquence invalide, le listage retombe sur l’alias 8.3 plutôt que de publier un nom non vérifié.
+`fat32_list_root` parcourt la chaîne racine, ignore les entrées supprimées et les volumes, reconstitue les fragments UTF-16LE en UTF-8 dans un buffer `os_fat16_dirent_t` fourni par l’appelant, puis n’accepte le nom long que si la séquence d’ordinals et le checksum de l’alias sont cohérents. En cas de séquence invalide, le listage retombe sur l’alias 8.3 plutôt que de publier un nom non vérifié. La lecture reconnaît le nom long, tandis que `fat32_rename_lfn_file` et `fat32_unlink_file` assurent respectivement son renommage et sa suppression transactionnels sans allocation dynamique.
 
 ## Limites explicites
 
-Le contrat reste borné à l’ASCII, à `OS_NAME_MAX - 1` caractères et à 20 entrées LFN par fichier. Les caractères Unicode hors ASCII, les paires substituts UTF-16 complètes, la suppression/renommage LFN et l’intégration complète au VFS FAT32 restent hors périmètre.
+Le contrat reste borné à `OS_NAME_MAX - 1` octets de sortie UTF-8, à 13 unités UTF-16 par entrée et à 20 entrées LFN par fichier. Les entrées sont limitées aux séquences UTF-8 valides et excluent les séparateurs de chemin ainsi que les contrôles. L’intégration du volume FAT32 aux opérations VFS génériques reste hors de ce périmètre.
 
 ## Validation
 
-Le test `test_fat32_lfn_encoding` vérifie checksum, ordinal, attribut, UTF-16LE, borne de 13 caractères et rejet du quatorzième caractère. `test_fat32_lfn_file_and_list` vérifie création d’un nom multi-entrée, publication de l’alias et reconstruction validée au listage. Le module FAT32 passe **4/4 tests** et la suite `make test-all` reste verte avec **422 tests exécutés avec succès**.
+Le test `test_lfn_utf8_bmp_conversion` vérifie les conversions UTF-8/UTF-16LE, y compris les paires substituts. `test_fat32_lfn_encoding` vérifie checksum, ordinal, attribut, encodage UTF-16LE et borne d’entrée. `test_fat32_lfn_file_and_list` couvre création, lecture par noms court et long, listage, renommage et suppression ; les tests de round-trip vérifient ensuite un nom BMP et un nom non-BMP. La suite complète `make test-all` est le contrôle de non-régression de référence.

--- a/docs/aos1973_1980_fat32_gguf_reconciliation.md
+++ b/docs/aos1973_1980_fat32_gguf_reconciliation.md
@@ -1,0 +1,46 @@
+# AOS-1973 à AOS-1980 — Réconciliation FAT32 LFN et runtime GGUF
+
+## Objet
+
+Ce macro-lot ne modifie pas les algorithmes du noyau. Il aligne la documentation de référence sur les fonctionnalités déjà présentes dans le code et couvertes par les tests : gestion FAT32 des noms longs Unicode, et exécution de la génération locale par le runtime GPT-2 GGUF quantifié.
+
+| Domaine | État vérifié | Limite conservée |
+|---|---|---|
+| FAT32 LFN | Création, publication multi-entrée, lecture, listage, renommage et suppression par nom long sont disponibles. | Le volume FAT32 n’est pas encore exposé comme backend des opérations VFS génériques. |
+| Encodage LFN | La conversion UTF-8/UTF-16LE valide les séquences, couvre le BMP et les paires substituts pour les points de code non-BMP. | Les noms restent bornés par `OS_NAME_MAX`, 13 unités UTF-16 par entrée et 20 entrées LFN. |
+| Runtime GGUF | Le chargement prépare la génération quantifiée Q3_K/Q4_K/Q6_K, le cache KV, puis exécute la génération échantillonnée top-k avec des espaces de travail caller-owned. | Les contraintes de taille du modèle et de capacité mémoire de la plateforme i386 demeurent inchangées. |
+
+## Preuves FAT32
+
+Les helpers [`lfn_utf8.h`](../kernel/fs/lfn_utf8.h) convertissent les noms UTF-8 validés vers UTF-16LE et reconstituent l’UTF-8 ; ils émettent et vérifient les paires substituts. Le module [`fat32.c`](../kernel/fs/fat32.c) compose ensuite ces helpers dans `fat32_create_lfn_file`, `fat32_read_file`, `fat32_rename_lfn_file`, `fat32_unlink_file` et `fat32_list_root`. Ces chemins demeurent déterministes : les buffers appartiennent à l’appelant et aucune allocation dynamique n’est introduite.
+
+La régression [`test_fat32.c`](../tests/unit/kernel/test_fat32.c) couvre les conversions UTF-8/UTF-16, l’encodage d’entrée, la création d’un nom long, la lecture par alias et par nom long, le listage, le renommage, la suppression, ainsi que les aller-retours UTF-8 BMP et non-BMP.
+
+> L’intégration FAT32 au VFS est volontairement conservée comme travail distinct : cette réconciliation ne transforme pas les primitives de volume caller-owned en backend VFS.
+
+## Preuves GGUF
+
+Le chargeur [`gpt2_gguf_loader.c`](../kernel/llm/gpt2_gguf_loader.c) valide les tenseurs Q3_K/Q4_K/Q6_K, prépare une structure de génération et exécute un token de génération avec cache KV. Le runtime [`gpt2_gguf_infer.c`](../kernel/llm/gpt2_gguf_infer.c) expose la génération échantillonnée, tandis que les interfaces syscall raccordent ce chemin à la session IA locale. La mention historique indiquant que la génération quantifiée était non livrée est donc supprimée.
+
+| Contrôle de non-régression | Portée |
+|---|---|
+| `test_fat32` | Contrats de volume, LFN UTF-8/UTF-16, cycle de vie du nom long. |
+| `test_gpt2_gguf` | Validation GGUF, préparation de génération et contraintes des tenseurs quantifiés. |
+| `test_gpt2_gguf_infer` | Exécution du chemin d’inférence GGUF. |
+| `make -s test-all` | Validation globale de tous les modules concernés et de leurs intégrations. |
+
+## Résultat
+
+Les descriptions historiques de limitations FAT32 LFN et GGUF ont été réconciliées avec le code exécutable. Les limitations toujours réelles — notamment le branchement FAT32 au VFS générique — restent explicitement documentées afin d’éviter de créer un faux état de complétude.
+
+## Références
+
+[1] [Conversion LFN UTF-8/UTF-16LE](../kernel/fs/lfn_utf8.h)
+
+[2] [Primitives FAT32 LFN](../kernel/fs/fat32.c)
+
+[3] [Tests FAT32 LFN](../tests/unit/kernel/test_fat32.c)
+
+[4] [Préparation et génération GPT-2 GGUF](../kernel/llm/gpt2_gguf_loader.c)
+
+[5] [Runtime d’inférence GPT-2 GGUF](../kernel/llm/gpt2_gguf_infer.c)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -58,7 +58,7 @@
 - [x] AOS-020…026 : sonde GGUF, BPE UTF-8, contrats QEMU, overlay V2, IRQ0, stub OpenAI, FAT16 lecture seule
 - [x] Kernels GGUF Q3_K/Q4_K/Q6_K, index, mapping, génération shell et échantillonnage local FAT16
 - [x] Réduire la latence locale GGUF ; le forward Q3_K réel sans branche, le cache KV, les lectures FAT16 inter-clusters et la session locale coopérative sont validés. Les essais supplémentaires de cache paresseux de constantes et de spécialisation Q3_K top-k n’ayant pas dépassé la variabilité QEMU TCG, l’axe est clôturé avec mesures et critères dans [aos1641_1648_gguf_latency_closure.md](aos1641_1648_gguf_latency_closure.md).
-- [x] Écriture FAT16 8.3, création de fichiers FAT32, écriture/chaînage FAT32, extension de racine et primitives LFN FAT32 — [aos_fat_volume.md](aos_fat_volume.md) ; intégration VFS complète, Unicode hors ASCII et suppression/renommage LFN restent à faire ; pas ext2
+- [x] Écriture FAT16 8.3, création de fichiers FAT32, écriture/chaînage FAT32, extension de racine et LFN FAT32 UTF-8 avec lecture, renommage et suppression — [aos_fat_volume.md](aos_fat_volume.md) ; l’intégration FAT32 au VFS reste distincte ; pas ext2
 - [x] Pilote NE2000 ISA et codecs ARP/IPv4/UDP/DHCP/DNS/TCP/TLS record (lots 113–154)
 - [x] Validation page-par-page des pointeurs socket utilisateur dans le VMM
 - [x] Reprise SSE fine avec `Last-Event-ID` et client OpenAI Chat Completions activable dans le shell ; campagne d’intégration réelle suspendue jusqu’à une clé API valide hors CI
@@ -136,6 +136,7 @@
 - [x] AOS-1949…1956 : captures QEMU GUI portables, saisie contrôlée avec reprise et validation shell/IA/NE2000 reproductible — [aos1949_1956_portable_gui_captures.md](aos1949_1956_portable_gui_captures.md)
 - [x] AOS-1957…1964 : réconciliation GGUF, validation `C/V/T` et axes de couches branchés aux kernels quantifiés caller-owned — [aos1957_1964_gguf_dimension_reconciliation.md](aos1957_1964_gguf_dimension_reconciliation.md)
 - [x] AOS-1965…1972 : rollback ELF transactionnel après restauration du VMM actif et restitution PMM des mappings partiels — [aos1965_1972_elf_transactional_rollback.md](aos1965_1972_elf_transactional_rollback.md)
+- [x] AOS-1973…1980 : réconciliation FAT32 LFN UTF-8 et runtime GGUF quantifié avec les capacités déjà couvertes par le code et les tests ; intégration FAT32 au VFS explicitement distincte — [aos1973_1980_fat32_gguf_reconciliation.md](aos1973_1980_fat32_gguf_reconciliation.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)
@@ -907,12 +908,12 @@ Le writer FAT32 caller-owned réalise une lecture-modification-écriture 28 bits
 Voir [aos1257_fat32_write_chain.md](aos1257_fat32_write_chain.md).
 
 ### AOS-1273 à AOS-1288 — données et entrée racine FAT32
-Le système écrit un cluster FAT32 caller-owned et publie une entrée racine 8.3 après validation du nom, de l’attribut, du cluster initial et de la taille. La recherche parcourt la chaîne racine sans allocation implicite. Validation historique du lot : **419 tests verts**. L’extension de la racine, la création transactionnelle et les primitives LFN bornées ont ensuite été livrées ; la publication multi-entrée LFN reste à faire.
+Le système écrit un cluster FAT32 caller-owned et publie une entrée racine 8.3 après validation du nom, de l’attribut, du cluster initial et de la taille. La recherche parcourt la chaîne racine sans allocation implicite. Validation historique du lot : **419 tests verts**. L’extension de la racine, la création transactionnelle et les primitives LFN bornées ont ensuite été livrées, y compris la publication multi-entrée, la lecture, le renommage et la suppression par nom long UTF-8.
 
 Voir [aos1273_fat32_data_root.md](aos1273_fat32_data_root.md).
 
 ### AOS-1289 à AOS-1304 — création transactionnelle de fichier FAT32
-`fat32_create_file` réserve, écrit et chaîne une ou plusieurs unités FAT32, puis publie l’entrée racine 8.3. Toute erreur libère la chaîne partielle dans toutes les FAT ; le buffer de données reste caller-owned. Validation historique du lot : **419 tests verts**. L’extension automatique de la racine et les primitives LFN bornées ont ensuite été livrées ; la publication de séquences LFN reste à faire.
+`fat32_create_file` réserve, écrit et chaîne une ou plusieurs unités FAT32, puis publie l’entrée racine 8.3. Toute erreur libère la chaîne partielle dans toutes les FAT ; le buffer de données reste caller-owned. Validation historique du lot : **419 tests verts**. L’extension automatique de la racine et les primitives LFN bornées ont ensuite été livrées, suivies par la publication de séquences multi-entrée, la lecture, le renommage et la suppression par nom long UTF-8.
 
 Voir [aos1289_fat32_create_file.md](aos1289_fat32_create_file.md).
 
@@ -922,7 +923,7 @@ Le répertoire racine FAT32 peut être étendu de façon caller-owned : le derni
 Voir [aos1305_fat32_root_extension.md](aos1305_fat32_root_extension.md).
 
 ### AOS-1321 à AOS-1332 — fondations LFN FAT32 bornées
-`fat32_lfn_checksum` calcule le checksum de l’alias 8.3 et `fat32_encode_lfn_entry` encode une entrée LFN de 32 octets en UTF-16LE ASCII borné, sans allocation dynamique. `fat32_create_lfn_file` publie désormais une séquence multi-entrée dans la chaîne racine, et `fat32_list_root` reconstruit le nom après validation des ordinals et du checksum dans un buffer caller-owned. Le contrat accepte au plus 13 caractères par entrée et 20 entrées par fichier, refuse les caractères non ASCII et conserve l’alias 8.3 en repli si la séquence est invalide. Validation actuelle : **4/4 tests FAT32** et **422 tests exécutés avec succès** ; l’intégration complète au VFS, Unicode hors ASCII et suppression/renommage LFN restent à réaliser.
+`fat32_lfn_checksum` calcule le checksum de l’alias 8.3 et `fat32_encode_lfn_entry` encode une entrée LFN de 32 octets en UTF-16LE sans allocation dynamique. `fat32_create_lfn_file` publie une séquence multi-entrée dans la chaîne racine, `fat32_list_root` reconstruit le nom dans un buffer caller-owned après validation des ordinals et du checksum, et la lecture, le renommage ainsi que la suppression reconnaissent les noms longs. Le contrat accepte au plus 13 unités UTF-16 par entrée et 20 entrées LFN par fichier, convertit les noms UTF-8 avec paires substituts et conserve l’alias 8.3 en repli si la séquence est invalide. Les tests couvrent la création, la lecture, le listage, le renommage, la suppression et les noms BMP/non-BMP ; seule l’intégration FAT32 au VFS reste distincte.
 
 Voir [aos1321_fat32_lfn.md](aos1321_fat32_lfn.md).
 


### PR DESCRIPTION
## Résumé

- réconcilie l’état réel et le backlog avec les LFN FAT32 UTF-8 déjà livrés : création, lecture, listage, renommage et suppression ;
- corrige l’affirmation historique sur l’absence de génération quantifiée GGUF et documente le runtime Q3_K/Q4_K/Q6_K ;
- préserve explicitement la limite réelle : le branchement du volume FAT32 au VFS générique reste distinct.

## Validation

- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` : noyau i386 compilé ;
- `git diff --check` et audit des formulations obsolètes : réussis.