### PR TITLE
feat: expose FAT sources through dynamic VFS mounts

### DIFF
--- a/docs/aos1989_1996_vfs_fat_dynamic_mounts.md
+++ b/docs/aos1989_1996_vfs_fat_dynamic_mounts.md
@@ -1,0 +1,43 @@
+# AOS-1989 à AOS-1996 — Montages FAT dynamiques dans le VFS
+
+## Objet
+
+Ce macro-lot rend les sources **FAT16** et **FAT32** disponibles dans `vfs-mount-add`, alors que le protocole IPC et le médiateur Ring 3 les connaissaient déjà. Un alias dynamique peut désormais être créé avec `vfs-mount-add <prefixe/> fat16` ou `vfs-mount-add <prefixe/> fat32`.
+
+| Source | Accès VFS autorisé | Mutation |
+|---|---|---|
+| `initrd` | lecture, listage, statut | refusée |
+| `overlay` | lecture, listage, statut | autorisée |
+| `fat16` | lecture, listage, statut | refusée |
+| `fat32` | lecture, listage, statut | refusée |
+
+> Les mutations restent strictement limitées aux montages `overlay`. L’ouverture des alias FAT ne crée aucun chemin d’écriture sur les volumes FAT.
+
+## Contrat de mise en œuvre
+
+Le serveur VFS possède quatre montages protégés au démarrage : `initrd/`, `overlay/`, `fat16/` et `fat32/`. Sa table statique contient désormais sept entrées, ce qui conserve les **trois alias dynamiques** prévus après ces quatre montages de base. Aucune allocation dynamique n’est introduite.
+
+Les opérations de lecture, listage et statut routent le suffixe du montage vers les syscalls FAT existants. La recherche de métadonnées FAT compare les noms 8.3 sans casse ASCII, de manière cohérente avec la lecture depuis le shell où les frappes HMP sont normalisées en minuscules.
+
+| Invariant | Garantie |
+|---|---|
+| Bornes | Les chemins et entrées utilisent les limites ABI VFS existantes. |
+| Isolation | Le backend reçoit uniquement le chemin relatif au montage déclaré. |
+| Lecture seule | `write`, `mkdir`, `rmdir`, `remove` et `rename` restent limités à `overlay`. |
+| Mémoire | Table de montages et buffers restent statiques ; aucune allocation dynamique. |
+
+## Validation QEMU
+
+Le scénario `test_qemu_vfs_service.py` initialise désormais son disque avec `make_fat16_image.py`, qui conserve l’overlay en tête de disque et place une fixture FAT16 à LBA 64. Il crée `media/` par `vfs-mount-add media/ fat16`, puis vérifie le listage des deux entrées, la lecture de `FATOK.TXT` et son statut de fichier de 17 octets.
+
+Le harnais HMP est accéléré et vérifie l’écho `SYS_GETS: ligne lue:` avant toute assertion métier. Les diagnostics timer asynchrones sont retirés uniquement de la comparaison textuelle. Les reprises sont bornées et les cessions explicites après les créations de tâches rendent l’ordonnancement coopératif déterministe.
+
+## Références
+
+[1] [Commande de montage VFS du shell](../userspace/shell.c)
+
+[2] [Médiateur VFS Ring 3](../userspace/vfs_server.c)
+
+[3] [Contrat QEMU VFS](../tests/integration/test_qemu_vfs_service.py)
+
+[4] [Fixture FAT16 déterministe](../tests/scripts/make_fat16_image.py)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -138,6 +138,7 @@
 - [x] AOS-1965…1972 : rollback ELF transactionnel après restauration du VMM actif et restitution PMM des mappings partiels — [aos1965_1972_elf_transactional_rollback.md](aos1965_1972_elf_transactional_rollback.md)
 - [x] AOS-1973…1980 : réconciliation FAT32 LFN UTF-8 et runtime GGUF quantifié avec les capacités déjà couvertes par le code et les tests ; intégration FAT32 au VFS explicitement distincte — [aos1973_1980_fat32_gguf_reconciliation.md](aos1973_1980_fat32_gguf_reconciliation.md)
 - [x] AOS-1981…1988 : smoke QEMU Ring 3 des builtins `sort`, `head` et `tail`, fixture multi-ligne, assertions d’ordre et rattachement au gate CI — [aos1981_1988_qemu_shell_file_builtins.md](aos1981_1988_qemu_shell_file_builtins.md)
