### PR TITLE
test: cover FAT32 VFS mount in QEMU

### DIFF
--- a/docs/aos1997_2004_vfs_fat32_secondary.md
+++ b/docs/aos1997_2004_vfs_fat32_secondary.md
@@ -1,0 +1,20 @@
+# AOS-1997 à AOS-2004 — VFS FAT32 secondaire multi-disque
+
+Le contrat QEMU VFS démarre désormais deux disques IDE déterministes : une image FAT16 primaire contenant l’overlay à LBA 0 et sa fixture à LBA 64, ainsi qu’une image FAT32 secondaire montée par le noyau sur le canal esclave. Le scénario crée les alias `media/` (FAT16) et `media32/` (FAT32), puis vérifie pour chacun le listage, la lecture et le statut d’un fichier réel.
+
+| Alias | Fixture | Contrôles |
+|---|---|---|
+| `media/` | `FATOK.TXT`, 17 octets | listage, lecture, statut sans casse |
+| `media32/` | `FAT32OK.TXT`, 27 octets | listage, lecture, statut sans casse |
+
+La table de montages VFS est statique et contient huit entrées : quatre sources protégées et quatre alias dynamiques. La vue virtuelle `vfs-mounts` reste strictement bornée à `OS_VFS_READ_MAX` ; les entrées qui ne tiennent pas sont omises sans écriture hors borne. Les mutations restent limitées à l’overlay.
+
+Les assertions de statistiques de synthèse vérifient la publication des compteurs, tandis que les opérations de lecture, statut et mutation possèdent chacune leur assertion fonctionnelle directe. Cette distinction évite de confondre les reprises de commandes du clavier HMP avec la validité des parcours VFS.
+
+## Références
+
+[1] [Médiateur VFS Ring 3](../userspace/vfs_server.c)
+
+[2] [Contrat QEMU VFS multi-disque](../tests/integration/test_qemu_vfs_service.py)
+
+[3] [Constructeur FAT32 secondaire](../scripts/make_fat32_secondary_image.py)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -139,6 +139,7 @@
 - [x] AOS-1973…1980 : réconciliation FAT32 LFN UTF-8 et runtime GGUF quantifié avec les capacités déjà couvertes par le code et les tests ; intégration FAT32 au VFS explicitement distincte — [aos1973_1980_fat32_gguf_reconciliation.md](aos1973_1980_fat32_gguf_reconciliation.md)
 - [x] AOS-1981…1988 : smoke QEMU Ring 3 des builtins `sort`, `head` et `tail`, fixture multi-ligne, assertions d’ordre et rattachement au gate CI — [aos1981_1988_qemu_shell_file_builtins.md](aos1981_1988_qemu_shell_file_builtins.md)
 - [x] AOS-1989…1996 : alias VFS dynamiques FAT16/FAT32, table statique préservant trois alias, lecture seule et contrat QEMU sur fixture FAT16 — [aos1989_1996_vfs_fat_dynamic_mounts.md](aos1989_1996_vfs_fat_dynamic_mounts.md)
+- [x] AOS-1997…2004 : VFS QEMU multi-disque avec fixtures FAT16/FAT32, quatre alias dynamiques statiques et contrôles de lecture, listage et statut — [aos1997_2004_vfs_fat32_secondary.md](aos1997_2004_vfs_fat32_secondary.md)
 - [x] Contrats QEMU dans `tests/integration` (cœur, IRQ0, fournisseur, NE2000, IPC, VFS, services)
 
 ## Phase 6: Tests finaux et soumission sur GitHub ✅ (août 2026)

--- a/tests/integration/test_qemu_vfs_service.py
+++ b/tests/integration/test_qemu_vfs_service.py
@@ -15,6 +15,7 @@ MON = os.path.join(LOG_DIR, "vfs-service-monitor.sock")
 KERNEL = os.path.join(ROOT, "build", "ai_os.bin")
 INITRD = os.path.join(ROOT, "my_initrd.tar")
 DISK = os.path.join(LOG_DIR, "vfs-service-overlay.img")
+FAT32_DISK = os.path.join(LOG_DIR, "vfs-service-fat32.img")
 KEY_DELAY = float(os.environ.get("KEY_DELAY", "0.24"))
 KEY_RETRIES = int(os.environ.get("KEY_RETRIES", "3"))
 
@@ -112,7 +113,7 @@ def send_command_until(client, command, needle, proc, attempts=3):
 
 def main():
     os.makedirs(LOG_DIR, exist_ok=True)
-    for path in (LOG, ERR, MON, DISK):
+    for path in (LOG, ERR, MON, DISK, FAT32_DISK):
         try:
             os.remove(path)
         except OSError:
@@ -122,13 +123,19 @@ def main():
         os.path.join(ROOT, "tests", "scripts", "make_fat16_image.py"),
         "--image", DISK,
     ])
+    subprocess.check_call([
+        sys.executable,
+        os.path.join(ROOT, "scripts", "make_fat32_secondary_image.py"),
+        "--image", FAT32_DISK,
+    ])
     command = [
         "qemu-system-i386", "-cpu", "pentium3", "-kernel", KERNEL, "-initrd", INITRD,
         "-m", "1024M", "-display", "none", "-vga", "none",
         "-serial", "file:" + LOG,
         "-monitor", "unix:%s,server,nowait" % MON,
         "-machine", "type=pc,accel=tcg", "-no-reboot", "-no-shutdown",
-        "-drive", "file=%s,format=raw,if=ide,cache=writethrough" % DISK,
+        "-drive", "file=%s,format=raw,if=ide,index=0,cache=writethrough" % DISK,
+        "-drive", "file=%s,format=raw,if=ide,index=1,cache=writethrough" % FAT32_DISK,
     ]
     with open(ERR, "wb") as err_handle:
         proc = subprocess.Popen(command, stdout=err_handle, stderr=err_handle)
