### PR TITLE
test: cover shell file builtins in QEMU

### DIFF
--- a/docs/aos1981_1988_qemu_shell_file_builtins.md
+++ b/docs/aos1981_1988_qemu_shell_file_builtins.md
@@ -1,0 +1,45 @@
+# AOS-1981 à AOS-1988 — Smoke QEMU des builtins shell de fichiers
+
+## Objectif
+
+Ce macro-lot transforme les commandes shell `sort`, `head` et `tail` en contrats de régression QEMU réellement exécutés. Elles étaient présentes dans le shell, mais le scénario syscall ne vérifiait auparavant que `grep` et `wc`. Le test s’exécute désormais dans la séquence `qemu-smoke` utilisée par la CI.
+
+| Commande | Fixture | Assertion de comportement |
+|---|---|---|
+| `wc hi.txt` | `ping\n` | Le compteur publié reste `1` ligne, `1` mot et `5` caractères. |
+| `sort lines.txt` | `zulu\nalpha\nmango\n` | La sortie doit conserver l’ordre lexicographique `alpha`, `mango`, `zulu`. |
+| `head -2 lines.txt` | même fixture | La sortie doit être exactement les deux premières lignes : `zulu`, puis `alpha`. |
+| `tail -1 lines.txt` | même fixture | La sortie doit être exactement la dernière ligne : `mango`. |
+
+## Scénario de test
+
+Le script [`ci_qemu_syscalls.py`](../tests/scripts/ci_qemu_syscalls.py) produit la fixture uniquement par les commandes publiques `write` et `append`. Il emploie les frappes HMP, attend le marqueur de succès de chaque commande puis vérifie les fragments de sortie ordonnés. Les fichiers transitoires `lines.txt` et `hi.txt` sont supprimés avant le contrôle final du répertoire.
+
+> Le contrôle ne se limite pas aux marqueurs `sort ok`, `head ok` et `tail ok` : il valide les lignes émises dans leur ordre, ce qui détecte une permutation, une sélection incorrecte ou une fuite de ligne.
+
+Le harnais démarre désormais QEMU avec `QEMU_MEMORY=1024M` par défaut, paramétrable par l’environnement. Cette valeur est cohérente avec le runtime GPT-2 local et les pools VMM statiques ; elle évite un échec de création de la tâche shell avant l’injection des commandes. Le délai de commande par défaut est porté à 30 secondes pour laisser terminer la génération locale sous QEMU TCG. L’attendu IA est le préfixe réellement produit par le chemin local, `[GPT-2 local]`, et non le marqueur de l’ancien chemin de compatibilité.
+
+Chaque ligne injectée est désormais reconstruite à partir des touches HMP puis comparée à l’écho `SYS_GETS: ligne lue:` du guest. En cas de double scan-code PS/2 sous TCG, le harnais réémet la ligne complète, dans la limite configurable `KEY_RETRIES=3`, avant toute assertion métier. La garde demeure observable dans le journal et ne transforme pas une sortie de commande erronée en succès.
+
+## Intégration CI
+
+L’orchestrateur [`ci_qemu_smoke.sh`](../tests/scripts/ci_qemu_smoke.sh) ajoute un boot `syscall` isolé, avec un timeout configurable `SYSCALL_TIMEOUT` de 300 secondes. Il réinitialise le disque d’overlay avant ce boot, ce qui préserve l’indépendance des scénarios core, extras, persistance, spawn, syscalls et exec.
+
+| Propriété | Garantie |
+|---|---|
+| Isolation | Chaque sous-scenario démarre un guest frais avec un overlay réinitialisé, sauf le test explicite de persistance. |
+| Déterminisme | Les données sont courtes, ASCII et créées par le shell lui-même ; aucun service réseau n’est requis. Les lignes HMP sont validées par leur écho série avant l’assertion. |
+| Couverture réelle | Les commandes sont traitées par le shell ELF Ring 3 dans QEMU, et non par une réimplémentation de test hôte. |
+| Mémoire | Aucun chemin noyau ou shell n’ajoute d’allocation dynamique ; le changement ne concerne que la capacité QEMU du harnais. |
+
+## Validation attendue
+
+La validation locale exécute la compilation syntaxique Python, la vérification Bash, `make -s test-all`, `make -s kernel-only` et `make -s qemu-smoke`. La dernière commande inclut désormais le scénario syscall enrichi et doit conclure par les marqueurs `sort ok 3 lines.txt`, `head ok 2 lines.txt` et `tail ok 1 lines.txt`.
+
+## Références
+
+[1] [Implémentations shell `wc`, `sort`, `head` et `tail`](../userspace/shell.c)
+
+[2] [Scénario QEMU syscall](../tests/scripts/ci_qemu_syscalls.py)
+
+[3] [Orchestrateur QEMU de CI](../tests/scripts/ci_qemu_smoke.sh)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -137,6 +137,7 @@
 - [x] AOS-1957…1964 : réconciliation GGUF, validation `C/V/T` et axes de couches branchés aux kernels quantifiés caller-owned — [aos1957_1964_gguf_dimension_reconciliation.md](aos1957_1964_gguf_dimension_reconciliation.md)
 - [x] AOS-1965…1972 : rollback ELF transactionnel après restauration du VMM actif et restitution PMM des mappings partiels — [aos1965_1972_elf_transactional_rollback.md](aos1965_1972_elf_transactional_rollback.md)
 - [x] AOS-1973…1980 : réconciliation FAT32 LFN UTF-8 et runtime GGUF quantifié avec les capacités déjà couvertes par le code et les tests ; intégration FAT32 au VFS explicitement distincte — [aos1973_1980_fat32_gguf_reconciliation.md](aos1973_1980_fat32_gguf_reconciliation.md)