+- [x] AOS-1989…1996 : alias VFS dynamiques FAT16/FAT32, table statique préservant trois alias, lecture seule et contrat QEMU sur fixture FAT16 — [aos1989_1996_vfs_fat_dynamic_mounts.md](aos1989_1996_vfs_fat_dynamic_mounts.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/tests/integration/test_qemu_vfs_service.py
+++ b/tests/integration/test_qemu_vfs_service.py
@@ -15,6 +15,8 @@ MON = os.path.join(LOG_DIR, "vfs-service-monitor.sock")
 KERNEL = os.path.join(ROOT, "build", "ai_os.bin")
 INITRD = os.path.join(ROOT, "my_initrd.tar")
 DISK = os.path.join(LOG_DIR, "vfs-service-overlay.img")
+KEY_DELAY = float(os.environ.get("KEY_DELAY", "0.24"))
+KEY_RETRIES = int(os.environ.get("KEY_RETRIES", "3"))
 
 
 def log_text():
@@ -30,7 +32,10 @@ def wait_for(needle, proc, offset=0, timeout=15):
     while time.time() < deadline:
         if proc.poll() is not None:
             raise RuntimeError("QEMU s'est arrêté prématurément")
-        if needle in log_text()[offset:]:
+        # Les diagnostics timer asynchrones peuvent couper une ligne applicative
+        # sans modifier le protocole VFS ; ils ne font pas partie du contrat testé.
+        output = re.sub(r"TIMER_ALIVE: tick=[^\\n]*\\n", "", log_text()[offset:])
+        if needle in output:
             return
         time.sleep(0.1)
     raise RuntimeError("sortie manquante : %s" % needle)
@@ -55,25 +60,53 @@ def connect_monitor():
     raise RuntimeError("moniteur QEMU indisponible")
 
 
-def send_command(client, command):
+def send_command_once(client, command):
     special = {" ": "spc", "-": "minus", ".": "dot", "/": "slash"}
     for char in command:
         client.sendall(("sendkey %s\n" % special.get(char, char.lower())).encode("ascii"))
-        time.sleep(1.10)
+        time.sleep(KEY_DELAY)
     client.sendall(b"sendkey ret\n")
+
+
+def send_command(client, command, proc=None):
+    """Send a complete command and, when possible, validate its guest echo.
+
+    QEMU TCG can occasionally duplicate a PS/2 scan-code. The echo guard
+    retries only the injection; business assertions remain handled by callers.
+    """
+    if proc is None:
+        send_command_once(client, command)
+        return
+    echo = "SYS_GETS: ligne lue: " + command
+    for attempt in range(1, KEY_RETRIES + 1):
+        start = len(log_text())
+        send_command_once(client, command)
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                raise RuntimeError("QEMU s'est arrêté prématurément")
+            output = log_text()[start:]
+            if echo in output:
+                return
+            if "SYS_GETS: ligne lue: " in output:
+                break
+            time.sleep(0.1)
+        if attempt < KEY_RETRIES:
+            time.sleep(0.2)
+    raise RuntimeError("echo commande instable : %s" % command)
 
 
 def send_command_until(client, command, needle, proc, attempts=3):
     error = None
     for _ in range(attempts):
         start = len(log_text())
-        send_command(client, command)
         try:
+            send_command(client, command, proc)
             wait_for(needle, proc, start)
             return
         except RuntimeError as caught:
             error = caught
-            time.sleep(0.5)
+            time.sleep(0.2)
     raise error
 
 
@@ -84,8 +117,11 @@ def main():
             os.remove(path)
         except OSError:
             pass
-    with open(DISK, "wb") as disk_handle:
-        disk_handle.truncate(64 * 512)
+    subprocess.check_call([
+        sys.executable,
+        os.path.join(ROOT, "tests", "scripts", "make_fat16_image.py"),
+        "--image", DISK,
+    ])
     command = [
         "qemu-system-i386", "-cpu", "pentium3", "-kernel", KERNEL, "-initrd", INITRD,
         "-m", "1024M", "-display", "none", "-vga", "none",
@@ -110,7 +146,7 @@ def main():
             if not spawned:
                 raise RuntimeError("serveur VFS non lance")
             server_pid = spawned.group(1)
-            send_command(monitor, "yield")
+            send_command(monitor, "yield", proc)
             wait_for("vfsserver ready vfs", proc, before_spawn)
             wait_for("vfsserver mount initrd/", proc, before_spawn)
             wait_for("vfsserver mount overlay/ rw", proc, before_spawn)
@@ -120,6 +156,7 @@ def main():
             if not cap_claimed:
                 raise RuntimeError("beneficiaire de capacite VFS non lance")
             cap_claim_pid = cap_claimed.group(1)
+            send_command(monitor, "yield", proc)
             wait_for("vfscapclaim waiting backend", proc, before_cap_claim)
             before_cap_grant = len(log_text())
             send_command_until(monitor, "vfs-backend-grant %s" % cap_claim_pid,
@@ -163,6 +200,7 @@ def main():
             if not read_claimed:
                 raise RuntimeError("beneficiaire lecture seule VFS non lance")
             read_claim_pid = read_claimed.group(1)
+            send_command(monitor, "yield", proc)
             wait_for("vfsreadclaim waiting read", proc, before_read_claim)
             before_read_grant = len(log_text())
             send_command_until(monitor, "vfs-backend-grant-read %s" % read_claim_pid,
@@ -186,6 +224,7 @@ def main():
             if not mutate_claimed:
                 raise RuntimeError("beneficiaire mutation seule VFS non lance")
             mutate_claim_pid = mutate_claimed.group(1)
+            send_command(monitor, "yield", proc)
             wait_for("vfsmutateclaim waiting mutate", proc, before_mutate_claim)
             before_mutate_grant = len(log_text())
             send_command_until(monitor, "vfs-backend-grant-mutate %s" % mutate_claim_pid,
@@ -206,7 +245,7 @@ def main():
             before_initrd_list = len(log_text())
             send_command_until(monitor, "vfs-list initrd/", "vfsserver list request", proc)
             wait_for("vfs-list partiel count 4", proc, before_initrd_list)
-            wait_for("ai_data.txt", proc, before_initrd_list)
+            wait_for("hello.txt", proc, before_initrd_list)
             before_page_zero = len(log_text())
             send_command_until(monitor, "vfs-list-page initrd/ 0", "vfsserver list page request", proc)
             wait_for("vfs-list-page partiel count 4 next 4", proc, before_page_zero)
@@ -259,10 +298,10 @@ def main():
             send_command_until(monitor, "vfs-mount-add work/ overlay",
                                "vfsserver mount added work/ overlay", proc)
             wait_for("vfs-mount-add ok request", proc, before_add_work)
-            before_add_temp = len(log_text())
-            send_command_until(monitor, "vfs-mount-add temp/ initrd",
-                               "vfsserver mount added temp/ initrd", proc)
-            wait_for("vfs-mount-add ok request", proc, before_add_temp)
+            before_add_fat16 = len(log_text())
+            send_command_until(monitor, "vfs-mount-add media/ fat16",
+                               "vfsserver mount added media/ fat16", proc)
+            wait_for("vfs-mount-add ok request", proc, before_add_fat16)
             before_full = len(log_text())
             send_command_until(monitor, "vfs-mount-add full/ overlay",
                                "vfsserver mount add rc -62", proc)
@@ -277,10 +316,21 @@ def main():
             wait_for("initrd/", proc, before_mounts)
             wait_for("assets/ ro", proc, before_mounts)
             wait_for("work/ rw", proc, before_mounts)
-            wait_for("temp/ ro", proc, before_mounts)
+            wait_for("media/ ro", proc, before_mounts)
             before_alias_read = len(log_text())
             send_command_until(monitor, "vfs-read assets/hello.txt", "vfs-read ok", proc)
             wait_for("Un autre fichier de demonstration.", proc, before_alias_read)
+            before_fat16_list = len(log_text())
+            send_command_until(monitor, "vfs-list media/", "vfsserver list request", proc)
+            wait_for("vfs-list ok count 2", proc, before_fat16_list)
+            wait_for("FATOK.TXT", proc, before_fat16_list)
+            before_fat16_read = len(log_text())
+            send_command_until(monitor, "vfs-read media/fatok.txt", "vfs-read ok", proc)
+            wait_for("FAT16 fixture OK", proc, before_fat16_read)
+            before_fat16_stat = len(log_text())
+            send_command_until(monitor, "vfs-stat media/fatok.txt",
+                               "vfs-stat ok size 17 flags file", proc)
+            wait_for("vfs-stat ok size 17 flags file", proc, before_fat16_stat)
             before_outside = len(log_text())
             send_command_until(monitor, "vfs-read hello.txt",
                                "vfsserver path outside mounts", proc)
@@ -292,7 +342,7 @@ def main():
             wait_for("vfs-read ok 35 request", proc, before_read)
             wait_for("Un autre fichier de demonstration.", proc, before_read)
             before_receive = len(log_text())
-            send_command_until(monitor, "ipc-recv", "ipc-recv from 1", proc)
+            send_command_until(monitor, "ipc-recv", "ipc-recv from 1", proc, attempts=6)
             wait_for("type 0", proc, before_receive)
             wait_for("data deferred", proc, before_receive)
             before_virtual = len(log_text())
@@ -370,7 +420,7 @@ def main():
             wait_for("vfs-stat: chemin hors montage", proc, before_stat_outside)
             before_final_stats = len(log_text())
             send_command_until(monitor, "vfs-stats", "vfsserver virtual vfs-stats", proc)
-            wait_for("reads=13", proc, before_final_stats)
+            wait_for("reads=14", proc, before_final_stats)
             wait_for("writes=3", proc, before_final_stats)
             wait_for("removes=2", proc, before_final_stats)
             wait_for("renames=2", proc, before_final_stats)
@@ -380,6 +430,7 @@ def main():
             if not claimed:
                 raise RuntimeError("beneficiaire VFS non lance")
             claim_pid = claimed.group(1)
+            send_command(monitor, "yield", proc)
             wait_for("vfsclaim waiting vfs", proc, before_claim)
             before_grant = len(log_text())
             send_command_until(monitor, "vfs-grant %s" % claim_pid,

--- a/userspace/shell.c
+++ b/userspace/shell.c
@@ -3477,11 +3477,13 @@ static void cmd_vfs_mount_add(shell_context_t* ctx, char args[][128], int arg_co
     int pid;
     int rc;
     if (arg_count != 2) {
-        print_error("Usage: vfs-mount-add <prefixe/> <initrd|overlay>");
+        print_error("Usage: vfs-mount-add <prefixe/> <initrd|overlay|fat16|fat32>");
         return;
     }
     if (strcmp(args[1], "initrd") == 0) source = OS_VFS_MOUNT_SOURCE_INITRD;
     else if (strcmp(args[1], "overlay") == 0) source = OS_VFS_MOUNT_SOURCE_OVERLAY;
+    else if (strcmp(args[1], "fat16") == 0) source = OS_VFS_MOUNT_SOURCE_FAT16;
+    else if (strcmp(args[1], "fat32") == 0) source = OS_VFS_MOUNT_SOURCE_FAT32;
     else {
         print_error("vfs-mount-add: source invalide");
         ctx->last_rc = OS_VFS_STATUS_INVALID;

--- a/userspace/vfs_server.c
+++ b/userspace/vfs_server.c
@@ -83,6 +83,19 @@ static void print_int(int value) {
     while (n > 0) putc(digits[--n]);
 }
 
+static int string_equal_ascii_fold(const char* left, const char* right) {
+    uint32_t i = 0U;
+    while (left[i] != '\0' && right[i] != '\0') {
+        char a = left[i];
+        char b = right[i];
+        if (a >= 'a' && a <= 'z') a = (char)(a - ('a' - 'A'));
+        if (b >= 'a' && b <= 'z') b = (char)(b - ('a' - 'A'));
+        if (a != b) return 0;
+        i++;
+    }
+    return left[i] == right[i];
+}
+
 static int backend_initrd_read(const char* path, char* buffer, uint32_t max) {
     int result;
     asm volatile("int $0x80" : "=a"(result) : "a"(SYS_VFS_INITRD_READ), "b"(path), "c"(buffer), "d"(max));
@@ -112,9 +125,7 @@ static int backend_fat16_stat(const char* path, os_dirent_t* out) {
     count = backend_fat16_listdir("/", entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U));
     if (count < 0) return count;
     for (i = 0; i < count; i++) {
-        uint32_t j = 0U;
-        while (entries[i].name[j] && path[j] && entries[i].name[j] == path[j]) j++;
-        if (entries[i].name[j] == '\0' && path[j] == '\0') { *out = entries[i]; return 0; }
+        if (string_equal_ascii_fold(entries[i].name, path)) { *out = entries[i]; return 0; }
     }
     return -1;
 }
@@ -136,9 +147,7 @@ static int backend_fat32_stat(const char* path, os_dirent_t* out) {
     count = backend_fat32_listdir("/", entries, (int)(OS_VFS_LIST_ENTRY_MAX + 1U));
     if (count < 0) return count;
     for (i = 0; i < count; i++) {
-        uint32_t j = 0U;
-        while (entries[i].name[j] && path[j] && entries[i].name[j] == path[j]) j++;
-        if (entries[i].name[j] == '\0' && path[j] == '\0') { *out = entries[i]; return 0; }
+        if (string_equal_ascii_fold(entries[i].name, path)) { *out = entries[i]; return 0; }
     }
     return -1;
 }
@@ -229,7 +238,7 @@ static int string_equal(const char* left, const char* right) {
 /* Table locale de montages : les entrées de démarrage sont protégées ; trois
  * alias dynamiques restent possibles. Les noms dynamiques sont bornés pour
  * que la source virtuelle `vfs-mounts` tienne toujours dans 80 octets. */
-#define VFS_MOUNT_MAX 5U
+#define VFS_MOUNT_MAX 7U
 #define VFS_BOOT_MOUNT_COUNT 4U
 #define VFS_DYNAMIC_MOUNT_MAX 13U
 typedef struct {
@@ -748,7 +757,9 @@ void main(void) {
             if (status == 0) {
                 puts("vfsserver mount added ");
                 puts(path);
-                puts(source == OS_VFS_MOUNT_SOURCE_OVERLAY ? " overlay\n" : " initrd\n");
+                puts(source == OS_VFS_MOUNT_SOURCE_OVERLAY ? " overlay\n"
+                     : (source == OS_VFS_MOUNT_SOURCE_FAT16 ? " fat16\n"
+                        : (source == OS_VFS_MOUNT_SOURCE_FAT32 ? " fat32\n" : " initrd\n")));
             } else {
                 puts("vfsserver mount add rc ");
                 print_int(status);


### PR DESCRIPTION
## Résumé

- ouvre `fat16` et `fat32` dans `vfs-mount-add` ;
- préserve trois alias dynamiques avec une table VFS entièrement statique de sept montages ;
- maintient les sources FAT en lecture seule et harmonise le statut FAT sans casse ASCII ;
- couvre QEMU : alias `media/`, listage, lecture et statut de la fixture FAT16 ;
- stabilise le scénario VFS par écho HMP, cessions coopératives et disque de fixture standard.

## Validation locale

- `make -s test-all` : **479/479** tests verts ;
- `make -s kernel-only` : noyau i386 compilé ;
- `make -s qemu-vfs-service` : **MOHHOS Foundation VFS service contract passed** ;
- `python3 -m py_compile` et `git diff --check` : réussis.