@@ -298,6 +305,10 @@ def main():
             send_command_until(monitor, "vfs-mount-add work/ overlay",
                                "vfsserver mount added work/ overlay", proc)
             wait_for("vfs-mount-add ok request", proc, before_add_work)
+            before_add_fat32 = len(log_text())
+            send_command_until(monitor, "vfs-mount-add media32/ fat32",
+                               "vfsserver mount added media32/ fat32", proc)
+            wait_for("vfs-mount-add ok request", proc, before_add_fat32)
             before_add_fat16 = len(log_text())
             send_command_until(monitor, "vfs-mount-add media/ fat16",
                                "vfsserver mount added media/ fat16", proc)
@@ -316,7 +327,7 @@ def main():
             wait_for("initrd/", proc, before_mounts)
             wait_for("assets/ ro", proc, before_mounts)
             wait_for("work/ rw", proc, before_mounts)
-            wait_for("media/ ro", proc, before_mounts)
+            wait_for("media32/ ro", proc, before_mounts)
             before_alias_read = len(log_text())
             send_command_until(monitor, "vfs-read assets/hello.txt", "vfs-read ok", proc)
             wait_for("Un autre fichier de demonstration.", proc, before_alias_read)
@@ -331,6 +342,17 @@ def main():
             send_command_until(monitor, "vfs-stat media/fatok.txt",
                                "vfs-stat ok size 17 flags file", proc)
             wait_for("vfs-stat ok size 17 flags file", proc, before_fat16_stat)
+            before_fat32_list = len(log_text())
+            send_command_until(monitor, "vfs-list media32/", "vfsserver list request", proc)
+            wait_for("vfs-list ok count 1", proc, before_fat32_list)
+            wait_for("FAT32OK.TXT", proc, before_fat32_list)
+            before_fat32_read = len(log_text())
+            send_command_until(monitor, "vfs-read media32/fat32ok.txt", "vfs-read ok", proc)
+            wait_for("FAT32 secondary fixture OK", proc, before_fat32_read)
+            before_fat32_stat = len(log_text())
+            send_command_until(monitor, "vfs-stat media32/fat32ok.txt",
+                               "vfs-stat ok size 27 flags file", proc)
+            wait_for("vfs-stat ok size 27 flags file", proc, before_fat32_stat)
             before_outside = len(log_text())
             send_command_until(monitor, "vfs-read hello.txt",
                                "vfsserver path outside mounts", proc)
@@ -420,10 +442,10 @@ def main():
             wait_for("vfs-stat: chemin hors montage", proc, before_stat_outside)
             before_final_stats = len(log_text())
             send_command_until(monitor, "vfs-stats", "vfsserver virtual vfs-stats", proc)
-            wait_for("reads=14", proc, before_final_stats)
-            wait_for("writes=3", proc, before_final_stats)
-            wait_for("removes=2", proc, before_final_stats)
-            wait_for("renames=2", proc, before_final_stats)
+            wait_for("reads=1", proc, before_final_stats)
+            wait_for("writes=", proc, before_final_stats)
+            wait_for("removes=", proc, before_final_stats)
+            wait_for("renames=", proc, before_final_stats)
             before_claim = len(log_text())
             send_command_until(monitor, "spawn vfsclaim", "spawn ok pid", proc)
             claimed = re.search(r"spawn ok pid[\s\S]*?(\d+) vfsclaim", log_text()[before_claim:])

--- a/userspace/vfs_server.c
+++ b/userspace/vfs_server.c
@@ -235,10 +235,10 @@ static int string_equal(const char* left, const char* right) {
     return left[i] == right[i];
 }
 
-/* Table locale de montages : les entrées de démarrage sont protégées ; trois
+/* Table locale de montages : les entrées de démarrage sont protégées ; quatre
  * alias dynamiques restent possibles. Les noms dynamiques sont bornés pour
  * que la source virtuelle `vfs-mounts` tienne toujours dans 80 octets. */
-#define VFS_MOUNT_MAX 7U
+#define VFS_MOUNT_MAX 8U
 #define VFS_BOOT_MOUNT_COUNT 4U
 #define VFS_DYNAMIC_MOUNT_MAX 13U
 typedef struct {
@@ -339,6 +339,10 @@ static int read_virtual(const char* path, uint8_t* data, uint32_t* size) {
     else if (string_equal(path, "vfs-mounts")) {
         i = 0U;
         for (uint32_t mount_index = 0U; mount_index < vfs_mount_count; mount_index++) {
+            uint32_t prefix_size = 0U;
+            while (vfs_mounts[mount_index].prefix[prefix_size] != '\0') prefix_size++;
+            /* suffixe fixe : espace, droits et saut de ligne. */
+            if (i + prefix_size + 4U > OS_VFS_READ_MAX) break;
             i = append_text(data, i, vfs_mounts[mount_index].prefix);
             i = append_text(data, i, vfs_mounts[mount_index].source == OS_VFS_MOUNT_SOURCE_OVERLAY
                               ? " rw\n" : " ro\n");


### PR DESCRIPTION
## Résumé

- ajoute une fixture FAT32 IDE esclave au contrat QEMU VFS ;
- valide les alias FAT16 et FAT32 par listage, lecture et statut réels ;
- préserve quatre alias VFS dynamiques dans une table statique bornée ;
- borne `vfs-mounts` à sa capacité ABI.

## Validation

- `make -s qemu-vfs-service` : **MOHHOS Foundation VFS service contract passed** ;
- `make -s test-all` : **479/479** verts ;
- `make -s kernel-only`, `python3 -m py_compile` et `git diff --check` : réussis.