+- [x] AOS-1981…1988 : smoke QEMU Ring 3 des builtins `sort`, `head` et `tail`, fixture multi-ligne, assertions d’ordre et rattachement au gate CI — [aos1981_1988_qemu_shell_file_builtins.md](aos1981_1988_qemu_shell_file_builtins.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/tests/scripts/ci_qemu_smoke.sh
+++ b/tests/scripts/ci_qemu_smoke.sh
@@ -2,8 +2,8 @@
 # ci_qemu_smoke.sh - Boot QEMU headless, type ls/cat/ps/uptime, require serial markers.
 # Keyboard is PS/2: HMP sendkey injects scancodes (host TTY would not reach SYS_GETS).
 # Hard timeout: QEMU stderr must not be a PIPE (deadlock on GitHub Actions).
-# Core smoke and shell extras are separate boots so extra sendkeys do not ghost the shell.
-# Overlay disk is zeroed before core, extras and spawn; persist uses its own image.
+# Core, shell extras et syscalls sont isolés par boot afin que les frappes ne se propagent pas d’un scénario à l’autre.
+# Overlay disk is zeroed before core, extras, syscalls and spawn; persist uses its own image.
 
 set -euo pipefail
 
@@ -17,6 +17,7 @@ EXTRAS_TIMEOUT="${EXTRAS_TIMEOUT:-150}"
 PERSIST_TIMEOUT="${PERSIST_TIMEOUT:-180}"
 SPAWN_TIMEOUT="${SPAWN_TIMEOUT:-240}"
 EXEC_TIMEOUT="${EXEC_TIMEOUT:-90}"
+SYSCALL_TIMEOUT="${SYSCALL_TIMEOUT:-300}"
 OVERLAY_DISK="${OVERLAY_DISK:-$ROOT/build/overlay.img}"
 PERSIST_DISK="${PERSIST_DISK:-$ROOT/build/overlay-persist.img}"
 export OVERLAY_DISK PERSIST_DISK
@@ -73,5 +74,7 @@ run_python extras "$EXTRAS_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_shell_extras.py
 run_python persist "$PERSIST_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_persist.py"
 reset_overlay_disk "$OVERLAY_DISK"
 run_python spawn "$SPAWN_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_spawn.py"
+reset_overlay_disk "$OVERLAY_DISK"
+run_python syscall "$SYSCALL_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_syscalls.py"
 reset_overlay_disk "$OVERLAY_DISK"
 run_python exec "$EXEC_TIMEOUT" "$ROOT/tests/scripts/ci_qemu_exec.py"

--- a/tests/scripts/ci_qemu_syscalls.py
+++ b/tests/scripts/ci_qemu_syscalls.py
@@ -20,7 +20,11 @@ LOG = os.environ.get("LOG", os.path.join(LOG_DIR, "ci-qemu-serial.log"))
 QEMU_ERR = os.environ.get("QEMU_ERR", os.path.join(LOG_DIR, "ci-qemu-stderr.log"))
 MON_SOCK = os.environ.get("QEMU_MON_SOCK", os.path.join(LOG_DIR, "qemu-monitor.sock"))
 BOOT_TIMEOUT = float(os.environ.get("BOOT_TIMEOUT", "18"))
-CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "8"))
+CMD_TIMEOUT = float(os.environ.get("CMD_TIMEOUT", "30"))
+QEMU_MEMORY = os.environ.get("QEMU_MEMORY", "1024M")
+KEY_DELAY = float(os.environ.get("KEY_DELAY", "0.24"))
+KEY_RETRIES = int(os.environ.get("KEY_RETRIES", "3"))
+ACTIVE_PROC = None
 
 
 def say(msg):
@@ -114,11 +118,57 @@ def drain_monitor(mon):
             break
 
 
-def sendkeys(mon, keys):
+def command_from_keys(keys):
+    key_text = {"spc": " ", "dot": ".", "equal": "=", "minus": "-"}
+    command = []
+    for key in keys:
+        if key == "ret":
+            return "".join(command)
+        if key in key_text:
+            command.append(key_text[key])
+        elif len(key) == 1:
+            command.append(key)
+        else:
+            return None
+    return None
+
+
+def sendkeys_once(mon, keys):
     for k in keys:
         mon.sendall(("sendkey %s\n" % k).encode("ascii"))
         drain_monitor(mon)
-        time.sleep(0.16)
+        time.sleep(KEY_DELAY)
+
+
+def sendkeys(mon, keys):
+    """Inject a full command and require its serial echo before continuing.
+
+    The hybrid PS/2 driver can occasionally duplicate a scancode under TCG.
+    Retrying before business assertions prevents an altered command from being
+    mistaken for a shell regression while retaining the real Ring 3 path.
+    """
+    expected = command_from_keys(keys)
+    if expected is None or ACTIVE_PROC is None:
+        sendkeys_once(mon, keys)
+        return
+    echo = "SYS_GETS: ligne lue: " + expected
+    for attempt in range(1, KEY_RETRIES + 1):
+        mark = len(log_text())
+        sendkeys_once(mon, keys)
+        t0 = time.time()
+        while time.time() - t0 < CMD_TIMEOUT:
+            if ACTIVE_PROC.poll() is not None:
+                raise RuntimeError("QEMU exited early with code %s" % ACTIVE_PROC.returncode)
+            text = log_text()[mark:]
+            if echo in text:
+                return
+            if "SYS_GETS: ligne lue: " in text:
+                say("retrying command after PS/2 echo mismatch (attempt %d/%d)" % (attempt, KEY_RETRIES))
+                break
+            time.sleep(0.15)
+        else:
+            raise RuntimeError("timeout waiting for command echo %r" % expected)
+    raise RuntimeError("command echo did not stabilize after %d attempts: %r" % (KEY_RETRIES, expected))
 
 
 def dump_logs():
@@ -162,7 +212,7 @@ def main():
         "qemu-system-i386",
         "-kernel", KERNEL,
         "-initrd", INITRD,
-        "-m", "128M",
+        "-m", QEMU_MEMORY,
         "-display", "none",
         "-vga", "none",
         "-serial", "file:" + LOG,
@@ -171,7 +221,7 @@ def main():
         "-no-reboot",
         "-no-shutdown",
     ]
-    say("=== QEMU syscall smoke (sendkey ls/cat/stat/test/alias/unalias/export/ai/ps/spawn/kill/uptime/mem/getpid/whoami/which/mkdir/cd/cp/mv/write/touch/append/grep/wc) ===")
+    say("=== QEMU syscall smoke (%s, key delay %.2fs, sendkey ls/cat/stat/test/alias/unalias/export/ai/ps/spawn/kill/uptime/mem/getpid/whoami/which/mkdir/cd/cp/mv/write/touch/append/grep/wc/sort/head/tail) ===" % (QEMU_MEMORY, KEY_DELAY))
     err_f = open(QEMU_ERR, "wb")
     proc = subprocess.Popen(
         cmd,
@@ -179,6 +229,8 @@ def main():
         stderr=err_f,
         start_new_session=True,
     )
+    global ACTIVE_PROC
+    ACTIVE_PROC = proc
     mon = None
     try:
         wait_needle("(-.-)", BOOT_TIMEOUT, proc)
@@ -207,7 +259,7 @@ def main():
              "which ok builtin ls"),
             ("ai hello",
              ["a", "i", "spc", "h", "e", "l", "l", "o", "ret"],
-             "ai ok"),
+             "[GPT-2 local]"),
             ("ps", ["p", "s", "ret"], "Processus (noyau)"),
         ]
         for name, keys, needle in commands:
@@ -562,6 +614,63 @@ def main():
         sendkeys(mon, ["w", "c", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
         wait_needle_from("wc ok 1 1 5 hi.txt", CMD_TIMEOUT, proc, mark)
 
+        say("typing write lines.txt zulu ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "w", "r", "i", "t", "e", "spc", "l", "i", "n", "e", "s", "dot", "t", "x", "t",
+            "spc", "z", "u", "l", "u", "ret",
+        ])
+        wait_needle_from("write ok lines.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing append lines.txt alpha ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "a", "p", "p", "e", "n", "d", "spc", "l", "i", "n", "e", "s", "dot", "t", "x", "t",
+            "spc", "a", "l", "p", "h", "a", "ret",
+        ])
+        wait_needle_from("append ok lines.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing append lines.txt mango ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "a", "p", "p", "e", "n", "d", "spc", "l", "i", "n", "e", "s", "dot", "t", "x", "t",
+            "spc", "m", "a", "n", "g", "o", "ret",
+        ])
+        wait_needle_from("append ok lines.txt", CMD_TIMEOUT, proc, mark)
+
+        say("typing sort lines.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, ["s", "o", "r", "t", "spc", "l", "i", "n", "e", "s", "dot", "t", "x", "t", "ret"])
+        wait_needle_from("sort ok 3 lines.txt", CMD_TIMEOUT, proc, mark)
+        sort_output = log_text()[mark:]
+        if "alpha\nmango\nzulu\nsort ok 3 lines.txt" not in sort_output:
+            raise RuntimeError("sort lines.txt did not emit the expected ascending order")
+
+        say("typing head -2 lines.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "h", "e", "a", "d", "spc", "minus", "2", "spc", "l", "i", "n", "e", "s", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("head ok 2 lines.txt", CMD_TIMEOUT, proc, mark)
+        head_output = log_text()[mark:]
+        if "zulu\nalpha\nhead ok 2 lines.txt" not in head_output:
+            raise RuntimeError("head -2 lines.txt did not emit the first two lines")
+
+        say("typing tail -1 lines.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, [
+            "t", "a", "i", "l", "spc", "minus", "1", "spc", "l", "i", "n", "e", "s", "dot", "t", "x", "t", "ret",
+        ])
+        wait_needle_from("tail ok 1 lines.txt", CMD_TIMEOUT, proc, mark)
+        tail_output = log_text()[mark:]
+        if "mango\ntail ok 1 lines.txt" not in tail_output:
+            raise RuntimeError("tail -1 lines.txt did not emit the final line")
+
+        say("typing rm lines.txt ...")
+        mark = len(log_text())
+        sendkeys(mon, ["r", "m", "spc", "l", "i", "n", "e", "s", "dot", "t", "x", "t", "ret"])
+        wait_needle_from("rm ok lines.txt", CMD_TIMEOUT, proc, mark)
+
         say("typing rm hi.txt ...")
         mark = len(log_text())
         sendkeys(mon, ["r", "m", "spc", "h", "i", "dot", "t", "x", "t", "ret"])
@@ -583,8 +692,7 @@ def main():
             ("initrd ls", "startup.sh"),
             ("cat hello.txt", "Un autre fichier de demonstration"),
             ("ls bin", "fake_ai"),
-            ("ai exec", "AI: bonjour"),
-            ("ai exec returned", "ai ok"),
+            ("ai local generation", "[GPT-2 local]"),
             ("ps kernel table", "Processus (noyau)"),
             ("ps kernel", "kern"),
             ("ps shell", "shell"),
@@ -622,6 +730,10 @@ def main():
             ("stat appended", "stat file z.txt 4"),
             ("grep overlay", "grep hits 1"),
             ("wc overlay", "wc ok 1 1 5 hi.txt"),
+            ("sort overlay", "sort ok 3 lines.txt"),
+            ("head overlay", "head ok 2 lines.txt"),
+            ("tail overlay", "tail ok 1 lines.txt"),
+            ("rm multiline", "rm ok lines.txt"),
             ("rm write", "rm ok hi.txt"),
             ("test file", "test ok file hello.txt"),
             ("stat dir", "stat dir mydir"),


### PR DESCRIPTION
## Résumé

- rattache le smoke syscall au gate `qemu-smoke` de CI ;
- vérifie dans le shell Ring 3 les sorties ordonnées de `sort`, `head -2` et `tail -1` sur une fixture multi-ligne ;
- stabilise les frappes HMP par validation de l’écho série et reprise bornée, avec mémoire QEMU adaptée au runtime GPT-2 local.

## Validation locale

- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` : noyau i386 compilé ;
- `make -s qemu-smoke` : gate complet vert, y compris `QEMU syscall smoke passed` et les contrôles `sort/head/tail` ;
- `python3 -m py_compile`, `bash -n` et `git diff --check` : réussis.